### PR TITLE
Add sample_id named parameter to massql table function

### DIFF
--- a/docs/massql.md
+++ b/docs/massql.md
@@ -20,6 +20,16 @@ SELECT * FROM massql(
 
 That's it. The `massql()` function takes your MassQL query string and a data source (file path or table name), and returns results as a table.
 
+### Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | VARCHAR | MassQL query string (positional, required) |
+| `source` | VARCHAR | File path or table/view name (positional, required) |
+| `sample_id` | VARCHAR | Column name to iterate over per-sample (named, optional) |
+
+When `sample_id` is provided, the function queries distinct values of that column, runs the MassQL pipeline independently for each value, and streams results back with the sample identifier prepended as the first output column. The output column preserves the original column's type (VARCHAR, INTEGER, etc.).
+
 ## Quick Comparison: Python MassQL vs MIINT
 
 | Python MassQL | MIINT (DuckDB) |
@@ -229,6 +239,32 @@ SELECT COUNT(*) FROM massql(
   'sample.mzML'
 );
 ```
+
+### Query per sample
+
+When your table contains data from multiple samples, use `sample_id` to run the MassQL query independently for each sample:
+
+```sql
+-- Load multiple files with filepath as sample identifier
+CREATE TABLE all_spectra AS
+  SELECT * FROM read_mzml('data/*.mzML', include_filepath=true);
+
+-- Run the query per file — results include 'filepath' as the first column
+SELECT * FROM massql(
+  'QUERY scaninfo(MS2DATA) WHERE MS2PROD=167.0857',
+  'all_spectra',
+  sample_id := 'filepath'
+);
+
+-- Count matching spectra per sample
+SELECT filepath, COUNT(*) FROM massql(
+  'QUERY scannum(MS2DATA) WHERE MS2PROD=167.0857',
+  'all_spectra',
+  sample_id := 'filepath'
+) GROUP BY filepath;
+```
+
+The `sample_id` column must not contain NULL values. It works with any column type (VARCHAR, INTEGER, etc.) and cannot be used with file path sources — load the file into a table first.
 
 ### Work with multiple files
 

--- a/src/massql_function.cpp
+++ b/src/massql_function.cpp
@@ -55,8 +55,7 @@ static string MaterializePeaks(Connection &conn, const miint::MassQLQuery &parse
 }
 
 // Materialize peaks, transpile, execute, and store result in data.result.
-static void RunPipeline(Connection &conn, const miint::MassQLQuery &parsed, const string &source,
-                        MassQLData &data) {
+static void RunPipeline(Connection &conn, const miint::MassQLQuery &parsed, const string &source, MassQLData &data) {
 	auto ms1_table = MaterializePeaks(conn, parsed, source);
 
 	string exec_sql;
@@ -94,8 +93,8 @@ static void RunSamplePipeline(MassQLData &data, const Value &sample_value) {
 	// Generate transpiled SQL and wrap with sample_id column (single execution)
 	string exec_sql;
 	try {
-		exec_sql =
-		    miint::MassQLTranspiler::to_sql_materialized(data.parsed, "__massql_per_sample", "__massql_base", ms1_table);
+		exec_sql = miint::MassQLTranspiler::to_sql_materialized(data.parsed, "__massql_per_sample", "__massql_base",
+		                                                        ms1_table);
 	} catch (const std::exception &e) {
 		throw InvalidInputException(e.what());
 	}
@@ -168,8 +167,7 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 		data->sample_id_type = probe->types[0];
 
 		// Reject NULLs early before collecting distinct values
-		auto null_check =
-		    conn.Query("SELECT COUNT(*) FROM " + quoted_source + " WHERE " + quoted_col + " IS NULL");
+		auto null_check = conn.Query("SELECT COUNT(*) FROM " + quoted_source + " WHERE " + quoted_col + " IS NULL");
 		if (null_check->HasError()) {
 			throw InvalidInputException("MassQL: failed to check for NULLs: %s", null_check->GetError());
 		}
@@ -179,8 +177,8 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 		}
 
 		// Collect distinct values
-		auto distinct_result = conn.Query("SELECT DISTINCT " + quoted_col + " FROM " + quoted_source + " ORDER BY " +
-		                                  quoted_col);
+		auto distinct_result =
+		    conn.Query("SELECT DISTINCT " + quoted_col + " FROM " + quoted_source + " ORDER BY " + quoted_col);
 		if (distinct_result->HasError()) {
 			throw InvalidInputException("MassQL: failed to query sample_id values: %s", distinct_result->GetError());
 		}

--- a/src/massql_function.cpp
+++ b/src/massql_function.cpp
@@ -14,9 +14,107 @@ namespace duckdb {
 //        SELECT * FROM massql('QUERY ...', 'path/to/file.mzML')
 
 struct MassQLData : public TableFunctionData {
+	// Result iteration (both paths)
 	unique_ptr<MaterializedQueryResult> result;
 	unique_ptr<DataChunk> current_chunk; // keeps fetched chunk alive for Reference()
+
+	// Sample iteration state (sample_id path only)
+	bool has_sample_id = false;
+	string sample_id_col;
+	LogicalType sample_id_type;
+	vector<Value> sample_values;
+	idx_t current_sample_idx = 0;
+
+	// Deferred execution state (kept alive for per-sample pipeline in Execute)
+	miint::MassQLQuery parsed;
+	string effective_source;
+	unique_ptr<Connection> conn;
 };
+
+// Materialize base peaks (and optionally MS1 peaks) into temp tables.
+// Returns the ms1_table name (empty string if not needed).
+static string MaterializePeaks(Connection &conn, const miint::MassQLQuery &parsed, const string &source) {
+	auto mat_sql = miint::MassQLTranspiler::materialize_base_sql(parsed, source, "__massql_base");
+	auto mat_result = conn.Query(mat_sql);
+	if (mat_result->HasError()) {
+		throw InvalidInputException("MassQL: failed to materialize peaks: %s", mat_result->GetError());
+	}
+
+	auto plan = miint::MassQLTranspiler::get_materialization_plan(parsed);
+	string ms1_table;
+	if (plan.needs_ms1) {
+		ms1_table = "__massql_ms1";
+		auto ms1_sql = miint::MassQLTranspiler::materialize_ms1_sql(source, ms1_table);
+		auto ms1_result = conn.Query(ms1_sql);
+		if (ms1_result->HasError()) {
+			throw InvalidInputException("MassQL: failed to materialize MS1 peaks: %s", ms1_result->GetError());
+		}
+	}
+
+	return ms1_table;
+}
+
+// Materialize peaks, transpile, execute, and store result in data.result.
+static void RunPipeline(Connection &conn, const miint::MassQLQuery &parsed, const string &source,
+                        MassQLData &data) {
+	auto ms1_table = MaterializePeaks(conn, parsed, source);
+
+	string exec_sql;
+	try {
+		exec_sql = miint::MassQLTranspiler::to_sql_materialized(parsed, source, "__massql_base", ms1_table);
+	} catch (const std::exception &e) {
+		throw InvalidInputException(e.what());
+	}
+
+	data.result = conn.Query(exec_sql);
+	if (data.result->HasError()) {
+		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", data.result->GetError(), exec_sql);
+	}
+}
+
+// Run the MassQL pipeline for a single sample value: create a filtered view,
+// materialize peaks, and execute a single wrapped query with the sample_id column.
+static void RunSamplePipeline(MassQLData &data, const Value &sample_value) {
+	auto &conn = *data.conn;
+	auto quoted_col = KeywordHelper::WriteOptionallyQuoted(data.sample_id_col);
+	auto quoted_source = KeywordHelper::WriteOptionallyQuoted(data.effective_source);
+
+	// Create filtered view for this sample
+	auto escaped_val = StringUtil::Replace(sample_value.ToString(), "'", "''");
+	auto view_sql = "CREATE OR REPLACE TEMP VIEW __massql_per_sample AS SELECT * FROM " + quoted_source +
+	                " WHERE CAST(" + quoted_col + " AS VARCHAR) = '" + escaped_val + "'";
+	auto view_result = conn.Query(view_sql);
+	if (view_result->HasError()) {
+		throw InvalidInputException("MassQL: failed to create per-sample view: %s", view_result->GetError());
+	}
+
+	// Materialize peaks from the filtered view
+	auto ms1_table = MaterializePeaks(conn, data.parsed, "__massql_per_sample");
+
+	// Generate transpiled SQL and wrap with sample_id column (single execution)
+	string exec_sql;
+	try {
+		exec_sql =
+		    miint::MassQLTranspiler::to_sql_materialized(data.parsed, "__massql_per_sample", "__massql_base", ms1_table);
+	} catch (const std::exception &e) {
+		throw InvalidInputException(e.what());
+	}
+
+	auto sample_literal = sample_value.ToSQLString();
+	auto wrapped_sql = "SELECT " + sample_literal + " AS " + quoted_col + ", __q.* FROM (" + exec_sql + ") __q";
+
+	data.result = conn.Query(wrapped_sql);
+	if (data.result->HasError()) {
+		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", data.result->GetError(), wrapped_sql);
+	}
+}
+
+static void ExtractSchema(MassQLData &data, vector<LogicalType> &return_types, vector<string> &names) {
+	for (idx_t i = 0; i < data.result->ColumnCount(); i++) {
+		names.push_back(data.result->ColumnName(i));
+		return_types.push_back(data.result->types[i]);
+	}
+}
 
 static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunctionBindInput &input,
                                            vector<LogicalType> &return_types, vector<string> &names) {
@@ -24,6 +122,18 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 
 	auto query_str = input.inputs[0].GetValue<string>();
 	auto source_str = input.inputs[1].GetValue<string>();
+
+	// Read optional sample_id named parameter
+	string sample_id_col;
+	bool has_sample_id = false;
+	auto it = input.named_parameters.find("sample_id");
+	if (it != input.named_parameters.end()) {
+		sample_id_col = it->second.GetValue<string>();
+		if (sample_id_col.empty()) {
+			throw InvalidInputException("sample_id column name must not be empty");
+		}
+		has_sample_id = true;
+	}
 
 	// Parse MassQL (convert parser exceptions to DuckDB exceptions)
 	miint::MassQLQuery parsed;
@@ -34,58 +144,83 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 	}
 
 	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection conn(db);
 
-	// If source is a file path, create a temp view so mzml_peaks() can reference it by name
+	// Reject sample_id with file path source early
 	auto effective_source = source_str;
 	if (miint::MassQLTranspiler::is_file_path(source_str)) {
-		effective_source = "__massql_src";
-		auto escaped_path = StringUtil::Replace(source_str, "'", "''");
-		auto view_result = conn.Query("CREATE OR REPLACE TEMP VIEW " + effective_source +
-		                              " AS SELECT * FROM read_mzml('" + escaped_path + "')");
-		if (view_result->HasError()) {
-			throw InvalidInputException("MassQL: failed to read source file: %s", view_result->GetError());
+		if (has_sample_id) {
+			throw InvalidInputException("sample_id cannot be used with a file path source");
 		}
 	}
 
-	// Materialize peaks into a temp table to avoid repeated mzml_peaks() UNNEST evaluation
-	auto mat_sql = miint::MassQLTranspiler::materialize_base_sql(parsed, effective_source, "__massql_base");
-	auto mat_result = conn.Query(mat_sql);
-	if (mat_result->HasError()) {
-		throw InvalidInputException("MassQL: failed to materialize peaks: %s", mat_result->GetError());
-	}
+	if (has_sample_id) {
+		// ── sample_id path: store conn and state for per-sample iteration in Execute ──
+		data->conn = make_uniq<Connection>(db);
+		auto &conn = *data->conn;
 
-	// For cross-level queries (MS1MZ=X AND MS2PREC=X), also materialize MS1 peaks.
-	// get_materialization_plan() is the authoritative source for which tables are needed.
-	auto plan = miint::MassQLTranspiler::get_materialization_plan(parsed);
-	string ms1_table;
-	if (plan.needs_ms1) {
-		ms1_table = "__massql_ms1";
-		auto ms1_sql = miint::MassQLTranspiler::materialize_ms1_sql(effective_source, ms1_table);
-		auto ms1_result = conn.Query(ms1_sql);
-		if (ms1_result->HasError()) {
-			throw InvalidInputException("MassQL: failed to materialize MS1 peaks: %s", ms1_result->GetError());
+		// Validate column exists and get its type
+		auto quoted_col = KeywordHelper::WriteOptionallyQuoted(sample_id_col);
+		auto quoted_source = KeywordHelper::WriteOptionallyQuoted(effective_source);
+		auto probe = conn.Query("SELECT " + quoted_col + " FROM " + quoted_source + " LIMIT 0");
+		if (probe->HasError()) {
+			throw InvalidInputException("sample_id column '%s' not found", sample_id_col);
 		}
-	}
+		data->sample_id_type = probe->types[0];
 
-	// Execute using pre-materialized tables for performance
-	string exec_sql;
-	try {
-		exec_sql = miint::MassQLTranspiler::to_sql_materialized(parsed, effective_source, "__massql_base", ms1_table);
-	} catch (const std::exception &e) {
-		throw InvalidInputException(e.what());
-	}
+		// Reject NULLs early before collecting distinct values
+		auto null_check =
+		    conn.Query("SELECT COUNT(*) FROM " + quoted_source + " WHERE " + quoted_col + " IS NULL");
+		if (null_check->HasError()) {
+			throw InvalidInputException("MassQL: failed to check for NULLs: %s", null_check->GetError());
+		}
+		auto null_count = null_check->GetValue(0, 0).GetValue<int64_t>();
+		if (null_count > 0) {
+			throw InvalidInputException("NULL values in sample_id column '%s'", sample_id_col);
+		}
 
-	data->result = conn.Query(exec_sql);
+		// Collect distinct values
+		auto distinct_result = conn.Query("SELECT DISTINCT " + quoted_col + " FROM " + quoted_source + " ORDER BY " +
+		                                  quoted_col);
+		if (distinct_result->HasError()) {
+			throw InvalidInputException("MassQL: failed to query sample_id values: %s", distinct_result->GetError());
+		}
+		auto &materialized = distinct_result->Cast<MaterializedQueryResult>();
+		while (auto chunk = materialized.Fetch()) {
+			for (idx_t i = 0; i < chunk->size(); i++) {
+				data->sample_values.push_back(chunk->data[0].GetValue(i));
+			}
+		}
 
-	if (data->result->HasError()) {
-		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", data->result->GetError(), exec_sql);
-	}
+		// Store state for deferred execution
+		data->has_sample_id = true;
+		data->sample_id_col = sample_id_col;
+		data->parsed = parsed;
+		data->effective_source = effective_source;
 
-	// Extract schema from result
-	for (idx_t i = 0; i < data->result->ColumnCount(); i++) {
-		names.push_back(data->result->ColumnName(i));
-		return_types.push_back(data->result->types[i]);
+		if (data->sample_values.empty()) {
+			throw InvalidInputException("sample_id column '%s' has no non-NULL values", sample_id_col);
+		}
+
+		// Run first sample to determine schema
+		RunSamplePipeline(*data, data->sample_values[0]);
+		data->current_sample_idx = 1;
+		ExtractSchema(*data, return_types, names);
+	} else {
+		// ── non-sample_id path: existing behavior, conn is stack-local ──
+		Connection conn(db);
+
+		if (miint::MassQLTranspiler::is_file_path(source_str)) {
+			effective_source = "__massql_src";
+			auto escaped_path = StringUtil::Replace(source_str, "'", "''");
+			auto view_result = conn.Query("CREATE OR REPLACE TEMP VIEW " + effective_source +
+			                              " AS SELECT * FROM read_mzml('" + escaped_path + "')");
+			if (view_result->HasError()) {
+				throw InvalidInputException("MassQL: failed to read source file: %s", view_result->GetError());
+			}
+		}
+
+		RunPipeline(conn, parsed, effective_source, *data);
+		ExtractSchema(*data, return_types, names);
 	}
 
 	return data;
@@ -94,13 +229,31 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 static void MassQLExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
 	auto &data = input.bind_data->CastNoConst<MassQLData>();
 
-	data.current_chunk = data.result->Fetch();
-	if (!data.current_chunk || data.current_chunk->size() == 0) {
-		output.SetCardinality(0);
-		return;
-	}
+	while (true) {
+		// Drain current result
+		data.current_chunk = data.result->Fetch();
+		if (data.current_chunk && data.current_chunk->size() > 0) {
+			output.Reference(*data.current_chunk);
+			return;
+		}
 
-	output.Reference(*data.current_chunk);
+		// For non-sample_id path, we're done
+		if (!data.has_sample_id) {
+			output.SetCardinality(0);
+			return;
+		}
+
+		// All samples exhausted
+		if (data.current_sample_idx >= data.sample_values.size()) {
+			output.SetCardinality(0);
+			return;
+		}
+
+		// Run pipeline for next sample
+		RunSamplePipeline(data, data.sample_values[data.current_sample_idx]);
+		data.current_sample_idx++;
+		// Loop back to drain this sample's result
+	}
 }
 
 // ── massql_to_sql() scalar function ──────────────────────────────────────────
@@ -124,6 +277,7 @@ static void MassQLToSQLFunction(DataChunk &args, ExpressionState &state, Vector 
 void MassQLFunction::Register(ExtensionLoader &loader) {
 	// massql(query, source) table function
 	TableFunction massql_func("massql", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MassQLExecute, MassQLBind);
+	massql_func.named_parameters["sample_id"] = LogicalType::VARCHAR;
 	loader.RegisterFunction(massql_func);
 
 	// massql_to_sql(query, source) scalar function

--- a/test/sql/massql_sample_id.test
+++ b/test/sql/massql_sample_id.test
@@ -1,0 +1,109 @@
+# name: test/sql/massql_sample_id.test
+# description: test massql sample_id named parameter
+# group: [sql]
+
+statement ok
+PRAGMA enable_verification;
+
+require miint
+
+# Load test data
+statement ok
+CREATE TABLE spectra AS SELECT * FROM read_mzml('data/mzml/basic_3spectra.mzML');
+
+# ----- Cycle 1: Error on invalid sample_id -----
+
+# sample_id column doesn't exist in the source relation
+statement error
+SELECT * FROM massql('QUERY scannum(MS2DATA)', 'spectra', sample_id := 'no_such_column')
+----
+sample_id column 'no_such_column' not found
+
+# sample_id must not be empty string
+statement error
+SELECT * FROM massql('QUERY scannum(MS2DATA)', 'spectra', sample_id := '')
+----
+sample_id column name must not be empty
+
+# ----- Cycle 2: Output schema includes sample_id, results streamed per-sample -----
+
+statement ok
+CREATE VIEW multi_sample AS
+  SELECT 'A' AS sample, * FROM spectra
+  UNION ALL
+  SELECT 'B' AS sample, * FROM spectra;
+
+query TI
+SELECT sample, COUNT(*) FROM massql('QUERY scannum(MS2DATA)', 'multi_sample', sample_id := 'sample')
+  GROUP BY sample ORDER BY sample
+----
+A	2
+B	2
+
+# ----- Cycle 3: Per-sample isolation (different results per sample) -----
+
+# 'has_peak' gets all spectra (includes MS2 with peak near 220)
+# 'no_peak' gets only MS1 spectra (no MS2 data at all)
+statement ok
+CREATE VIEW diff_samples AS
+  SELECT 'has_peak' AS sid, * FROM spectra
+  UNION ALL
+  SELECT 'no_peak' AS sid, * FROM spectra WHERE ms_level = 1;
+
+# MS2PROD=220 should match only in 'has_peak'
+query T
+SELECT sid
+  FROM massql('QUERY scannum(MS2DATA) WHERE MS2PROD=220', 'diff_samples', sample_id := 'sid')
+  ORDER BY sid
+----
+has_peak
+
+# ----- Cycle 4: Without sample_id, existing behavior unchanged -----
+
+query I
+SELECT COUNT(*) FROM massql('QUERY scaninfo(MS2DATA) WHERE MS2PROD=220', 'spectra')
+----
+1
+
+# ----- Cycle 5: sample_id rejected with file path source -----
+
+statement error
+SELECT * FROM massql('QUERY scannum(MS2DATA)', 'data/mzml/basic_3spectra.mzML', sample_id := 'sample')
+----
+sample_id cannot be used with a file path source
+
+# ----- Cycle 6: NULL sample_id values are rejected -----
+
+statement ok
+CREATE VIEW null_sample AS
+  SELECT NULL::VARCHAR AS sid, * FROM spectra;
+
+statement error
+SELECT * FROM massql('QUERY scannum(MS2DATA)', 'null_sample', sample_id := 'sid')
+----
+NULL values in sample_id column
+
+# ----- Cycle 7: Integer sample_id column preserves type -----
+
+statement ok
+CREATE VIEW int_sample AS
+  SELECT 1 AS sample_num, * FROM spectra
+  UNION ALL
+  SELECT 2 AS sample_num, * FROM spectra;
+
+query II
+SELECT sample_num, COUNT(*) FROM massql('QUERY scannum(MS2DATA)', 'int_sample', sample_id := 'sample_num')
+  GROUP BY sample_num ORDER BY sample_num
+----
+1	2
+2	2
+
+# ----- Empty source table errors -----
+
+statement ok
+CREATE VIEW empty_spectra AS SELECT 'A' AS sample, * FROM spectra WHERE 1=0;
+
+statement error
+SELECT * FROM massql('QUERY scannum(MS2DATA)', 'empty_spectra', sample_id := 'sample')
+----
+has no non-NULL values


### PR DESCRIPTION
Enables per-sample MassQL queries by iterating over distinct values of a named column, running the pipeline independently for each, and streaming results with the sample identifier prepended as the first output column.