### PR TITLE
Normalize filepath in glob tests for Windows compatibility

### DIFF
--- a/test/sql/glob_read_alignments.test
+++ b/test/sql/glob_read_alignments.test
@@ -18,7 +18,7 @@ SELECT COUNT(*) FROM read_alignments('data/sam/foo_has_header*.sam');
 
 # Verify sorting by checking filepath order
 query II
-SELECT read_id, filepath
+SELECT read_id, replace(filepath, '\', '/') as filepath
 FROM read_alignments('data/sam/foo_has_header*.sam', include_filepath=true)
 ORDER BY filepath, read_id
 LIMIT 4;
@@ -40,7 +40,7 @@ SELECT COUNT(*) FROM read_alignments('data/sam/foo_has_header*.bam');
 # Let's test BAM specifically
 
 query IIII
-SELECT read_id, flags, reference, filepath
+SELECT read_id, flags, reference, replace(filepath, '\', '/') as filepath
 FROM read_alignments('data/sam/foo_has_header*.bam', include_filepath=true)
 ORDER BY filepath, read_id
 LIMIT 2;

--- a/test/sql/glob_read_biom.test
+++ b/test/sql/glob_read_biom.test
@@ -14,7 +14,8 @@ PRAGMA enable_verification;
 # Glob pattern matches multiple files (file1.biom, file2.biom)
 # Files are sorted alphabetically, so file1.biom comes before file2.biom
 query IIII
-SELECT * FROM read_biom('data/biom/file*.biom', include_filepath=true)
+SELECT sample_id, feature_id, count, replace(filepath, '\', '/') as filepath
+FROM read_biom('data/biom/file*.biom', include_filepath=true)
 ORDER BY filepath, sample_id, feature_id;
 ----
 S1	O2	3.0	data/biom/file1.biom

--- a/test/sql/glob_read_biom.test
+++ b/test/sql/glob_read_biom.test
@@ -14,7 +14,7 @@ PRAGMA enable_verification;
 # Glob pattern matches multiple files (file1.biom, file2.biom)
 # Files are sorted alphabetically, so file1.biom comes before file2.biom
 query IIII
-SELECT sample_id, feature_id, count, replace(filepath, '\', '/') as filepath
+SELECT sample_id, feature_id, value, replace(filepath, '\', '/') as filepath
 FROM read_biom('data/biom/file*.biom', include_filepath=true)
 ORDER BY filepath, sample_id, feature_id;
 ----

--- a/test/sql/glob_read_fastx.test
+++ b/test/sql/glob_read_fastx.test
@@ -11,7 +11,9 @@ require miint
 
 # Glob pattern matches multiple files (sorted alphabetically)
 query IIIIIIII
-SELECT * FROM read_fastx('data/fastq/glob_single*.fq', include_filepath=true)
+SELECT sequence_index, read_id, comment, sequence1, sequence2, qual1, qual2,
+       replace(filepath, '\', '/') as filepath
+FROM read_fastx('data/fastq/glob_single*.fq', include_filepath=true)
 ORDER BY filepath, sequence_index;
 ----
 1	single1_read1	NULL	AAAA	NULL	[40, 40, 40, 40]	NULL	data/fastq/glob_single1.fq
@@ -30,9 +32,11 @@ SELECT COUNT(*) FROM read_fastx('data/fastq/glob_single*.fq');
 # glob_sample1_R1.fq pairs with glob_sample1_R2.fq
 # glob_sample2_R1.fq pairs with glob_sample2_R2.fq
 query IIIIIIII
-SELECT * FROM read_fastx('data/fastq/glob_sample*_R1.fq',
-                          sequence2='data/fastq/glob_sample*_R2.fq',
-                          include_filepath=true)
+SELECT sequence_index, read_id, comment, sequence1, sequence2, qual1, qual2,
+       replace(filepath, '\', '/') as filepath
+FROM read_fastx('data/fastq/glob_sample*_R1.fq',
+                 sequence2='data/fastq/glob_sample*_R2.fq',
+                 include_filepath=true)
 ORDER BY filepath, sequence_index;
 ----
 1	glob_s1_read1	NULL	AAAA	CCCC	[40, 40, 40, 40]	[38, 38, 38, 38]	data/fastq/glob_sample1_R1.fq

--- a/test/sql/glob_read_sequences_sam.test
+++ b/test/sql/glob_read_sequences_sam.test
@@ -15,7 +15,7 @@ read5	GATTACA
 
 # Glob with include_filepath
 query II
-SELECT read_id, filepath FROM read_sequences_sam('data/sam/ubam_no_sq*.sam', include_filepath=true) ORDER BY filepath, sequence_index;
+SELECT read_id, replace(filepath, '\', '/') as filepath FROM read_sequences_sam('data/sam/ubam_no_sq*.sam', include_filepath=true) ORDER BY filepath, sequence_index;
 ----
 read1	data/sam/ubam_no_sq.sam
 read2	data/sam/ubam_no_sq.sam

--- a/test/sql/read_jplace.test
+++ b/test/sql/read_jplace.test
@@ -79,7 +79,7 @@ SELECT COUNT(*) FROM read_jplace('data/jplace/test*.jplace');
 
 # Test glob pattern with filepath
 query TT
-SELECT fragment, filepath FROM read_jplace('data/jplace/test*.jplace') ORDER BY fragment;
+SELECT fragment, replace(filepath, '\', '/') as filepath FROM read_jplace('data/jplace/test*.jplace') ORDER BY fragment;
 ----
 fragment1	data/jplace/test.jplace
 fragment2	data/jplace/test.jplace


### PR DESCRIPTION
Glob-expanded paths use OS-native separators (backslash on Windows), causing test failures. Wrap filepath with replace(filepath, '\', '/') in queries that check glob-expanded filepath values.