### PR TITLE
Parallelize massql() sample_id path with per-thread Connection isolation

### DIFF
--- a/src/massql_function.cpp
+++ b/src/massql_function.cpp
@@ -6,6 +6,9 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+#include <atomic>
 
 namespace duckdb {
 
@@ -14,21 +17,50 @@ namespace duckdb {
 //        SELECT * FROM massql('QUERY ...', 'path/to/file.mzML')
 
 struct MassQLData : public TableFunctionData {
-	// Result iteration (both paths)
-	unique_ptr<MaterializedQueryResult> result;
-	unique_ptr<DataChunk> current_chunk; // keeps fetched chunk alive for Reference()
+	// Non-sample_id: pre-run result at Bind time; ownership moved to GlobalState at InitGlobal.
+	unique_ptr<MaterializedQueryResult> non_sample_result;
 
 	// Sample iteration state (sample_id path only)
 	bool has_sample_id = false;
 	string sample_id_col;
 	LogicalType sample_id_type;
 	vector<Value> sample_values;
-	idx_t current_sample_idx = 0;
+
+	// Sample_id: sample[0] pre-run for schema inference; moved to GlobalState at InitGlobal.
+	unique_ptr<MaterializedQueryResult> sample0_result;
 
 	// Deferred execution state (kept alive for per-sample pipeline in Execute)
 	miint::MassQLQuery parsed;
 	string effective_source;
-	unique_ptr<Connection> conn;
+};
+
+struct MassQLGlobalState : public GlobalTableFunctionState {
+	// Sample_id: atomic counter starts at 1 (sample[0] pre-run at Bind time).
+	atomic<idx_t> next_sample_idx {0};
+	idx_t max_threads = 1;
+
+	// Non-sample_id: pre-run result transferred from MassQLData at InitGlobal.
+	// Single thread drains it from Execute; no synchronization needed.
+	unique_ptr<MaterializedQueryResult> non_sample_result;
+
+	// Sample_id: sample[0] pre-run result (schema probe); claimed by the first Execute thread.
+	// Each per-thread Connection owns its own TEMP objects (__massql_base, __massql_per_sample,
+	// __massql_ms1), so parallel threads never collide on those names despite the shared names.
+	unique_ptr<MaterializedQueryResult> sample0_result;
+	atomic<bool> sample0_claimed {false};
+
+	idx_t MaxThreads() const override {
+		return max_threads;
+	}
+};
+
+struct MassQLLocalState : public LocalTableFunctionState {
+	unique_ptr<Connection> conn;                // sample_id: per-thread isolated connection
+	unique_ptr<MaterializedQueryResult> result; // current sample's result
+	// Keeps the fetched chunk alive while output.Reference() points into its buffers.
+	// Overwritten only on the next Execute call, after the upstream operator has consumed
+	// the previous output (DuckDB pull-based execution guarantee).
+	unique_ptr<DataChunk> current_chunk;
 };
 
 // Materialize base peaks (and optionally MS1 peaks) into temp tables.
@@ -54,8 +86,9 @@ static string MaterializePeaks(Connection &conn, const miint::MassQLQuery &parse
 	return ms1_table;
 }
 
-// Materialize peaks, transpile, execute, and store result in data.result.
-static void RunPipeline(Connection &conn, const miint::MassQLQuery &parsed, const string &source, MassQLData &data) {
+// Materialize peaks, transpile, and execute. Returns the materialized result.
+static unique_ptr<MaterializedQueryResult> RunPipeline(Connection &conn, const miint::MassQLQuery &parsed,
+                                                       const string &source) {
 	auto ms1_table = MaterializePeaks(conn, parsed, source);
 
 	string exec_sql;
@@ -65,36 +98,40 @@ static void RunPipeline(Connection &conn, const miint::MassQLQuery &parsed, cons
 		throw InvalidInputException(e.what());
 	}
 
-	data.result = conn.Query(exec_sql);
-	if (data.result->HasError()) {
-		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", data.result->GetError(), exec_sql);
+	auto result = conn.Query(exec_sql);
+	if (result->HasError()) {
+		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", result->GetError(), exec_sql);
 	}
+	return result;
 }
 
-// Run the MassQL pipeline for a single sample value: create a filtered view,
-// materialize peaks, and execute a single wrapped query with the sample_id column.
-static void RunSamplePipeline(MassQLData &data, const Value &sample_value) {
-	auto &conn = *data.conn;
-	auto quoted_col = KeywordHelper::WriteOptionallyQuoted(data.sample_id_col);
-	auto quoted_source = KeywordHelper::WriteOptionallyQuoted(data.effective_source);
+// Run the MassQL pipeline for a single sample value. Returns the materialized result.
+// Each call creates its own TEMP objects (__massql_per_sample, __massql_base, __massql_ms1)
+// scoped to `conn`. Since each thread has its own Connection, parallel calls are safe.
+static unique_ptr<MaterializedQueryResult> RunSamplePipeline(Connection &conn, const miint::MassQLQuery &parsed,
+                                                             const string &effective_source,
+                                                             const string &sample_id_col, const Value &sample_value) {
+	auto quoted_col = KeywordHelper::WriteOptionallyQuoted(sample_id_col);
+	auto quoted_source = KeywordHelper::WriteOptionallyQuoted(effective_source);
 
-	// Create filtered view for this sample
-	auto escaped_val = StringUtil::Replace(sample_value.ToString(), "'", "''");
+	// Use ToSQLString() for safe SQL literal construction — handles all Value types
+	// (integers, timestamps, intervals, etc.) without manual escaping.
+	auto filter_val = sample_value.ToSQLString();
 	auto view_sql = "CREATE OR REPLACE TEMP VIEW __massql_per_sample AS SELECT * FROM " + quoted_source +
-	                " WHERE CAST(" + quoted_col + " AS VARCHAR) = '" + escaped_val + "'";
+	                " WHERE CAST(" + quoted_col + " AS VARCHAR) = CAST(" + filter_val + " AS VARCHAR)";
 	auto view_result = conn.Query(view_sql);
 	if (view_result->HasError()) {
 		throw InvalidInputException("MassQL: failed to create per-sample view: %s", view_result->GetError());
 	}
 
 	// Materialize peaks from the filtered view
-	auto ms1_table = MaterializePeaks(conn, data.parsed, "__massql_per_sample");
+	auto ms1_table = MaterializePeaks(conn, parsed, "__massql_per_sample");
 
 	// Generate transpiled SQL and wrap with sample_id column (single execution)
 	string exec_sql;
 	try {
-		exec_sql = miint::MassQLTranspiler::to_sql_materialized(data.parsed, "__massql_per_sample", "__massql_base",
-		                                                        ms1_table);
+		exec_sql =
+		    miint::MassQLTranspiler::to_sql_materialized(parsed, "__massql_per_sample", "__massql_base", ms1_table);
 	} catch (const std::exception &e) {
 		throw InvalidInputException(e.what());
 	}
@@ -102,16 +139,17 @@ static void RunSamplePipeline(MassQLData &data, const Value &sample_value) {
 	auto sample_literal = sample_value.ToSQLString();
 	auto wrapped_sql = "SELECT " + sample_literal + " AS " + quoted_col + ", __q.* FROM (" + exec_sql + ") __q";
 
-	data.result = conn.Query(wrapped_sql);
-	if (data.result->HasError()) {
-		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", data.result->GetError(), wrapped_sql);
+	auto result = conn.Query(wrapped_sql);
+	if (result->HasError()) {
+		throw InvalidInputException("MassQL query failed: %s\nGenerated SQL: %s", result->GetError(), wrapped_sql);
 	}
+	return result;
 }
 
-static void ExtractSchema(MassQLData &data, vector<LogicalType> &return_types, vector<string> &names) {
-	for (idx_t i = 0; i < data.result->ColumnCount(); i++) {
-		names.push_back(data.result->ColumnName(i));
-		return_types.push_back(data.result->types[i]);
+static void ExtractSchema(MaterializedQueryResult &result, vector<LogicalType> &return_types, vector<string> &names) {
+	for (idx_t i = 0; i < result.ColumnCount(); i++) {
+		names.push_back(result.ColumnName(i));
+		return_types.push_back(result.types[i]);
 	}
 }
 
@@ -153,9 +191,8 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 	}
 
 	if (has_sample_id) {
-		// ── sample_id path: store conn and state for per-sample iteration in Execute ──
-		data->conn = make_uniq<Connection>(db);
-		auto &conn = *data->conn;
+		// ── sample_id path: use stack-local conn for bind-time validation only ──
+		Connection conn(db);
 
 		// Validate column exists and get its type
 		auto quoted_col = KeywordHelper::WriteOptionallyQuoted(sample_id_col);
@@ -189,20 +226,20 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 			}
 		}
 
+		if (data->sample_values.empty()) {
+			throw InvalidInputException("sample_id column '%s' has no non-NULL values", sample_id_col);
+		}
+
 		// Store state for deferred execution
 		data->has_sample_id = true;
 		data->sample_id_col = sample_id_col;
 		data->parsed = parsed;
 		data->effective_source = effective_source;
 
-		if (data->sample_values.empty()) {
-			throw InvalidInputException("sample_id column '%s' has no non-NULL values", sample_id_col);
-		}
-
-		// Run first sample to determine schema
-		RunSamplePipeline(*data, data->sample_values[0]);
-		data->current_sample_idx = 1;
-		ExtractSchema(*data, return_types, names);
+		// Run sample[0] to determine the output schema. The result is stored here and
+		// moved to GlobalState at InitGlobal so it is not re-run in Execute.
+		data->sample0_result = RunSamplePipeline(conn, parsed, effective_source, sample_id_col, data->sample_values[0]);
+		ExtractSchema(*data->sample0_result, return_types, names);
 	} else {
 		// ── non-sample_id path: existing behavior, conn is stack-local ──
 		Connection conn(db);
@@ -217,40 +254,87 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 			}
 		}
 
-		RunPipeline(conn, parsed, effective_source, *data);
-		ExtractSchema(*data, return_types, names);
+		// Run pipeline at bind time. Result is fully materialized before conn goes out of scope,
+		// so any TEMP views created above are no longer needed after this call.
+		data->non_sample_result = RunPipeline(conn, parsed, effective_source);
+		ExtractSchema(*data->non_sample_result, return_types, names);
 	}
 
 	return data;
 }
 
-static void MassQLExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+static unique_ptr<GlobalTableFunctionState> MassQLInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	// CastNoConst: we move result ownership out of bind data into global state.
+	// InitGlobal is called exactly once before any Execute thread starts, so this is safe.
 	auto &data = input.bind_data->CastNoConst<MassQLData>();
+	auto gstate = make_uniq<MassQLGlobalState>();
+	if (data.has_sample_id) {
+		idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+		gstate->max_threads = std::max<idx_t>(1, std::min(db_threads, data.sample_values.size()));
+		// Transfer sample[0]'s pre-run result; Execute threads start claiming from index 1.
+		gstate->sample0_result = std::move(data.sample0_result);
+		gstate->next_sample_idx = 1;
+	} else {
+		// Transfer the pre-run result; single Execute thread drains it from global state.
+		gstate->non_sample_result = std::move(data.non_sample_result);
+	}
+	return gstate;
+}
 
+static unique_ptr<LocalTableFunctionState> MassQLInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                           GlobalTableFunctionState * /*global_state*/) {
+	auto &data = input.bind_data->Cast<MassQLData>();
+	auto lstate = make_uniq<MassQLLocalState>();
+	if (data.has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		lstate->conn = make_uniq<Connection>(db);
+	}
+	return lstate;
+}
+
+static void MassQLExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &data = input.bind_data->Cast<MassQLData>();
+	auto &gstate = input.global_state->Cast<MassQLGlobalState>();
+	auto &lstate = input.local_state->Cast<MassQLLocalState>();
+
+	if (!data.has_sample_id) {
+		// Single thread drains the pre-run result from global state.
+		// current_chunk keeps the chunk alive while output references its buffers;
+		// it is overwritten only on the next Execute call (DuckDB pull-based guarantee).
+		lstate.current_chunk = gstate.non_sample_result->Fetch();
+		if (lstate.current_chunk && lstate.current_chunk->size() > 0) {
+			output.Reference(*lstate.current_chunk);
+			return;
+		}
+		output.SetCardinality(0);
+		return;
+	}
+
+	// Sample_id: each thread atomically claims sample indices and processes independently.
 	while (true) {
-		// Drain current result
-		data.current_chunk = data.result->Fetch();
-		if (data.current_chunk && data.current_chunk->size() > 0) {
-			output.Reference(*data.current_chunk);
-			return;
+		if (lstate.result) {
+			lstate.current_chunk = lstate.result->Fetch();
+			if (lstate.current_chunk && lstate.current_chunk->size() > 0) {
+				output.Reference(*lstate.current_chunk);
+				return;
+			}
+			lstate.result.reset();
 		}
-
-		// For non-sample_id path, we're done
-		if (!data.has_sample_id) {
+		// Claim sample[0]'s pre-run result before pulling new samples from the counter.
+		// exchange returns the old value: false means this thread is the claimant.
+		if (!gstate.sample0_claimed.exchange(true, std::memory_order_acq_rel)) {
+			lstate.result = std::move(gstate.sample0_result);
+			continue;
+		}
+		// Atomically claim the next sample index. relaxed: only atomicity needed, no
+		// ordering with respect to other memory operations.
+		idx_t sample_idx = gstate.next_sample_idx.fetch_add(1, std::memory_order_relaxed);
+		if (sample_idx >= data.sample_values.size()) {
 			output.SetCardinality(0);
 			return;
 		}
-
-		// All samples exhausted
-		if (data.current_sample_idx >= data.sample_values.size()) {
-			output.SetCardinality(0);
-			return;
-		}
-
-		// Run pipeline for next sample
-		RunSamplePipeline(data, data.sample_values[data.current_sample_idx]);
-		data.current_sample_idx++;
-		// Loop back to drain this sample's result
+		lstate.result = RunSamplePipeline(*lstate.conn, data.parsed, data.effective_source, data.sample_id_col,
+		                                  data.sample_values[sample_idx]);
 	}
 }
 
@@ -274,8 +358,11 @@ static void MassQLToSQLFunction(DataChunk &args, ExpressionState &state, Vector 
 
 void MassQLFunction::Register(ExtensionLoader &loader) {
 	// massql(query, source) table function
-	TableFunction massql_func("massql", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MassQLExecute, MassQLBind);
+	// order_preservation_type=NO_ORDER: parallel samples produce non-deterministic interleaving.
+	TableFunction massql_func("massql", {LogicalType::VARCHAR, LogicalType::VARCHAR}, MassQLExecute, MassQLBind,
+	                          MassQLInitGlobal, MassQLInitLocal);
 	massql_func.named_parameters["sample_id"] = LogicalType::VARCHAR;
+	massql_func.order_preservation_type = OrderPreservationType::NO_ORDER;
 	loader.RegisterFunction(massql_func);
 
 	// massql_to_sql(query, source) scalar function

--- a/src/massql_function.cpp
+++ b/src/massql_function.cpp
@@ -270,7 +270,7 @@ static unique_ptr<GlobalTableFunctionState> MassQLInitGlobal(ClientContext &cont
 	auto gstate = make_uniq<MassQLGlobalState>();
 	if (data.has_sample_id) {
 		idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
-		gstate->max_threads = std::max<idx_t>(1, std::min(db_threads, data.sample_values.size()));
+		gstate->max_threads = std::max<idx_t>(1, std::min<idx_t>(db_threads, data.sample_values.size()));
 		// Transfer sample[0]'s pre-run result; Execute threads start claiming from index 1.
 		gstate->sample0_result = std::move(data.sample0_result);
 		gstate->next_sample_idx = 1;

--- a/test/sql/massql_sample_id.test
+++ b/test/sql/massql_sample_id.test
@@ -107,3 +107,72 @@ statement error
 SELECT * FROM massql('QUERY scannum(MS2DATA)', 'empty_spectra', sample_id := 'sample')
 ----
 has no non-NULL values
+
+# ----- Cycle 8: Parallel execution correctness -----
+
+
+# With threads=4 and 4 samples, all samples must appear exactly once
+statement ok
+SET threads=4;
+
+statement ok
+CREATE VIEW four_samples AS
+  SELECT 'S1' AS sid, * FROM spectra
+  UNION ALL SELECT 'S2' AS sid, * FROM spectra
+  UNION ALL SELECT 'S3' AS sid, * FROM spectra
+  UNION ALL SELECT 'S4' AS sid, * FROM spectra;
+
+query TI
+SELECT sid, COUNT(*) FROM massql('QUERY scannum(MS2DATA)', 'four_samples', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+S1	2
+S2	2
+S3	2
+S4	2
+
+# With threads > samples, no samples should be duplicated or missed
+statement ok
+SET threads=8;
+
+query TI
+SELECT sid, COUNT(*) FROM massql('QUERY scannum(MS2DATA)', 'four_samples', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+S1	2
+S2	2
+S3	2
+S4	2
+
+# Restore to default
+statement ok
+RESET threads;
+
+# ----- Cycle 9: Missing coverage -----
+
+# Cross-level query (MS1MZ=X AND MS2PREC=X) with sample_id — exercises the __massql_ms1
+# temp table path (needs_ms1=true) under per-thread Connection isolation.
+# multi_sample has A and B, each 3 spectra: 1 MS1 + 2 MS2 (spectra 1, 2 match the pattern).
+query TI
+SELECT sample, COUNT(*) FROM massql('QUERY scannum(MS2DATA) WHERE MS1MZ=X AND MS2PREC=X', 'multi_sample', sample_id := 'sample')
+  GROUP BY sample ORDER BY sample
+----
+A	2
+B	2
+
+# Single-sample case: max_threads is clamped to 1 regardless of thread setting;
+# the sample0 pre-run path must complete cleanly.
+statement ok
+CREATE VIEW single_sample AS SELECT 'only' AS sid, * FROM spectra;
+
+query TI
+SELECT sid, COUNT(*) FROM massql('QUERY scannum(MS2DATA)', 'single_sample', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+only	2
+
+# All samples return zero rows: function must complete without error.
+query I
+SELECT COUNT(*) FROM massql('QUERY scannum(MS2DATA) WHERE MS2PROD=999', 'multi_sample', sample_id := 'sample')
+----
+0


### PR DESCRIPTION
Each Execute thread now atomically claims a sample index and processes it on its own Connection, so DuckDB can dispatch multiple threads and run samples concurrently. Previously the sample_id path was single-threaded: Execute iterated sequentially through samples, each sharing one Connection and mutating bind data.

Implementation:
- Add MassQLGlobalState (atomic counter, max_threads capped to min(db_threads, sample_count)) and MassQLLocalState (per-thread Connection, result, current_chunk)
- Move pre-run results out of bind data into GlobalState at InitGlobal, eliminating all bind-data mutation from Execute
- Cache sample[0] result in GlobalState (moved from bind data at InitGlobal, counter starts at 1); first Execute thread claims it via atomic exchange so sample[0] is never run twice
- Register InitGlobal/InitLocal and set NO_ORDER (parallel samples produce non-deterministic interleaving)
- Fix per-sample view filter to use ToSQLString() instead of ToString()+manual escaping, correctly handling all Value types
- Relax atomic counter memory order to relaxed (only atomicity needed)
- Add comments on TEMP name isolation per Connection, current_chunk lifetime contract, and NO_ORDER rationale

Tests:
- Cycle 8: threads=4 and threads=8 with 4 samples, each sample exactly once
- Cycle 9: cross-level query (MS1MZ=X AND MS2PREC=X) exercises the __massql_ms1 temp table path under parallel isolation; single-sample case; all-samples-zero-match completes cleanly