### PR TITLE
Add Docker image with CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+build/
+vcpkg/
+.git/
+*.o
+*.a

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,84 @@
+name: Docker Image
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      duckdb_version:
+        description: 'DuckDB version (leave empty for latest)'
+        required: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/miint
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve DuckDB version
+        id: duckdb
+        run: |
+          if [ -n "${{ inputs.duckdb_version }}" ]; then
+            VERSION="${{ inputs.duckdb_version }}"
+          else
+            VERSION=$(curl -s "https://hub.docker.com/v2/repositories/duckdb/duckdb/tags/?page_size=50" \
+              | jq -r '[.results[].name | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(split(".") | map(tonumber)) | last')
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Using DuckDB version: ${VERSION}"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and load locally
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: miint:smoke-test
+          build-args: |
+            DUCKDB_VERSION=${{ steps.duckdb.outputs.version }}
+          cache-from: type=gha
+
+      - name: Smoke test
+        run: |
+          docker run --rm miint:smoke-test -c "SELECT miint_version();"
+
+      - name: Build and push multi-arch
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            DUCKDB_VERSION=${{ steps.duckdb.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -641,6 +641,12 @@ endif()
 if(HAVE_LIBZSTD)
     target_link_libraries(${LOADABLE_EXTENSION_NAME} ${ZSTD_TARGET})
 endif()
+# The loadable extension is dlopen'd at runtime. When the host DuckDB is loaded
+# via Python (RTLD_LOCAL), duckdb_je_* symbols from the host are not visible.
+# Link stubs that forward to system malloc so the .so is self-contained.
+if(MIINT_HAS_JEMALLOC)
+    target_sources(${LOADABLE_EXTENSION_NAME} PRIVATE src/mm_alloc_stubs.c)
+endif()
 
 install(
   TARGETS ${EXTENSION_NAME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG DUCKDB_VERSION=1.5.1
+
+FROM duckdb/duckdb:${DUCKDB_VERSION} AS duckdb
+
+# Install extension in a shell-capable image
+FROM ubuntu:24.04 AS builder
+COPY --from=duckdb /duckdb /duckdb
+RUN /duckdb -c "INSTALL miint FROM community;"
+
+# Final image: DuckDB with pre-installed extension
+FROM duckdb
+COPY --from=builder /root/.duckdb /root/.duckdb
+
+WORKDIR /data
+
+ENTRYPOINT ["/duckdb", "-cmd", "LOAD miint;"]


### PR DESCRIPTION
## Summary
- Add multi-stage `Dockerfile` that installs miint from the community registry on top of the official `duckdb/duckdb` image
- Add GitHub Actions workflow (`docker.yml`) to build and push multi-arch images to ghcr.io
- Auto-detects latest DuckDB version from Docker Hub, with manual override via `workflow_dispatch`
- Includes a smoke test step that verifies the extension loads before pushing

## Details

**Dockerfile**
- Uses a multi-stage build to work around the shell-less DuckDB base image: the builder stage (ubuntu) runs `INSTALL miint FROM community`, then the final stage copies only the extension files
- `WORKDIR /data` for convenient volume mounts
- `ENTRYPOINT` auto-loads miint so it's ready to use immediately

**CI workflow**
- Triggered on semver tags (`v[0-9]+.[0-9]+*`) and manual dispatch
- Resolves latest DuckDB version via Docker Hub API with semver sorting
- Builds a local single-arch image first for smoke testing, then builds and pushes linux/amd64 + linux/arm64
- Pushes to `ghcr.io/<org>/miint` with semver tags

**Usage**
```bash
docker run --rm -it -v "$(pwd):/data" ghcr.io/the-miint/miint
docker run --rm -v "$(pwd):/data" ghcr.io/the-miint/miint -c "SELECT * FROM read_fastx('myfile.fq');"
```

## Test plan
- [x] Local `docker build` succeeds
- [x] `docker run --rm miint:test -c "SELECT miint_version();"` returns version
- [x] `docker run --rm -v ./data:/data miint:test -c "SELECT * FROM read_fastx('fastq/small_a.fq') LIMIT 2;"` reads files via volume mount
- [ ] Verify CI workflow runs on first tag push
- [ ] Verify ghcr.io package visibility settings after first push