### PR TITLE
Add read_jplace_newick and tree_resolve_placement table functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -596,10 +596,14 @@ set(EXTENSION_SOURCES
     src/copy_fastq.cpp
     src/copy_fasta.cpp
     src/copy_sam.cpp
+    src/catalog_utils.cpp
     src/reference_table_reader.cpp
     src/placement_table_reader.cpp
     src/NewickTree.cpp
+    src/read_jplace_newick.cpp
     src/read_newick.cpp
+    src/tree_table_reader.cpp
+    src/tree_resolve_placement.cpp
     src/copy_newick.cpp
     src/Minimap2Aligner.cpp
     src/sequence_table_reader.cpp

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -16,7 +16,9 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`read_ncbi_fasta`](#read_ncbi_fastaaccession-api_key-include_filepathfalse) - NCBI FASTA sequences
 - [`read_ncbi_annotation`](#read_ncbi_annotationaccession-api_key-include_filepathfalse) - NCBI genome annotations
 - [`read_jplace`](#read_jplacepath) - Phylogenetic placement files
+- [`read_jplace_newick`](#read_jplace_newickpath-include_filepathfalse) - Newick tree from jplace files
 - [`read_newick`](#read_newickfilename-include_filepathfalse) - Newick phylogenetic trees
+- [`tree_resolve_placement`](#tree_resolve_placementtree_table-placements_table) - Resolve phylogenetic placements into a tree
 - [`align_minimap2`](#align_minimap2query_table-subject_tablenull-index_pathnull-options) - Minimap2 alignment
 - [`save_minimap2_index`](#save_minimap2_indexsubject_table-output_path-options) - Save minimap2 index
 - [`align_minimap2_sharded`](#align_minimap2_shardedquery_table-shard_directory-read_to_shard-options) - Sharded minimap2 alignment
@@ -903,6 +905,57 @@ JOIN edge_taxa e ON p.edge_num = e.edge_num;
 
 **Implementation note:** Implemented as a DuckDB macro using `read_json` with JSON path extraction.
 
+## `read_jplace_newick(path, [include_filepath=false])`
+
+Extract the reference Newick tree from jplace phylogenetic placement files. Returns the tree in the same schema as `read_newick`, with one row per node.
+
+**Parameters:**
+- `path` (VARCHAR or VARCHAR[]): Path to jplace file(s), supports glob patterns (e.g., `'data/*.jplace'`)
+- `include_filepath` (BOOLEAN, optional, default false): Add filepath column to output
+
+**Output schema:** Same as [`read_newick`](#read_newickfilename-include_filepathfalse):
+- `node_index` (BIGINT): 0-based index of node in tree
+- `name` (VARCHAR): Node label (empty string for unlabeled internal nodes)
+- `branch_length` (DOUBLE, nullable): Branch length
+- `edge_id` (BIGINT, nullable): Edge identifier from `{n}` syntax
+- `parent_index` (BIGINT, nullable): Parent node's node_index (NULL for root)
+- `is_tip` (BOOLEAN): Whether node is a tip/leaf
+- `filepath` (VARCHAR, optional): File path when include_filepath=true
+
+**Behavior:**
+- Reads the `"tree"` field from each jplace JSON file and parses it as Newick
+- Schema is UNION ALL-compatible with `read_newick`
+- Supports glob patterns for reading trees from multiple jplace files
+- Supports gzip-compressed jplace files
+
+**Examples:**
+```sql
+-- Extract the reference tree from a jplace file
+SELECT * FROM read_jplace_newick('placements.jplace');
+
+-- Get tip names from the reference tree
+SELECT name FROM read_jplace_newick('placements.jplace')
+WHERE is_tip = true;
+
+-- Combine with placement data for a full workflow
+CREATE TABLE ref_tree AS
+SELECT * FROM read_jplace_newick('placements.jplace');
+
+CREATE TABLE placements AS
+SELECT fragment AS fragment_id, edge_num::BIGINT AS edge_id,
+       like_weight_ratio, distal_length, pendant_length
+FROM read_jplace('placements.jplace');
+
+-- Now use tree_resolve_placement to insert placements into the tree
+SELECT * FROM tree_resolve_placement('ref_tree', 'placements');
+
+-- Compare trees across multiple jplace files
+SELECT filepath, COUNT(*) AS num_nodes,
+       COUNT(*) FILTER (WHERE is_tip) AS num_tips
+FROM read_jplace_newick('results/*.jplace', include_filepath=true)
+GROUP BY filepath;
+```
+
 ## `read_newick(filename, [include_filepath=false])`
 
 Read Newick phylogenetic tree files and return a table with one row per node.
@@ -1002,6 +1055,82 @@ COPY (
 - Colons precede branch lengths: `A:0.1` means tip A with branch length 0.1
 - Semicolons terminate the tree: `(A,B);`
 - Edge IDs in braces are an extension for jplace: `A:0.1{0}` has edge_id 0
+
+## `tree_resolve_placement(tree_table, placements_table)`
+
+Resolve phylogenetic placements into a reference tree, returning a fully resolved tree with placed fragments as new tips. This exposes the `insert_fully_resolved` algorithm as a SQL-accessible table function.
+
+**Parameters:**
+- `tree_table` (VARCHAR): Name of a table or view containing tree data in `read_newick` schema (requires `node_index` and `parent_index` columns; `name`, `branch_length`, `edge_id` are optional)
+- `placements_table` (VARCHAR): Name of a table or view containing placement data (requires `fragment_id`, `edge_id`, `like_weight_ratio`, `distal_length`, `pendant_length` columns)
+
+**Output schema:** Same as [`read_newick`](#read_newickfilename-include_filepathfalse) (without filepath):
+- `node_index` (BIGINT): 0-based index of node in resolved tree
+- `name` (VARCHAR): Node label (placed fragments use their fragment_id as name)
+- `branch_length` (DOUBLE, nullable): Branch length
+- `edge_id` (BIGINT, nullable): Edge identifier (NULL for newly created nodes)
+- `parent_index` (BIGINT, nullable): Parent node's node_index (NULL for root)
+- `is_tip` (BOOLEAN): Whether node is a tip/leaf
+
+**Behavior:**
+- Reads tree data from the tree table and builds a `NewickTree`
+- Reads placements and inserts each fragment as a new tip on the specified edge
+- Each placement creates 2 new nodes: an internal node (splitting the edge) and a fragment tip
+- Deduplicates placements by `fragment_id` (keeps highest `like_weight_ratio`, then lowest `pendant_length`)
+- Multiple placements on the same edge are sorted by `distal_length` and inserted as a chain
+- Preserves original tip-to-tip distances in the tree
+- Works with both tables and views for either parameter
+- Schema is UNION ALL-compatible with `read_newick`
+
+**Examples:**
+```sql
+-- Basic workflow: load tree, load placements, resolve
+CREATE TABLE ref_tree AS
+SELECT * FROM read_newick('reference.nwk');
+
+CREATE TABLE placements AS
+SELECT * FROM (VALUES
+    ('seq1', 0::BIGINT, 0.95::DOUBLE, 0.05::DOUBLE, 0.001::DOUBLE),
+    ('seq2', 1::BIGINT, 0.80::DOUBLE, 0.10::DOUBLE, 0.002::DOUBLE)
+) AS t(fragment_id, edge_id, like_weight_ratio, distal_length, pendant_length);
+
+SELECT * FROM tree_resolve_placement('ref_tree', 'placements');
+
+-- Full jplace workflow: extract tree and placements from jplace file
+CREATE TABLE jplace_tree AS
+SELECT * FROM read_jplace_newick('results.jplace');
+
+CREATE TABLE jplace_placements AS
+SELECT fragment AS fragment_id, edge_num::BIGINT AS edge_id,
+       like_weight_ratio, distal_length, pendant_length
+FROM read_jplace('results.jplace');
+
+-- Resolve and inspect the result
+SELECT name FROM tree_resolve_placement('jplace_tree', 'jplace_placements')
+WHERE is_tip = true
+ORDER BY name;
+
+-- Write resolved tree to Newick format
+COPY (
+    SELECT node_index, name, branch_length, edge_id, parent_index
+    FROM tree_resolve_placement('ref_tree', 'placements')
+) TO 'resolved.nwk' (FORMAT NEWICK);
+
+-- Use a view for filtered placements
+CREATE VIEW confident_placements AS
+SELECT * FROM jplace_placements WHERE like_weight_ratio > 0.8;
+
+SELECT COUNT(*) FROM tree_resolve_placement('jplace_tree', 'confident_placements')
+WHERE is_tip = true;
+```
+
+**Error conditions:**
+- Tree table or placements table does not exist
+- Tree table missing required `node_index` or `parent_index` columns
+- Placements table missing required columns (`fragment_id`, `edge_id`, `like_weight_ratio`, `distal_length`, `pendant_length`)
+- Placement references an `edge_id` not present in the tree
+- `distal_length` exceeds the edge's branch length
+- Negative `distal_length` or `pendant_length`
 
 ## `align_minimap2(query_table, [subject_table=NULL], [index_path=NULL], [options])`
 

--- a/src/catalog_utils.cpp
+++ b/src/catalog_utils.cpp
@@ -1,0 +1,43 @@
+#include "catalog_utils.hpp"
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/common/exception.hpp"
+
+namespace duckdb {
+
+TableOrViewColumns GetTableOrViewColumns(ClientContext &context, const std::string &table_name,
+                                         const std::string &entity_type) {
+	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
+	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
+
+	if (!entry) {
+		throw BinderException("%s or view '%s' does not exist", entity_type, table_name);
+	}
+
+	TableOrViewColumns result;
+
+	if (entry->type == CatalogType::TABLE_ENTRY) {
+		auto &table = entry->Cast<TableCatalogEntry>();
+		auto &columns = table.GetColumns();
+		for (idx_t i = 0; i < columns.LogicalColumnCount(); i++) {
+			auto &col = columns.GetColumn(LogicalIndex(i));
+			result.names.push_back(col.Name());
+			result.types.push_back(col.Type());
+		}
+		result.is_physical_table = true;
+	} else if (entry->type == CatalogType::VIEW_ENTRY) {
+		auto &view = entry->Cast<ViewCatalogEntry>();
+		view.BindView(context);
+		auto col_info = view.GetColumnInfo();
+		result.names = col_info->names;
+		result.types = col_info->types;
+		result.is_physical_table = false;
+	} else {
+		throw BinderException("'%s' is not a table or view", table_name);
+	}
+
+	return result;
+}
+
+} // namespace duckdb

--- a/src/include/catalog_utils.hpp
+++ b/src/include/catalog_utils.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/main/client_context.hpp"
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+struct TableOrViewColumns {
+	vector<string> names;
+	vector<LogicalType> types;
+	bool is_physical_table; // true for tables (have rowid), false for views
+};
+
+// Look up a table or view by name and return its column names and types.
+// entity_type is used in error messages (e.g., "Placement table", "Tree table").
+// Throws BinderException if the table/view does not exist.
+TableOrViewColumns GetTableOrViewColumns(ClientContext &context, const std::string &table_name,
+                                         const std::string &entity_type = "Table");
+
+} // namespace duckdb

--- a/src/include/read_jplace_newick.hpp
+++ b/src/include/read_jplace_newick.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "read_newick.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+class ReadJplaceNewickTableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::vector<std::string> file_paths;
+		bool include_filepath;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data(const std::vector<std::string> &paths, bool include_fp);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		std::mutex lock;
+		std::vector<std::string> file_paths;
+		size_t next_file_idx;
+		FileSystem &fs;
+
+		idx_t MaxThreads() const override {
+			return std::min<idx_t>(file_paths.size(), std::thread::hardware_concurrency());
+		}
+
+		GlobalState(const std::vector<std::string> &paths, FileSystem &fs_ref)
+		    : file_paths(paths), next_file_idx(0), fs(fs_ref) {
+		}
+	};
+
+	struct LocalState : public LocalTableFunctionState {
+		bool has_file = false;
+		std::vector<ReadNewickTableFunction::NodeRow> current_rows;
+		size_t current_row_idx = 0;
+		std::string current_filepath;
+	};
+
+	// Extract the "tree" field value from jplace JSON content.
+	static std::string ExtractTreeFromJplaceContent(const std::string &content, const std::string &path);
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/read_newick.hpp
+++ b/src/include/read_newick.hpp
@@ -35,14 +35,8 @@ public:
 		std::vector<LogicalType> types;
 
 		Data(const std::vector<std::string> &paths, bool include_fp, bool stdin_used)
-		    : file_paths(paths), include_filepath(include_fp), uses_stdin(stdin_used),
-		      names({"node_index", "name", "branch_length", "edge_id", "parent_index", "is_tip"}),
-		      types({LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::BIGINT,
-		             LogicalType::BIGINT, LogicalType::BOOLEAN}) {
-			if (include_filepath) {
-				names.emplace_back("filepath");
-				types.emplace_back(LogicalType::VARCHAR);
-			}
+		    : file_paths(paths), include_filepath(include_fp), uses_stdin(stdin_used) {
+			GetSchema(names, types, include_filepath);
 		}
 	};
 
@@ -91,6 +85,14 @@ public:
 
 	// Convert parsed tree to row format
 	static std::vector<NodeRow> TreeToRows(const miint::NewickTree &tree);
+
+	// Populate names/types with the standard newick table schema.
+	// Shared by read_newick, read_jplace_newick, tree_resolve_placement.
+	static void GetSchema(std::vector<std::string> &names, std::vector<LogicalType> &types, bool include_filepath);
+
+	// Emit NodeRow data into a DataChunk (shared by read_newick, read_jplace_newick, tree_resolve_placement)
+	static void EmitNodeRows(const std::vector<NodeRow> &rows, size_t start_idx, size_t count, DataChunk &output,
+	                         idx_t output_offset, bool include_filepath, const std::string &filepath);
 
 	static TableFunction GetFunction();
 	static void Register(ExtensionLoader &loader);

--- a/src/include/tree_resolve_placement.hpp
+++ b/src/include/tree_resolve_placement.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "read_newick.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+class TreeResolvePlacementTableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::string tree_table_name;
+		std::string placements_table_name;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data(std::string tree_table, std::string placements_table);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		std::vector<ReadNewickTableFunction::NodeRow> rows;
+		size_t current_row_idx = 0;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/tree_table_reader.hpp
+++ b/src/include/tree_table_reader.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "NewickTree.hpp"
+#include "duckdb/main/client_context.hpp"
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// Validate that a table or view has the required columns for tree data
+// Required: node_index (integer), parent_index (integer, nullable)
+// Optional: name (VARCHAR), branch_length (DOUBLE/FLOAT), edge_id (integer)
+void ValidateTreeTableSchema(ClientContext &context, const std::string &table_name);
+
+// Read tree node data from a table or view and return as NodeInput structs.
+// Uses a separate Connection to avoid deadlocking the current context.
+std::vector<miint::NodeInput> ReadTreeTable(ClientContext &context, const std::string &table_name);
+
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -9,7 +9,9 @@
 #include <copy_fastq.hpp>
 #include <copy_newick.hpp>
 #include <copy_sam.hpp>
+#include <read_jplace_newick.hpp>
 #include <read_newick.hpp>
+#include <tree_resolve_placement.hpp>
 #include <kseq++/seqio.hpp>
 #include <read_fastx.hpp>
 #include <read_alignments.hpp>
@@ -162,6 +164,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ReadBIOMTableFunction::Register(loader);
 #endif
 	ReadNewickTableFunction::Register(loader);
+	ReadJplaceNewickTableFunction::Register(loader);
+	TreeResolvePlacementTableFunction::Register(loader);
 	AlignMinimap2TableFunction::Register(loader);
 	AlignMinimap2ShardedTableFunction::Register(loader);
 	SaveMinimap2IndexTableFunction::Register(loader);

--- a/src/placement_table_reader.cpp
+++ b/src/placement_table_reader.cpp
@@ -1,7 +1,5 @@
 #include "placement_table_reader.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "catalog_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
@@ -12,40 +10,10 @@
 
 namespace duckdb {
 
-// Helper to get column names and types from either a table or view
-static void GetTableOrViewColumns(ClientContext &context, const std::string &table_name, vector<string> &out_names,
-                                  vector<LogicalType> &out_types) {
-	// Use TABLE_ENTRY lookup which can return either tables or views
-	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
-	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
-
-	if (!entry) {
-		throw BinderException("Placement table or view '%s' does not exist", table_name);
-	}
-
-	if (entry->type == CatalogType::TABLE_ENTRY) {
-		auto &table = entry->Cast<TableCatalogEntry>();
-		auto &columns = table.GetColumns();
-		for (idx_t i = 0; i < columns.LogicalColumnCount(); i++) {
-			auto &col = columns.GetColumn(LogicalIndex(i));
-			out_names.push_back(col.Name());
-			out_types.push_back(col.Type());
-		}
-	} else if (entry->type == CatalogType::VIEW_ENTRY) {
-		auto &view = entry->Cast<ViewCatalogEntry>();
-		view.BindView(context);
-		auto col_info = view.GetColumnInfo();
-		out_names = col_info->names;
-		out_types = col_info->types;
-	} else {
-		throw BinderException("'%s' is not a table or view", table_name);
-	}
-}
-
 void ValidatePlacementTableSchema(ClientContext &context, const std::string &table_name) {
-	vector<string> col_names;
-	vector<LogicalType> col_types;
-	GetTableOrViewColumns(context, table_name, col_names, col_types);
+	auto info = GetTableOrViewColumns(context, table_name, "Placement table");
+	auto &col_names = info.names;
+	auto &col_types = info.types;
 
 	// Build name-to-index map (case-insensitive)
 	std::unordered_map<string, idx_t> name_to_idx;

--- a/src/read_jplace_newick.cpp
+++ b/src/read_jplace_newick.cpp
@@ -1,0 +1,180 @@
+#include "read_jplace_newick.hpp"
+#include "remote_file_helper.hpp"
+#include "table_function_common.hpp"
+#include "duckdb/common/vector_size.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// Extract the "tree" string value from jplace JSON content.
+// The jplace format (Matsen et al., 2012) has a top-level "tree" key whose value
+// is always a Newick string. We find this key and extract the JSON string value.
+std::string ReadJplaceNewickTableFunction::ExtractTreeFromJplaceContent(const std::string &content,
+                                                                        const std::string &path) {
+	auto pos = content.find("\"tree\"");
+	if (pos == std::string::npos) {
+		throw IOException("Jplace file '%s' does not contain a 'tree' field", path);
+	}
+
+	// Skip past "tree", whitespace, and colon
+	pos += 6;
+	while (pos < content.size() &&
+	       (content[pos] == ' ' || content[pos] == '\t' || content[pos] == '\n' || content[pos] == '\r')) {
+		pos++;
+	}
+	if (pos >= content.size() || content[pos] != ':') {
+		throw IOException("Jplace file '%s': malformed 'tree' field (expected ':')", path);
+	}
+	pos++;
+	while (pos < content.size() &&
+	       (content[pos] == ' ' || content[pos] == '\t' || content[pos] == '\n' || content[pos] == '\r')) {
+		pos++;
+	}
+	if (pos >= content.size() || content[pos] != '"') {
+		throw IOException("Jplace file '%s': 'tree' field value is not a string", path);
+	}
+
+	// Extract the JSON string value (handle escape sequences)
+	pos++;
+	std::string result;
+	while (pos < content.size() && content[pos] != '"') {
+		if (content[pos] == '\\' && pos + 1 < content.size()) {
+			pos++;
+			result += content[pos];
+		} else {
+			result += content[pos];
+		}
+		pos++;
+	}
+
+	if (result.empty()) {
+		throw IOException("Jplace file '%s': 'tree' field is empty", path);
+	}
+
+	return result;
+}
+
+ReadJplaceNewickTableFunction::Data::Data(const std::vector<std::string> &paths, bool include_fp)
+    : file_paths(paths), include_filepath(include_fp) {
+	ReadNewickTableFunction::GetSchema(names, types, include_filepath);
+}
+
+unique_ptr<FunctionData> ReadJplaceNewickTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                             vector<LogicalType> &return_types,
+                                                             vector<std::string> &names) {
+	FileSystem &fs = FileSystem::GetFileSystem(context);
+
+	std::vector<std::string> file_paths;
+
+	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
+		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
+		file_paths = std::move(result.paths);
+	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
+		auto &list_children = ListValue::GetChildren(input.inputs[0]);
+		for (const auto &child : list_children) {
+			file_paths.push_back(child.ToString());
+		}
+		if (file_paths.empty()) {
+			throw InvalidInputException("read_jplace_newick: at least one file path must be provided");
+		}
+	} else {
+		throw InvalidInputException("read_jplace_newick: first argument must be VARCHAR or VARCHAR[]");
+	}
+
+	// Validate files exist (skip remote paths)
+	for (const auto &path : file_paths) {
+		if (!miint::RemoteFileHelper::IsRemotePath(path) && !fs.FileExists(path)) {
+			throw IOException("File not found: " + path);
+		}
+	}
+
+	bool include_filepath = ParseIncludeFilepathParameter(input.named_parameters);
+
+	auto data = duckdb::make_uniq<Data>(file_paths, include_filepath);
+
+	for (const auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (const auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+unique_ptr<GlobalTableFunctionState> ReadJplaceNewickTableFunction::InitGlobal(ClientContext &context,
+                                                                               TableFunctionInitInput &input) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto &fs = FileSystem::GetFileSystem(context);
+	return duckdb::make_uniq<GlobalState>(data.file_paths, fs);
+}
+
+unique_ptr<LocalTableFunctionState> ReadJplaceNewickTableFunction::InitLocal(ExecutionContext &context,
+                                                                             TableFunctionInitInput &input,
+                                                                             GlobalTableFunctionState *global_state) {
+	return duckdb::make_uniq<LocalState>();
+}
+
+void ReadJplaceNewickTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &global_state = data_p.global_state->Cast<GlobalState>();
+	auto &local_state = data_p.local_state->Cast<LocalState>();
+
+	idx_t output_idx = 0;
+
+	while (output_idx < STANDARD_VECTOR_SIZE) {
+		// Emit remaining rows from current file
+		if (local_state.current_row_idx < local_state.current_rows.size()) {
+			size_t rows_to_output = std::min<size_t>(STANDARD_VECTOR_SIZE - output_idx,
+			                                         local_state.current_rows.size() - local_state.current_row_idx);
+
+			ReadNewickTableFunction::EmitNodeRows(local_state.current_rows, local_state.current_row_idx, rows_to_output,
+			                                      output, output_idx, bind_data.include_filepath,
+			                                      local_state.current_filepath);
+
+			output_idx += rows_to_output;
+			local_state.current_row_idx += rows_to_output;
+			continue;
+		}
+
+		// Claim next file
+		std::string path;
+		{
+			std::lock_guard<std::mutex> guard(global_state.lock);
+			if (global_state.next_file_idx >= global_state.file_paths.size()) {
+				break;
+			}
+			path = global_state.file_paths[global_state.next_file_idx];
+			global_state.next_file_idx++;
+		}
+
+		local_state.current_filepath = path;
+
+		// Read jplace file as text, extract tree string, parse newick
+		try {
+			std::string content = ReadNewickTableFunction::ReadNewickFile(global_state.fs, path);
+			std::string newick_str = ExtractTreeFromJplaceContent(content, path);
+			auto tree = miint::NewickTree::parse(newick_str);
+			local_state.current_rows = ReadNewickTableFunction::TreeToRows(tree);
+			local_state.current_row_idx = 0;
+		} catch (const IOException &) {
+			throw;
+		} catch (const std::exception &e) {
+			throw IOException("Error parsing tree from jplace file '%s': %s", path, e.what());
+		}
+	}
+
+	output.SetCardinality(output_idx);
+}
+
+TableFunction ReadJplaceNewickTableFunction::GetFunction() {
+	auto tf = TableFunction("read_jplace_newick", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
+	tf.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
+	return tf;
+}
+
+void ReadJplaceNewickTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/read_newick.cpp
+++ b/src/read_newick.cpp
@@ -106,6 +106,17 @@ std::string ReadNewickTableFunction::ReadNewickFile(FileSystem &fs, const std::s
 	return ReadFileHandleToString(*handle);
 }
 
+void ReadNewickTableFunction::GetSchema(std::vector<std::string> &names, std::vector<LogicalType> &types,
+                                        bool include_filepath) {
+	names = {"node_index", "name", "branch_length", "edge_id", "parent_index", "is_tip"};
+	types = {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::DOUBLE,
+	         LogicalType::BIGINT, LogicalType::BIGINT,  LogicalType::BOOLEAN};
+	if (include_filepath) {
+		names.emplace_back("filepath");
+		types.emplace_back(LogicalType::VARCHAR);
+	}
+}
+
 std::vector<ReadNewickTableFunction::NodeRow> ReadNewickTableFunction::TreeToRows(const miint::NewickTree &tree) {
 	std::vector<NodeRow> rows;
 	rows.reserve(tree.num_nodes());
@@ -205,6 +216,54 @@ unique_ptr<LocalTableFunctionState> ReadNewickTableFunction::InitLocal(Execution
 	return duckdb::make_uniq<LocalState>();
 }
 
+void ReadNewickTableFunction::EmitNodeRows(const std::vector<NodeRow> &rows, size_t start_idx, size_t count,
+                                           DataChunk &output, idx_t output_offset, bool include_filepath,
+                                           const std::string &filepath) {
+	for (size_t i = 0; i < count; ++i) {
+		const auto &row = rows[start_idx + i];
+
+		// node_index
+		FlatVector::GetData<int64_t>(output.data[0])[output_offset + i] = row.node_index;
+
+		// name (empty string if not specified, never NULL)
+		auto &name_vec = output.data[1];
+		FlatVector::GetData<string_t>(name_vec)[output_offset + i] = StringVector::AddString(name_vec, row.name);
+
+		// branch_length (nullable - NaN becomes NULL)
+		auto &bl_vec = output.data[2];
+		if (std::isnan(row.branch_length)) {
+			FlatVector::Validity(bl_vec).SetInvalid(output_offset + i);
+		} else {
+			FlatVector::GetData<double>(bl_vec)[output_offset + i] = row.branch_length;
+		}
+
+		// edge_id (nullable)
+		auto &edge_vec = output.data[3];
+		if (row.edge_id.has_value()) {
+			FlatVector::GetData<int64_t>(edge_vec)[output_offset + i] = row.edge_id.value();
+		} else {
+			FlatVector::Validity(edge_vec).SetInvalid(output_offset + i);
+		}
+
+		// parent_index (nullable)
+		auto &parent_vec = output.data[4];
+		if (row.parent_index.has_value()) {
+			FlatVector::GetData<int64_t>(parent_vec)[output_offset + i] = row.parent_index.value();
+		} else {
+			FlatVector::Validity(parent_vec).SetInvalid(output_offset + i);
+		}
+
+		// is_tip
+		FlatVector::GetData<bool>(output.data[5])[output_offset + i] = row.is_tip;
+
+		// filepath (if included)
+		if (include_filepath) {
+			auto &fp_vec = output.data[6];
+			FlatVector::GetData<string_t>(fp_vec)[output_offset + i] = StringVector::AddString(fp_vec, filepath);
+		}
+	}
+}
+
 void ReadNewickTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<Data>();
 	auto &global_state = data_p.global_state->Cast<GlobalState>();
@@ -218,50 +277,8 @@ void ReadNewickTableFunction::Execute(ClientContext &context, TableFunctionInput
 			size_t rows_to_output = std::min<size_t>(STANDARD_VECTOR_SIZE - output_idx,
 			                                         local_state.current_rows.size() - local_state.current_row_idx);
 
-			for (size_t i = 0; i < rows_to_output; ++i) {
-				const auto &row = local_state.current_rows[local_state.current_row_idx + i];
-
-				// node_index
-				FlatVector::GetData<int64_t>(output.data[0])[output_idx + i] = row.node_index;
-
-				// name (empty string if not specified, never NULL)
-				auto &name_vec = output.data[1];
-				FlatVector::GetData<string_t>(name_vec)[output_idx + i] = StringVector::AddString(name_vec, row.name);
-
-				// branch_length (nullable - NaN becomes NULL)
-				auto &bl_vec = output.data[2];
-				if (std::isnan(row.branch_length)) {
-					FlatVector::Validity(bl_vec).SetInvalid(output_idx + i);
-				} else {
-					FlatVector::GetData<double>(bl_vec)[output_idx + i] = row.branch_length;
-				}
-
-				// edge_id (nullable)
-				auto &edge_vec = output.data[3];
-				if (row.edge_id.has_value()) {
-					FlatVector::GetData<int64_t>(edge_vec)[output_idx + i] = row.edge_id.value();
-				} else {
-					FlatVector::Validity(edge_vec).SetInvalid(output_idx + i);
-				}
-
-				// parent_index (nullable)
-				auto &parent_vec = output.data[4];
-				if (row.parent_index.has_value()) {
-					FlatVector::GetData<int64_t>(parent_vec)[output_idx + i] = row.parent_index.value();
-				} else {
-					FlatVector::Validity(parent_vec).SetInvalid(output_idx + i);
-				}
-
-				// is_tip
-				FlatVector::GetData<bool>(output.data[5])[output_idx + i] = row.is_tip;
-
-				// filepath (if included)
-				if (bind_data.include_filepath) {
-					auto &fp_vec = output.data[6];
-					FlatVector::GetData<string_t>(fp_vec)[output_idx + i] =
-					    StringVector::AddString(fp_vec, local_state.current_filepath);
-				}
-			}
+			EmitNodeRows(local_state.current_rows, local_state.current_row_idx, rows_to_output, output, output_idx,
+			             bind_data.include_filepath, local_state.current_filepath);
 
 			output_idx += rows_to_output;
 			local_state.current_row_idx += rows_to_output;

--- a/src/reference_table_reader.cpp
+++ b/src/reference_table_reader.cpp
@@ -1,7 +1,5 @@
 #include "reference_table_reader.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "catalog_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
@@ -11,48 +9,18 @@
 
 namespace duckdb {
 
-// Helper to validate table/view schema for reference lengths
 static void ValidateReferenceTableSchema(ClientContext &context, const std::string &table_name) {
-	// Use TABLE_ENTRY lookup which can return either tables or views
-	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
-	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
+	auto info = GetTableOrViewColumns(context, table_name, "Reference table");
+	auto &col_types = info.types;
 
-	if (!entry) {
-		throw InvalidInputException("Reference table or view '%s' does not exist", table_name);
-	}
-
-	vector<string> col_names;
-	vector<LogicalType> col_types;
-
-	if (entry->type == CatalogType::TABLE_ENTRY) {
-		auto &table = entry->Cast<TableCatalogEntry>();
-		auto &columns = table.GetColumns();
-		for (idx_t i = 0; i < columns.LogicalColumnCount(); i++) {
-			auto &col = columns.GetColumn(LogicalIndex(i));
-			col_names.push_back(col.Name());
-			col_types.push_back(col.Type());
-		}
-	} else if (entry->type == CatalogType::VIEW_ENTRY) {
-		auto &view = entry->Cast<ViewCatalogEntry>();
-		view.BindView(context);
-		auto col_info = view.GetColumnInfo();
-		col_names = col_info->names;
-		col_types = col_info->types;
-	} else {
-		throw InvalidInputException("'%s' is not a table or view", table_name);
-	}
-
-	// Validate has at least 2 columns
 	if (col_types.size() < 2) {
 		throw InvalidInputException("Reference table '%s' must have at least 2 columns (name, length)", table_name);
 	}
 
-	// First column should be VARCHAR (reference name)
 	if (col_types[0].id() != LogicalTypeId::VARCHAR) {
 		throw InvalidInputException("First column of reference table must be VARCHAR (reference name)");
 	}
 
-	// Second column should be integer type (length)
 	auto length_type = col_types[1].id();
 	if (length_type != LogicalTypeId::BIGINT && length_type != LogicalTypeId::INTEGER &&
 	    length_type != LogicalTypeId::UBIGINT && length_type != LogicalTypeId::UINTEGER) {

--- a/src/sequence_table_reader.cpp
+++ b/src/sequence_table_reader.cpp
@@ -1,7 +1,5 @@
 #include "sequence_table_reader.hpp"
-#include "duckdb/catalog/catalog.hpp"
-#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "catalog_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/appender.hpp"
 #include "duckdb/main/connection.hpp"
@@ -11,42 +9,11 @@
 
 namespace duckdb {
 
-// Helper to get column names and types from either a table or view
-// Returns true if it's a physical table (has rowid), false if it's a view
-static bool GetTableOrViewColumns(ClientContext &context, const std::string &table_name, vector<string> &out_names,
-                                  vector<LogicalType> &out_types) {
-	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
-	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
-
-	if (!entry) {
-		throw BinderException("Table or view '%s' does not exist", table_name);
-	}
-
-	if (entry->type == CatalogType::TABLE_ENTRY) {
-		auto &table = entry->Cast<TableCatalogEntry>();
-		auto &columns = table.GetColumns();
-		for (idx_t i = 0; i < columns.LogicalColumnCount(); i++) {
-			auto &col = columns.GetColumn(LogicalIndex(i));
-			out_names.push_back(col.Name());
-			out_types.push_back(col.Type());
-		}
-		return true; // Physical table
-	} else if (entry->type == CatalogType::VIEW_ENTRY) {
-		auto &view = entry->Cast<ViewCatalogEntry>();
-		view.BindView(context);
-		auto col_info = view.GetColumnInfo();
-		out_names = col_info->names;
-		out_types = col_info->types;
-		return false; // View
-	} else {
-		throw BinderException("'%s' is not a table or view", table_name);
-	}
-}
-
 SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const std::string &table_name) {
-	vector<string> col_names;
-	vector<LogicalType> col_types;
-	bool is_physical_table = GetTableOrViewColumns(context, table_name, col_names, col_types);
+	auto info = GetTableOrViewColumns(context, table_name, "Sequence table");
+	auto &col_names = info.names;
+	auto &col_types = info.types;
+	bool is_physical_table = info.is_physical_table;
 
 	// Build name-to-index map (case-insensitive)
 	std::unordered_map<string, idx_t> name_to_idx;

--- a/src/tree_resolve_placement.cpp
+++ b/src/tree_resolve_placement.cpp
@@ -1,0 +1,93 @@
+#include "tree_resolve_placement.hpp"
+#include "placement_table_reader.hpp"
+#include "tree_table_reader.hpp"
+#include "duckdb/common/vector_size.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+TreeResolvePlacementTableFunction::Data::Data(std::string tree_table, std::string placements_table)
+    : tree_table_name(std::move(tree_table)), placements_table_name(std::move(placements_table)) {
+	ReadNewickTableFunction::GetSchema(names, types, false);
+}
+
+unique_ptr<FunctionData> TreeResolvePlacementTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                                 vector<LogicalType> &return_types,
+                                                                 vector<std::string> &names) {
+	auto tree_table_name = input.inputs[0].ToString();
+	auto placements_table_name = input.inputs[1].ToString();
+
+	// Validate schemas at bind time for early error detection
+	ValidateTreeTableSchema(context, tree_table_name);
+	ValidatePlacementTableSchema(context, placements_table_name);
+
+	auto data = duckdb::make_uniq<Data>(std::move(tree_table_name), std::move(placements_table_name));
+
+	for (const auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (const auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+unique_ptr<GlobalTableFunctionState> TreeResolvePlacementTableFunction::InitGlobal(ClientContext &context,
+                                                                                   TableFunctionInitInput &input) {
+	auto &bind_data = input.bind_data->Cast<Data>();
+	auto gstate = duckdb::make_uniq<GlobalState>();
+
+	// Read tree data and placements
+	auto node_inputs = ReadTreeTable(context, bind_data.tree_table_name);
+	auto placements = ReadPlacementTable(context, bind_data.placements_table_name);
+
+	// Build tree from node data
+	miint::NewickTree tree;
+	try {
+		tree = miint::NewickTree::build(node_inputs);
+	} catch (const std::exception &e) {
+		throw InvalidInputException("Failed to build tree from '%s': %s", bind_data.tree_table_name, e.what());
+	}
+
+	// Resolve placements
+	try {
+		tree.insert_fully_resolved(placements);
+	} catch (const std::runtime_error &e) {
+		throw InvalidInputException("Failed to resolve placements: %s", e.what());
+	}
+
+	// Convert to rows
+	gstate->rows = ReadNewickTableFunction::TreeToRows(tree);
+
+	return gstate;
+}
+
+void TreeResolvePlacementTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &global_state = data_p.global_state->Cast<GlobalState>();
+
+	if (global_state.current_row_idx >= global_state.rows.size()) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	size_t rows_to_output =
+	    std::min<size_t>(STANDARD_VECTOR_SIZE, global_state.rows.size() - global_state.current_row_idx);
+
+	ReadNewickTableFunction::EmitNodeRows(global_state.rows, global_state.current_row_idx, rows_to_output, output, 0,
+	                                      false, "");
+
+	global_state.current_row_idx += rows_to_output;
+	output.SetCardinality(rows_to_output);
+}
+
+TableFunction TreeResolvePlacementTableFunction::GetFunction() {
+	return TableFunction("tree_resolve_placement", {LogicalType::VARCHAR, LogicalType::VARCHAR}, Execute, Bind,
+	                     InitGlobal);
+}
+
+void TreeResolvePlacementTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/tree_table_reader.cpp
+++ b/src/tree_table_reader.cpp
@@ -1,0 +1,122 @@
+#include "tree_table_reader.hpp"
+#include "catalog_utils.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include <cmath>
+#include <limits>
+
+namespace duckdb {
+
+void ValidateTreeTableSchema(ClientContext &context, const std::string &table_name) {
+	auto info = GetTableOrViewColumns(context, table_name, "Tree table");
+	auto &col_names = info.names;
+	auto &col_types = info.types;
+
+	std::unordered_map<string, idx_t> name_to_idx;
+	for (idx_t i = 0; i < col_names.size(); i++) {
+		name_to_idx[StringUtil::Lower(col_names[i])] = i;
+	}
+
+	// Only check that required columns exist — the SQL query casts to correct types
+	auto check_exists = [&](const string &col_name) {
+		if (name_to_idx.find(col_name) == name_to_idx.end()) {
+			throw BinderException("Tree table '%s' missing required column '%s'", table_name, col_name);
+		}
+	};
+
+	check_exists("node_index");
+	check_exists("parent_index");
+}
+
+std::vector<miint::NodeInput> ReadTreeTable(ClientContext &context, const std::string &table_name) {
+	std::vector<miint::NodeInput> result;
+
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+
+	// Cast to canonical types so GetData<> always matches the backing store.
+	// DuckDB handles INTEGER->BIGINT, FLOAT->DOUBLE etc. transparently.
+	std::string query = "SELECT node_index::BIGINT, parent_index::BIGINT, name::VARCHAR, "
+	                    "branch_length::DOUBLE, edge_id::BIGINT FROM " +
+	                    KeywordHelper::WriteOptionallyQuoted(table_name);
+
+	auto query_result = conn.Query(query);
+
+	if (query_result->HasError()) {
+		throw InvalidInputException("Failed to read from tree table '%s': %s", table_name, query_result->GetError());
+	}
+
+	auto &materialized = query_result->Cast<MaterializedQueryResult>();
+
+	while (true) {
+		auto chunk = materialized.Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+
+		auto &node_index_vec = chunk->data[0];
+		auto &parent_index_vec = chunk->data[1];
+		auto &name_vec = chunk->data[2];
+		auto &branch_length_vec = chunk->data[3];
+		auto &edge_id_vec = chunk->data[4];
+
+		UnifiedVectorFormat node_data, parent_data, name_data, bl_data, edge_data;
+		node_index_vec.ToUnifiedFormat(chunk->size(), node_data);
+		parent_index_vec.ToUnifiedFormat(chunk->size(), parent_data);
+		name_vec.ToUnifiedFormat(chunk->size(), name_data);
+		branch_length_vec.ToUnifiedFormat(chunk->size(), bl_data);
+		edge_id_vec.ToUnifiedFormat(chunk->size(), edge_data);
+
+		auto node_indices = UnifiedVectorFormat::GetData<int64_t>(node_data);
+		auto parent_indices = UnifiedVectorFormat::GetData<int64_t>(parent_data);
+		auto names = UnifiedVectorFormat::GetData<string_t>(name_data);
+		auto branch_lengths = UnifiedVectorFormat::GetData<double>(bl_data);
+		auto edge_ids = UnifiedVectorFormat::GetData<int64_t>(edge_data);
+
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			miint::NodeInput node;
+
+			auto ni_idx = node_data.sel->get_index(i);
+			if (!node_data.validity.RowIsValid(ni_idx)) {
+				throw InvalidInputException("NULL node_index in tree table '%s'", table_name);
+			}
+			node.node_id = node_indices[ni_idx];
+
+			auto pi_idx = parent_data.sel->get_index(i);
+			if (parent_data.validity.RowIsValid(pi_idx)) {
+				node.parent_id = parent_indices[pi_idx];
+			} else {
+				node.parent_id = std::nullopt; // Root
+			}
+
+			auto nm_idx = name_data.sel->get_index(i);
+			if (name_data.validity.RowIsValid(nm_idx)) {
+				node.name = names[nm_idx].GetString();
+			}
+
+			node.branch_length = std::numeric_limits<double>::quiet_NaN();
+			auto bl_idx = bl_data.sel->get_index(i);
+			if (bl_data.validity.RowIsValid(bl_idx)) {
+				node.branch_length = branch_lengths[bl_idx];
+			}
+
+			auto ei_idx = edge_data.sel->get_index(i);
+			if (edge_data.validity.RowIsValid(ei_idx)) {
+				node.edge_id = edge_ids[ei_idx];
+			}
+
+			result.push_back(std::move(node));
+		}
+	}
+
+	if (result.empty()) {
+		throw InvalidInputException("Tree table '%s' is empty", table_name);
+	}
+
+	return result;
+}
+
+} // namespace duckdb

--- a/test/sql/read_jplace_newick.test
+++ b/test/sql/read_jplace_newick.test
@@ -1,0 +1,134 @@
+# name: test/sql/read_jplace_newick.test
+# description: Test read_jplace_newick table function for extracting Newick trees from jplace files
+# group: [sql]
+
+require miint
+
+# =============================================================================
+# Error Cases
+# =============================================================================
+
+# Nonexistent file
+statement error
+SELECT * FROM read_jplace_newick('nonexistent.jplace');
+----
+
+# =============================================================================
+# Basic parsing: test.jplace
+# Tree: ((A:0.1,B:0.2):0.3{0},(C:0.4,D:0.5):0.6{1}):0.0{2};
+# 7 nodes: 4 tips (A,B,C,D) + 3 internal
+# =============================================================================
+
+# Total node count
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/test.jplace');
+----
+7
+
+# Tip count
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/test.jplace') WHERE is_tip = true;
+----
+4
+
+# Internal node count
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/test.jplace') WHERE is_tip = false;
+----
+3
+
+# Tip names
+query T
+SELECT name FROM read_jplace_newick('data/jplace/test.jplace') WHERE is_tip = true ORDER BY name;
+----
+A
+B
+C
+D
+
+# Exactly one root (NULL parent)
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/test.jplace') WHERE parent_index IS NULL;
+----
+1
+
+# Edge IDs present on 3 of 7 nodes (only internal nodes have {n} in this test tree)
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/test.jplace') WHERE edge_id IS NOT NULL;
+----
+3
+
+# Branch lengths for tips
+query TR
+SELECT name, branch_length FROM read_jplace_newick('data/jplace/test.jplace') WHERE is_tip = true ORDER BY name;
+----
+A	0.1
+B	0.2
+C	0.4
+D	0.5
+
+# =============================================================================
+# Schema consistency with read_newick
+# =============================================================================
+
+# UNION ALL with read_newick must work (same column types)
+statement ok
+SELECT node_index, name, branch_length, edge_id, parent_index, is_tip
+FROM read_newick('data/newick/with_edge_ids.nwk')
+UNION ALL
+SELECT node_index, name, branch_length, edge_id, parent_index, is_tip
+FROM read_jplace_newick('data/jplace/test.jplace');
+
+# =============================================================================
+# Multiple files
+# =============================================================================
+
+# Glob: test.jplace and test2.jplace have the same tree (7 nodes each)
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/test*.jplace');
+----
+14
+
+# =============================================================================
+# include_filepath parameter
+# =============================================================================
+
+# Single file with filepath
+query I
+SELECT COUNT(DISTINCT filepath) FROM read_jplace_newick('data/jplace/test.jplace', include_filepath := true);
+----
+1
+
+# Glob with filepath shows distinct files
+query I
+SELECT COUNT(DISTINCT filepath) FROM read_jplace_newick('data/jplace/test*.jplace', include_filepath := true);
+----
+2
+
+# Without include_filepath, filepath column should not exist
+statement error
+SELECT filepath FROM read_jplace_newick('data/jplace/test.jplace');
+----
+
+# =============================================================================
+# Different jplace formats
+# =============================================================================
+
+# with_n.jplace uses 'n' format, tree: (A:0.1,B:0.2):0.0{0};
+# 3 nodes: 2 tips + 1 root
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/with_n.jplace');
+----
+3
+
+query T
+SELECT name FROM read_jplace_newick('data/jplace/with_n.jplace') WHERE is_tip = true ORDER BY name;
+----
+A
+B
+
+# empty.jplace has same tree structure as with_n.jplace
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/empty.jplace');
+----
+3

--- a/test/sql/tree_resolve_placement.test
+++ b/test/sql/tree_resolve_placement.test
@@ -1,0 +1,231 @@
+# name: test/sql/tree_resolve_placement.test
+# description: Test tree_resolve_placement table function for phylogenetic placement resolution
+# group: [sql]
+
+require miint
+
+require json
+
+# =============================================================================
+# Setup
+# =============================================================================
+
+# Tree from with_edge_ids.nwk: ((A:0.1{0},B:0.2{1}):0.3{2},C:0.4{3}):0.0{4};
+# 5 nodes: A(0), B(1), internal(2), C(3), root(4)
+statement ok
+CREATE TABLE ref_tree AS SELECT * FROM read_newick('data/newick/with_edge_ids.nwk');
+
+# Single placement on edge 0 (A's edge, length 0.1)
+statement ok
+CREATE TABLE single_placement AS
+SELECT * FROM (VALUES
+    ('frag1', 0::BIGINT, 0.95::DOUBLE, 0.05::DOUBLE, 0.001::DOUBLE)
+) AS t(fragment_id, edge_id, like_weight_ratio, distal_length, pendant_length);
+
+# =============================================================================
+# Error Cases
+# =============================================================================
+
+# Nonexistent tree table
+statement error
+SELECT * FROM tree_resolve_placement('no_tree', 'single_placement');
+----
+does not exist
+
+# Nonexistent placements table
+statement error
+SELECT * FROM tree_resolve_placement('ref_tree', 'no_placements');
+----
+does not exist
+
+# Tree table missing required node_index column
+statement ok
+CREATE TABLE bad_tree AS SELECT 1 AS x;
+
+statement error
+SELECT * FROM tree_resolve_placement('bad_tree', 'single_placement');
+----
+node_index
+
+statement ok
+DROP TABLE bad_tree;
+
+# Placements table missing required columns
+statement ok
+CREATE TABLE bad_placements AS SELECT 1 AS x;
+
+statement error
+SELECT * FROM tree_resolve_placement('ref_tree', 'bad_placements');
+----
+fragment_id
+
+statement ok
+DROP TABLE bad_placements;
+
+# Placements reference unknown edge_id
+statement ok
+CREATE TABLE bad_edge_placements AS
+SELECT * FROM (VALUES
+    ('frag1', 999::BIGINT, 0.95::DOUBLE, 0.05::DOUBLE, 0.001::DOUBLE)
+) AS t(fragment_id, edge_id, like_weight_ratio, distal_length, pendant_length);
+
+statement error
+SELECT * FROM tree_resolve_placement('ref_tree', 'bad_edge_placements');
+----
+edge
+
+statement ok
+DROP TABLE bad_edge_placements;
+
+# =============================================================================
+# Basic: single placement
+# =============================================================================
+
+# Single placement adds 2 nodes (1 internal + 1 fragment tip)
+# 5 original + 2 = 7
+query I
+SELECT COUNT(*) FROM tree_resolve_placement('ref_tree', 'single_placement');
+----
+7
+
+# Placed fragment appears as a tip
+query T
+SELECT name FROM tree_resolve_placement('ref_tree', 'single_placement')
+WHERE is_tip = true ORDER BY name;
+----
+A
+B
+C
+frag1
+
+# Still exactly one root
+query I
+SELECT COUNT(*) FROM tree_resolve_placement('ref_tree', 'single_placement')
+WHERE parent_index IS NULL;
+----
+1
+
+# Output has correct column types (no filepath column)
+query ITRIIT rowsort
+SELECT node_index, name, branch_length, edge_id, parent_index, is_tip
+FROM tree_resolve_placement('ref_tree', 'single_placement')
+WHERE parent_index IS NULL;
+----
+4
+(empty)
+0.0
+4
+NULL
+false
+
+# =============================================================================
+# Multiple placements on same edge
+# =============================================================================
+
+statement ok
+CREATE TABLE multi_placements AS
+SELECT * FROM (VALUES
+    ('frag1', 0::BIGINT, 0.95::DOUBLE, 0.05::DOUBLE, 0.001::DOUBLE),
+    ('frag2', 0::BIGINT, 0.80::DOUBLE, 0.02::DOUBLE, 0.002::DOUBLE)
+) AS t(fragment_id, edge_id, like_weight_ratio, distal_length, pendant_length);
+
+# Two placements = 4 new nodes. 5 + 4 = 9
+query I
+SELECT COUNT(*) FROM tree_resolve_placement('ref_tree', 'multi_placements');
+----
+9
+
+# Both fragments are tips
+query T
+SELECT name FROM tree_resolve_placement('ref_tree', 'multi_placements')
+WHERE is_tip = true ORDER BY name;
+----
+A
+B
+C
+frag1
+frag2
+
+# =============================================================================
+# Works with views
+# =============================================================================
+
+statement ok
+CREATE VIEW placement_view AS SELECT * FROM single_placement;
+
+query I
+SELECT COUNT(*) FROM tree_resolve_placement('ref_tree', 'placement_view');
+----
+7
+
+statement ok
+DROP VIEW placement_view;
+
+# =============================================================================
+# Works with tree from read_jplace_newick
+# =============================================================================
+
+# jplace tree has 7 nodes; use 2 valid placements (fragment3 targets root edge
+# with branch_length=0.0, which distal_length=0.2 exceeds)
+# 2 placements add 4 nodes = 11 total, 6 tips
+statement ok
+CREATE TABLE jplace_tree AS SELECT * FROM read_jplace_newick('data/jplace/test.jplace');
+
+statement ok
+CREATE TABLE jplace_placements AS
+SELECT fragment AS fragment_id, edge_num::BIGINT AS edge_id,
+       like_weight_ratio, distal_length, pendant_length
+FROM read_jplace('data/jplace/test.jplace')
+WHERE fragment != 'fragment3';
+
+query I
+SELECT COUNT(*) FROM tree_resolve_placement('jplace_tree', 'jplace_placements');
+----
+11
+
+query I
+SELECT COUNT(*) FROM tree_resolve_placement('jplace_tree', 'jplace_placements')
+WHERE is_tip = true;
+----
+6
+
+query T
+SELECT name FROM tree_resolve_placement('jplace_tree', 'jplace_placements')
+WHERE is_tip = true ORDER BY name;
+----
+A
+B
+C
+D
+fragment1
+fragment2
+
+# =============================================================================
+# Schema matches read_newick (UNION ALL compatibility)
+# =============================================================================
+
+statement ok
+SELECT node_index, name, branch_length, edge_id, parent_index, is_tip
+FROM read_newick('data/newick/with_edge_ids.nwk')
+UNION ALL
+SELECT node_index, name, branch_length, edge_id, parent_index, is_tip
+FROM tree_resolve_placement('ref_tree', 'single_placement');
+
+# =============================================================================
+# Cleanup
+# =============================================================================
+
+statement ok
+DROP TABLE ref_tree;
+
+statement ok
+DROP TABLE single_placement;
+
+statement ok
+DROP TABLE multi_placements;
+
+statement ok
+DROP TABLE jplace_tree;
+
+statement ok
+DROP TABLE jplace_placements;


### PR DESCRIPTION
Implements GitHub issues #16 and #17:

- read_jplace_newick: extracts the Newick reference tree from jplace JSON files, returning it in read_newick schema. Reads files directly with FileSystem and parses the JSON tree field without requiring the json extension at runtime.

- tree_resolve_placement: accepts a tree table (read_newick schema) and a placements table, resolves placements via insert_fully_resolved, and returns the fully resolved tree. Heavy work runs in InitGlobal, not Bind.

Also extracts shared utilities:
- catalog_utils.hpp: GetTableOrViewColumns shared across 4 table readers
- ReadNewickTableFunction::GetSchema: single schema definition for all newick-outputting functions
- ReadNewickTableFunction::EmitNodeRows: shared row emission helper