### PR TITLE
Address user feedback on onboarding tutorials

### DIFF
--- a/onboarding-tutorials/advanced.md
+++ b/onboarding-tutorials/advanced.md
@@ -133,6 +133,10 @@ Notice two patterns here:
 
 ## Complex analytical SQL
 
+The remaining examples in this tutorial are meant to be run interactively in
+the DuckDB shell (`duckdb`), rather than inlined in Bash scripts. Start a new
+shell session and paste the SQL blocks below.
+
 ### Verifying alignments against gene annotations
 
 In the intermediate tutorial we saw that 16S V4 reads cover only a tiny
@@ -168,11 +172,14 @@ CREATE TABLE alignments AS
         max_secondary=5
     );
 
+CREATE TABLE ncbi_annotations AS
+    SELECT * FROM read_ncbi_annotation('U00096.3');
+
 CREATE TABLE rrna_16s AS
     SELECT position AS gene_start,
            stop_position AS gene_end,
            strand
-    FROM read_ncbi_annotation('U00096.3')
+    FROM ncbi_annotations
     WHERE type = 'rRNA'
       AND attributes['product'] LIKE '%16S%';
 
@@ -199,6 +206,13 @@ Now, merge the alignment positions using
 and
 [`JOIN`](https://duckdb.org/docs/current/sql/query_syntax/from) them against
 the gene annotations to see which operons our reads hit:
+
+We filter to primary alignments with high
+[query coverage](../docs/scalar-functions.md#alignment_query_coveragecigar-typealigned)
+(&ge; 99% of the read aligned) to exclude partial soft-clipped matches that
+inflate counts &mdash; see the
+[intermediate tutorial](intermediate.md#step-5-the-query-coverage-lesson) for
+a detailed explanation of why this matters.
 
 ```sql
 WITH good_alns AS (
@@ -348,7 +362,7 @@ SELECT ci.start AS read_start,
        a.stop_position AS gene_end,
        a.attributes['product'] AS product
 FROM unmatched
-JOIN (SELECT * FROM read_ncbi_annotation('U00096.3')) a
+JOIN ncbi_annotations a
   ON ci.start >= a.position
  AND ci.stop <= a.stop_position
 WHERE a.type = 'CDS'
@@ -362,6 +376,20 @@ ORDER BY a.position;
 A read aligned with 100% identity and 100% query coverage to a region inside
 the *dosP* gene, which encodes an oxygen-sensing phosphodiesterase &mdash; not
 a 16S rRNA gene at all.
+
+Which read produced this alignment? We can find it by joining back to the
+alignments table on position:
+
+```sql
+SELECT read_id, position, cigar
+FROM alignments
+WHERE alignment_is_primary(flags)
+  AND position = 1565200;
+```
+
+| read_id | position | cigar |
+|---|---|---|
+| 10317.000004216_6599 | 1565200 | 151= |
 
 Unlike the 16S reads, which have multiple secondary alignments across operons,
 this read has **no secondary alignments** &mdash; the DosP location is its

--- a/onboarding-tutorials/beginner.md
+++ b/onboarding-tutorials/beginner.md
@@ -9,9 +9,14 @@ By the end you will be able to read a FASTQ file directly from the internet,
 explore its contents, and save the results as a Parquet file for downstream
 analysis.
 
-> **Prerequisites:** Python 3.9+, a Jupyter environment (JupyterLab, VS Code,
-> Google Colab, etc.), and the `duckdb` and `pandas` packages.
-> Install them with `pip install duckdb pandas matplotlib`.
+> **Prerequisites:** Python 3.9+ and a Jupyter environment (JupyterLab,
+> VS Code, Google Colab, etc.). Install the required packages:
+>
+> ```bash
+> pip install duckdb pyarrow pandas matplotlib           # pip
+> uv pip install duckdb pyarrow pandas matplotlib        # or uv
+> conda install -c conda-forge python-duckdb pyarrow pandas matplotlib  # or conda
+> ```
 
 ## Setup
 
@@ -166,8 +171,11 @@ rounds to one decimal place.
 ```python
 import os, tempfile
 import matplotlib
-matplotlib.use("Agg")
 import matplotlib.pyplot as plt
+
+# Use a non-interactive backend when running outside a notebook
+if "get_ipython" not in dir():
+    matplotlib.use("Agg")
 
 outdir = tempfile.gettempdir()
 

--- a/onboarding-tutorials/intermediate.md
+++ b/onboarding-tutorials/intermediate.md
@@ -9,13 +9,23 @@ taxa. You will learn
 [macros](https://duckdb.org/docs/current/sql/statements/create_macro), and
 &mdash; most importantly &mdash; why query coverage filtering matters.
 
-> **Prerequisites:** The [beginner tutorial](beginner.md). Familiarity with
-> running SQL queries in the
-> [DuckDB shell](https://duckdb.org/docs/current/clients/cli/overview).
+> **Prerequisites:** The [beginner tutorial](beginner.md). Install the DuckDB
+> command-line interface:
+>
+> ```bash
+> pip install duckdb-cli               # pip
+> uv pip install duckdb-cli            # or uv
+> conda install -c conda-forge duckdb-cli  # or conda
+> ```
+>
+> See the
+> [DuckDB installation page](https://duckdb.org/docs/current/installation/)
+> for other options (Homebrew, standalone binaries, etc.).
 
 ## Setup
 
-Start the DuckDB CLI and load the extensions we need:
+Open a terminal and start the DuckDB shell by running `duckdb`. You'll see an
+interactive prompt where you can type SQL queries. Load the extensions we need:
 
 ```sql
 INSTALL httpfs;

--- a/onboarding-tutorials/introduction.md
+++ b/onboarding-tutorials/introduction.md
@@ -29,6 +29,34 @@ et al., 2017) &mdash; and builds on the ideas introduced in the previous one.
 
 ## Installation
 
+### Install DuckDB
+
+DuckDB is available for many languages and platforms &mdash; see the
+[DuckDB installation page](https://duckdb.org/docs/current/installation/) for
+the full list. These tutorials use the
+[Python client](https://duckdb.org/docs/current/clients/python/overview) and
+the [command-line interface](https://duckdb.org/docs/current/clients/cli/overview);
+installation instructions for each are below.
+
+**Python library** (for the [beginner tutorial](beginner.md)):
+
+```bash
+pip install duckdb pyarrow pandas matplotlib           # pip
+uv pip install duckdb pyarrow pandas matplotlib        # or uv
+conda install -c conda-forge python-duckdb pyarrow pandas matplotlib  # or conda
+```
+
+**Command-line interface** (for the
+[intermediate](intermediate.md) and [advanced](advanced.md) tutorials):
+
+```bash
+pip install duckdb-cli               # pip
+uv pip install duckdb-cli            # or uv
+conda install -c conda-forge duckdb-cli  # or conda
+```
+
+### Install miint
+
 miint is published in the
 [DuckDB Community Extensions](https://community-extensions.duckdb.org/) repository.
 No compilation required &mdash; DuckDB will download and verify the extension


### PR DESCRIPTION
- introduction.md: add DuckDB installation instructions (pip/uv/conda) for both Python client and CLI
- beginner.md: add pip/uv/conda install options with pyarrow, fix matplotlib to show inline plots in Jupyter
- intermediate.md: add CLI install instructions, reframe prerequisite as learning rather than requiring familiarity
- advanced.md: note transition from bash to interactive CLI, add query coverage filtering explanation with link to intermediate tutorial, cache read_ncbi_annotation locally, show how DosP read_id was discovered