### PR TITLE
Convert mzml_peak_pair from SQL macro to C++ table function for perfo…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,6 +632,7 @@ set(EXTENSION_SOURCES
     src/massql_parser.cpp
     src/massql_transpiler.cpp
     src/massql_function.cpp
+    src/mzml_peak_pair_function.cpp
     src/mass_tables.cpp
     src/MzXMLReader.cpp
     src/read_mzxml.cpp

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -608,51 +608,7 @@ const std::string MZML_OR_CARDINALITY = // NOLINT
     "SELECT * FROM ms2 "
     "WHERE spectrum_index IN (SELECT spectrum_index FROM cardinality_check); ";
 
-// mzml_peak_pair(relation, formula_str)
-//
-// Find MS2 spectra containing a peak pair where one peak is at m/z = X and
-// another is at m/z = 2*X - formula(formula_str), within 0.1 Da tolerance.
-// Returns all peaks from matching spectra (composable with mzml_scaninfo).
-//
-// This implements the MassQL pattern:
-//   QUERY scaninfo(MS2DATA) WHERE MS2PROD=X AND MS2PROD=2.0*(X - formula(F))
-//
-// X candidates are drawn from all MS2 peaks across all scans (cross-scan matching)
-// and deduplicated with a greedy 0.05 Da step to match MassQL's algorithm.
-//
-// Usage:
-//   CREATE TABLE spectra AS SELECT * FROM read_mzml('file.mzML');
-//   SELECT * FROM mzml_peak_pair(spectra, 'Fe');
-//   -- Or with scaninfo:
-//   CREATE VIEW matches AS SELECT * FROM mzml_peak_pair(spectra, 'Fe');
-//   SELECT * FROM mzml_scaninfo(matches);
-const std::string MZML_PEAK_PAIR = // NOLINT
-    "CREATE OR REPLACE MACRO mzml_peak_pair(relation, formula_str) AS TABLE "
-    "WITH RECURSIVE ms2 AS ( "
-    "    SELECT * FROM mzml_peaks(relation) WHERE ms_level = 2 AND intensity > 0 "
-    "), "
-    "formula_mass AS ( "
-    "    SELECT formula(formula_str) AS mass "
-    "), "
-    "x_candidates(x_val, next_min) AS ( "
-    "    (SELECT mz, mz + 0.05 FROM ms2 ORDER BY mz LIMIT 1) "
-    "    UNION ALL "
-    "    (SELECT s.mz, s.mz + 0.05 "
-    "     FROM x_candidates g "
-    "     JOIN (SELECT DISTINCT mz FROM ms2) s ON s.mz >= g.next_min "
-    "     ORDER BY s.mz "
-    "     LIMIT 1) "
-    ") "
-    "SELECT * FROM ms2 "
-    "WHERE spectrum_index IN ( "
-    "    SELECT DISTINCT p1.spectrum_index "
-    "    FROM x_candidates xc "
-    "    CROSS JOIN formula_mass fm "
-    "    JOIN ms2 p1 ON p1.mz > xc.x_val - 0.1 AND p1.mz < xc.x_val + 0.1 "
-    "    JOIN ms2 p2 ON p2.spectrum_index = p1.spectrum_index "
-    "        AND p2.mz > 2.0 * xc.x_val - fm.mass - 0.1 "
-    "        AND p2.mz < 2.0 * xc.x_val - fm.mass + 0.1 "
-    "); ";
+// mzml_peak_pair is now a C++ table function — see src/mzml_peak_pair_function.cpp
 
 // mzml_i_norm(intensity_array, base_peak_intensity)
 //
@@ -892,7 +848,7 @@ public:
 		register_macro(MZML_X_MS1_MS2_PREC, "mzml_x_ms1_ms2_prec");
 		register_macro(MZML_X_OFFSET_PAIR_RANGE, "mzml_x_offset_pair_range");
 		register_macro(MZML_OR_CARDINALITY, "mzml_or_cardinality");
-		register_macro(MZML_PEAK_PAIR, "mzml_peak_pair");
+		// mzml_peak_pair is now a C++ table function (MzmlPeakPairFunction) for performance.
 		register_macro(MZML_I_NORM, "mzml_i_norm");
 		register_macro(MZML_I_TIC_NORM, "mzml_i_tic_norm");
 		register_macro(MZML_EXCLUDED_MS2PROD, "mzml_excluded_ms2prod");

--- a/src/include/mzml_peak_pair_function.hpp
+++ b/src/include/mzml_peak_pair_function.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+class MzmlPeakPairFunction {
+public:
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -29,6 +29,7 @@
 #include <sequence_functions.hpp>
 #include <formula_function.hpp>
 #include <massql_function.hpp>
+#include <mzml_peak_pair_function.hpp>
 #include <align_mafft.hpp>
 #include <align_pairwise_functions.hpp>
 #include <read_mzml.hpp>
@@ -192,6 +193,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SequenceFunctions::Register(loader);
 	FormulaFunction::Register(loader);
 	MassQLFunction::Register(loader);
+	MzmlPeakPairFunction::Register(loader);
 
 	AlignPairwiseScoreFunction::Register(loader);
 	AlignPairwiseCigarFunction::Register(loader);

--- a/src/mzml_peak_pair_function.cpp
+++ b/src/mzml_peak_pair_function.cpp
@@ -73,7 +73,8 @@ static unique_ptr<FunctionData> PeakPairBind(ClientContext &context, TableFuncti
 	Connection conn(db);
 
 	// Materialize MS2 peaks into a temp table.
-	auto mat_sql = "CREATE TEMP TABLE " + ms2_table + " AS "
+	auto mat_sql = "CREATE TEMP TABLE " + ms2_table +
+	               " AS "
 	               "SELECT * FROM mzml_peaks(" +
 	               quoted_relation + ") WHERE ms_level = 2 AND intensity > 0";
 	auto mat_result = conn.Query(mat_sql);
@@ -84,8 +85,10 @@ static unique_ptr<FunctionData> PeakPairBind(ClientContext &context, TableFuncti
 	// Materialize distinct m/z values. The recursive CTE re-evaluates
 	// SELECT DISTINCT mz at every recursion step (~3k iterations); pre-materializing
 	// this set is the key optimization (18s → <1s on real data).
-	auto distinct_sql = "CREATE TEMP TABLE " + mz_table + " AS "
-	                    "SELECT DISTINCT mz FROM " + ms2_table;
+	auto distinct_sql = "CREATE TEMP TABLE " + mz_table +
+	                    " AS "
+	                    "SELECT DISTINCT mz FROM " +
+	                    ms2_table;
 	auto distinct_result = conn.Query(distinct_sql);
 	if (distinct_result->HasError()) {
 		throw InvalidInputException("mzml_peak_pair: failed to materialize distinct mz: %s",
@@ -113,7 +116,8 @@ static unique_ptr<FunctionData> PeakPairBind(ClientContext &context, TableFuncti
 	                 "    SELECT DISTINCT p1.spectrum_index "
 	                 "    FROM x_candidates xc "
 	                 "    JOIN " +
-	                 ms2_table + " p1 ON p1.mz > xc.x_val - 0.1 AND p1.mz < xc.x_val + 0.1 "
+	                 ms2_table +
+	                 " p1 ON p1.mz > xc.x_val - 0.1 AND p1.mz < xc.x_val + 0.1 "
 	                 "    JOIN " +
 	                 ms2_table +
 	                 " p2 ON p2.spectrum_index = p1.spectrum_index "

--- a/src/mzml_peak_pair_function.cpp
+++ b/src/mzml_peak_pair_function.cpp
@@ -1,0 +1,168 @@
+#include "mzml_peak_pair_function.hpp"
+#include "formula_parser.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+
+#include <atomic>
+
+namespace duckdb {
+
+// ── mzml_peak_pair() table function ─────────────────────────────────────────
+// Usage: SELECT * FROM mzml_peak_pair('spectra', 'Fe')
+//
+// Finds MS2 spectra containing a peak pair where one peak is at m/z = X and
+// another is at m/z = 2*X - formula(formula_str), within 0.1 Da tolerance.
+// Returns all peaks from matching spectra (composable with mzml_scaninfo).
+//
+// This is a C++ table function replacement for the former SQL macro. The macro
+// suffered from severe performance issues because the recursive CTE's
+// `SELECT DISTINCT mz FROM ms2` was re-evaluated at every recursion step (~3k
+// iterations). This implementation materializes both the MS2 peaks and their
+// distinct m/z values into temp tables, reducing the query from ~18s to ~1s.
+
+static std::atomic<uint64_t> peak_pair_invocation_counter {0};
+
+struct MzmlPeakPairData : public TableFunctionData {
+	unique_ptr<MaterializedQueryResult> result;
+};
+
+struct MzmlPeakPairGlobalState : public GlobalTableFunctionState {
+	unique_ptr<MaterializedQueryResult> result;
+	idx_t MaxThreads() const override {
+		return 1;
+	}
+};
+
+struct MzmlPeakPairLocalState : public LocalTableFunctionState {
+	unique_ptr<DataChunk> current_chunk;
+};
+
+static void ExtractSchema(MaterializedQueryResult &result, vector<LogicalType> &return_types, vector<string> &names) {
+	for (idx_t i = 0; i < result.ColumnCount(); i++) {
+		names.push_back(result.ColumnName(i));
+		return_types.push_back(result.types[i]);
+	}
+}
+
+static unique_ptr<FunctionData> PeakPairBind(ClientContext &context, TableFunctionBindInput &input,
+                                             vector<LogicalType> &return_types, vector<string> &names) {
+	auto data = make_uniq<MzmlPeakPairData>();
+
+	auto relation = input.inputs[0].GetValue<string>();
+	auto formula_str = input.inputs[1].GetValue<string>();
+
+	auto quoted_relation = KeywordHelper::WriteOptionallyQuoted(relation);
+
+	// Compute formula mass in C++ — avoids embedding user input into SQL.
+	double formula_mass;
+	try {
+		formula_mass = miint::ParseFormula(formula_str);
+	} catch (const std::exception &e) {
+		throw InvalidInputException("mzml_peak_pair: invalid formula '%s': %s", formula_str, e.what());
+	}
+	auto mass_literal = StringUtil::Format("%.17g", formula_mass);
+
+	// Unique suffix per invocation to avoid temp table name collisions.
+	auto suffix = std::to_string(peak_pair_invocation_counter.fetch_add(1, std::memory_order_relaxed));
+	auto ms2_table = "__peak_pair_ms2_" + suffix;
+	auto mz_table = "__peak_pair_mz_" + suffix;
+
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+
+	// Materialize MS2 peaks into a temp table.
+	auto mat_sql = "CREATE TEMP TABLE " + ms2_table + " AS "
+	               "SELECT * FROM mzml_peaks(" +
+	               quoted_relation + ") WHERE ms_level = 2 AND intensity > 0";
+	auto mat_result = conn.Query(mat_sql);
+	if (mat_result->HasError()) {
+		throw InvalidInputException("mzml_peak_pair: failed to materialize MS2 peaks: %s", mat_result->GetError());
+	}
+
+	// Materialize distinct m/z values. The recursive CTE re-evaluates
+	// SELECT DISTINCT mz at every recursion step (~3k iterations); pre-materializing
+	// this set is the key optimization (18s → <1s on real data).
+	auto distinct_sql = "CREATE TEMP TABLE " + mz_table + " AS "
+	                    "SELECT DISTINCT mz FROM " + ms2_table;
+	auto distinct_result = conn.Query(distinct_sql);
+	if (distinct_result->HasError()) {
+		throw InvalidInputException("mzml_peak_pair: failed to materialize distinct mz: %s",
+		                            distinct_result->GetError());
+	}
+
+	// Run the recursive query against the materialized tables.
+	auto query_sql = "WITH RECURSIVE "
+	                 "x_candidates(x_val, next_min) AS ( "
+	                 "    (SELECT mz, mz + 0.05 FROM " +
+	                 mz_table +
+	                 " ORDER BY mz LIMIT 1) "
+	                 "    UNION ALL "
+	                 "    (SELECT s.mz, s.mz + 0.05 "
+	                 "     FROM x_candidates g "
+	                 "     JOIN " +
+	                 mz_table +
+	                 " s ON s.mz >= g.next_min "
+	                 "     ORDER BY s.mz "
+	                 "     LIMIT 1) "
+	                 ") "
+	                 "SELECT * FROM " +
+	                 ms2_table +
+	                 " WHERE spectrum_index IN ( "
+	                 "    SELECT DISTINCT p1.spectrum_index "
+	                 "    FROM x_candidates xc "
+	                 "    JOIN " +
+	                 ms2_table + " p1 ON p1.mz > xc.x_val - 0.1 AND p1.mz < xc.x_val + 0.1 "
+	                 "    JOIN " +
+	                 ms2_table +
+	                 " p2 ON p2.spectrum_index = p1.spectrum_index "
+	                 "        AND p2.mz > 2.0 * xc.x_val - " +
+	                 mass_literal +
+	                 " - 0.1 "
+	                 "        AND p2.mz < 2.0 * xc.x_val - " +
+	                 mass_literal +
+	                 " + 0.1 "
+	                 ")";
+	auto query_result = conn.Query(query_sql);
+	if (query_result->HasError()) {
+		throw InvalidInputException("mzml_peak_pair: query failed: %s", query_result->GetError());
+	}
+
+	data->result = unique_ptr_cast<QueryResult, MaterializedQueryResult>(std::move(query_result));
+	ExtractSchema(*data->result, return_types, names);
+
+	return data;
+}
+
+static unique_ptr<GlobalTableFunctionState> PeakPairInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	auto &data = input.bind_data->CastNoConst<MzmlPeakPairData>();
+	auto gstate = make_uniq<MzmlPeakPairGlobalState>();
+	gstate->result = std::move(data.result);
+	return gstate;
+}
+
+static unique_ptr<LocalTableFunctionState> PeakPairInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                             GlobalTableFunctionState *) {
+	return make_uniq<MzmlPeakPairLocalState>();
+}
+
+static void PeakPairExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &gstate = input.global_state->Cast<MzmlPeakPairGlobalState>();
+	auto &lstate = input.local_state->Cast<MzmlPeakPairLocalState>();
+
+	lstate.current_chunk = gstate.result->Fetch();
+	if (lstate.current_chunk && lstate.current_chunk->size() > 0) {
+		output.Reference(*lstate.current_chunk);
+		return;
+	}
+	output.SetCardinality(0);
+}
+
+void MzmlPeakPairFunction::Register(ExtensionLoader &loader) {
+	TableFunction func("mzml_peak_pair", {LogicalType::VARCHAR, LogicalType::VARCHAR}, PeakPairExecute, PeakPairBind,
+	                   PeakPairInitGlobal, PeakPairInitLocal);
+	loader.RegisterFunction(func);
+}
+
+} // namespace duckdb

--- a/test/sql/massql_iron_pattern.test
+++ b/test/sql/massql_iron_pattern.test
@@ -1,5 +1,5 @@
 # name: test/sql/massql_iron_pattern.test
-# description: MassQL iron-pattern integration test using mzml_peak_pair macro
+# description: MassQL iron-pattern integration test using mzml_peak_pair table function
 # group: [sql]
 
 require miint
@@ -13,7 +13,7 @@ CREATE TABLE spectra AS SELECT * FROM read_mzml('data/cache/bld_plt1_07_120_1.mz
 # Iron-pattern match via macro — equivalent to MassQL query:
 #   QUERY scaninfo(MS2DATA) WHERE MS2PROD=X AND MS2PROD=2.0*(X - formula(Fe))
 statement ok
-CREATE VIEW iron_peaks AS SELECT * FROM mzml_peak_pair(spectra, 'Fe');
+CREATE VIEW iron_peaks AS SELECT * FROM mzml_peak_pair('spectra', 'Fe');
 
 # Unique scan count must match MassQL ground truth (370)
 query I

--- a/test/sql/mzml_macros.test
+++ b/test/sql/mzml_macros.test
@@ -129,7 +129,7 @@ FROM mzml_scaninfo(ms2_peaks)
 
 # No iron pattern in basic_3spectra MS2 data (peaks at round numbers)
 query I
-SELECT COUNT(*) FROM mzml_peak_pair(spectra, 'Fe')
+SELECT COUNT(*) FROM mzml_peak_pair('spectra', 'Fe')
 ----
 0
 
@@ -144,7 +144,7 @@ SELECT 0 AS spectrum_index, 2 AS ms_level, 1.0 AS retention_time,
        [200.0, 344.0650625] AS mz_array, [1000.0, 500.0] AS intensity_array;
 
 query I
-SELECT COUNT(*) FROM mzml_peak_pair(iron_test, 'Fe')
+SELECT COUNT(*) FROM mzml_peak_pair('iron_test', 'Fe')
 ----
 2
 

--- a/test/sql/mzml_scan_macros.test
+++ b/test/sql/mzml_scan_macros.test
@@ -159,7 +159,7 @@ SELECT 0 AS spectrum_index, 2 AS ms_level, 1.0 AS retention_time,
 
 # Materialize peak_pair result for composability with scan macros
 statement ok
-CREATE TABLE iron_peaks AS SELECT * FROM mzml_peak_pair(iron_test, 'Fe');
+CREATE TABLE iron_peaks AS SELECT * FROM mzml_peak_pair('iron_test', 'Fe');
 
 query IR
 SELECT spectrum_index, total_intensity FROM mzml_scansum(iron_peaks)


### PR DESCRIPTION
…rmance

The SQL macro's recursive CTE re-evaluated `SELECT DISTINCT mz` at every recursion step (~3k iterations on real data). The new C++ table function materializes both the MS2 peaks and their distinct m/z values into temp tables before running the recursive query, reducing the iron-pattern query from ~18s to ~1s on real data.

Key changes:
- New src/mzml_peak_pair_function.cpp: table function with bind-time materialization via a separate Connection (same pattern as massql())
- Formula mass computed in C++ via ParseFormula() — no user input in SQL
- Atomic counter suffix on temp table names to prevent collisions
- Removed dead MZML_PEAK_PAIR macro constant and registration
- Tests updated: relation parameter now quoted (table function vs macro)