### PR TITLE
Use vsearch batch APIs for cluster, search, and chimera-ref

### DIFF
--- a/src/VsearchChimeraWrapper.cpp
+++ b/src/VsearchChimeraWrapper.cpp
@@ -283,6 +283,28 @@ UchimeResult VsearchChimeraWrapper::convert_result(const void *vsearch_result_pt
 	return result;
 }
 
+void VsearchChimeraWrapper::detect_batch(const std::vector<std::string> &query_labels,
+                                         const std::vector<std::string> &query_sequences,
+                                         std::vector<UchimeResult> &output) {
+	if (!state_ || !state_->db_initialized) {
+		throw std::runtime_error("detect_batch called before set_reference");
+	}
+	if (query_labels.empty()) {
+		return;
+	}
+
+	VsearchBatchArgs args(query_labels, query_sequences);
+
+	std::vector<chimera_result_s> raw_results(args.count);
+
+	chimera_detect_batch(args.seq_ptrs.data(), args.head_ptrs.data(), args.lens.data(), args.sizes.data(), args.count,
+	                     raw_results.data());
+
+	for (int i = 0; i < args.count; i++) {
+		output.push_back(convert_result(&raw_results[i]));
+	}
+}
+
 UchimeResult VsearchChimeraWrapper::detect_denovo(const std::string &query_label, const std::string &query_sequence,
                                                   int64_t query_abundance) {
 	assert(state_ && state_->thread_initialized && "detect_denovo called before prepare_denovo");

--- a/src/VsearchClusterWrapper.cpp
+++ b/src/VsearchClusterWrapper.cpp
@@ -141,22 +141,23 @@ std::vector<ClusterResult> VsearchClusterWrapper::cluster_all() {
 	struct cluster_session_s *cs = cluster_session_alloc();
 	cluster_session_init(cs);
 
-	// Step 7: assign each sequence to a cluster sequentially
+	// Step 7: assign sequences to clusters using batch API
+	// (internally parallelizes search across opt_threads)
+	std::vector<cluster_result_s> raw_results(state_->sequence_count);
+	cluster_assign_batch(cs, 0, state_->sequence_count, raw_results.data());
+
 	std::vector<ClusterResult> results;
 	results.reserve(state_->sequence_count);
-
-	struct cluster_result_s raw_result;
 	for (int i = 0; i < state_->sequence_count; i++) {
-		cluster_assign_single(cs, i, &raw_result);
-
+		auto &raw = raw_results[i];
 		ClusterResult cr;
 		cr.read_id = state_->labels[i];
-		cr.is_centroid = raw_result.is_centroid;
-		cr.cluster_id = raw_result.cluster_id;
-		cr.centroid_id = raw_result.centroid_label;
-		cr.identity = raw_result.identity;
-		cr.cigar = raw_result.cigar;
-		cr.cigar_truncated = raw_result.cigar_truncated;
+		cr.is_centroid = raw.is_centroid;
+		cr.cluster_id = raw.cluster_id;
+		cr.centroid_id = raw.centroid_label;
+		cr.identity = raw.identity;
+		cr.cigar = raw.cigar;
+		cr.cigar_truncated = raw.cigar_truncated;
 		results.push_back(std::move(cr));
 	}
 

--- a/src/VsearchSearchWrapper.cpp
+++ b/src/VsearchSearchWrapper.cpp
@@ -216,4 +216,42 @@ VsearchSearchWrapper::SearchHandle VsearchSearchWrapper::create_search_handle() 
 	return handle;
 }
 
+void VsearchSearchWrapper::search_batch(const std::vector<std::string> &query_labels,
+                                        const std::vector<std::string> &query_sequences,
+                                        std::vector<SearchResult> &output) {
+	if (!state_ || !state_->db_initialized) {
+		throw std::runtime_error("search_batch called before set_database");
+	}
+	if (query_labels.empty()) {
+		return;
+	}
+
+	VsearchBatchArgs args(query_labels, query_sequences);
+	int max_results = params_.maxaccepts;
+
+	std::vector<search_result_s> raw_results(args.count * max_results);
+	std::vector<int> result_counts(args.count);
+
+	::search_batch(args.seq_ptrs.data(), args.head_ptrs.data(), args.lens.data(), args.sizes.data(), args.count,
+	               raw_results.data(), max_results, result_counts.data());
+
+	for (int qi = 0; qi < args.count; qi++) {
+		for (int hi = 0; hi < result_counts[qi]; hi++) {
+			auto &r = raw_results[qi * max_results + hi];
+			SearchResult sr;
+			sr.query_id = query_labels[qi];
+			sr.target_id = r.target_label;
+			sr.identity = r.id;
+			sr.matches = r.matches;
+			sr.mismatches = r.mismatches;
+			sr.gaps = r.gaps;
+			sr.alignment_length = r.alignment_length;
+			sr.query_length = r.query_length;
+			sr.target_length = r.target_length;
+			sr.accepted = r.accepted;
+			output.push_back(std::move(sr));
+		}
+	}
+}
+
 } // namespace miint

--- a/src/include/VsearchChimeraWrapper.hpp
+++ b/src/include/VsearchChimeraWrapper.hpp
@@ -76,6 +76,13 @@ public:
 	// Index a single sequence in the k-mer index (de novo mode).
 	void index_sequence(uint64_t seqno);
 
+	// Detect chimeras for a batch of queries using vsearch's internal thread pool.
+	// Internally parallelizes across opt_threads. Results are appended to output.
+	// Must be called AFTER set_reference(). Not thread-safe — call from one thread.
+	// Reference mode only (not for de novo).
+	void detect_batch(const std::vector<std::string> &query_labels, const std::vector<std::string> &query_sequences,
+	                  std::vector<UchimeResult> &output);
+
 	// Detect chimera with abundance skew filtering (de novo mode, single-threaded).
 	UchimeResult detect_denovo(const std::string &query_label, const std::string &query_sequence,
 	                           int64_t query_abundance);

--- a/src/include/VsearchSearchWrapper.hpp
+++ b/src/include/VsearchSearchWrapper.hpp
@@ -79,6 +79,12 @@ public:
 	// Must be called AFTER set_database().
 	SearchHandle create_search_handle();
 
+	// Search a batch of queries using vsearch's internal thread pool.
+	// Internally parallelizes across opt_threads. Results are appended to output.
+	// Must be called AFTER set_database(). Not thread-safe — call from one thread.
+	void search_batch(const std::vector<std::string> &query_labels, const std::vector<std::string> &query_sequences,
+	                  std::vector<SearchResult> &output);
+
 private:
 	SearchParams params_;
 

--- a/src/include/search_sequences.hpp
+++ b/src/include/search_sequences.hpp
@@ -5,15 +5,14 @@
 
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/vector_size.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
-#include <atomic>
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -32,34 +31,25 @@ public:
 		std::vector<LogicalType> types;
 	};
 
-	static constexpr idx_t BATCH_SIZE = 64;
-	static constexpr idx_t MAX_THREADS = 8;
-
 	struct GlobalState : public GlobalTableFunctionState {
 		miint::VsearchSearchWrapper wrapper;
 
-		// Lazy streaming of query sequences — thread-safe, no upfront materialization.
+		// Lazy streaming of query sequences.
 		std::unique_ptr<QuerySequenceStream> query_stream;
 
-		idx_t MaxThreads() const override {
-			return MAX_THREADS;
-		}
-	};
-
-	struct LocalState : public LocalTableFunctionState {
-		std::optional<miint::VsearchSearchWrapper::SearchHandle> handle;
-
+		// Buffered results from the last search_batch call.
 		std::vector<miint::SearchResult> result_buffer;
-		idx_t buffer_offset = 0;
+		idx_t result_offset = 0;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
 	};
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
 	                                     vector<LogicalType> &return_types, vector<std::string> &names);
 
 	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
-
-	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
-	                                                     GlobalTableFunctionState *global_state);
 
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 

--- a/src/include/uchime_ref.hpp
+++ b/src/include/uchime_ref.hpp
@@ -5,14 +5,14 @@
 
 #include "duckdb/common/typedefs.hpp"
 #include "duckdb/common/types.hpp"
+#include "duckdb/common/vector_size.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
-#include <atomic>
-#include <optional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -32,44 +32,25 @@ public:
 		std::vector<LogicalType> types;
 	};
 
-	// Each thread claims BATCH_SIZE query IDs atomically, then fetches sequences
-	// and runs chimera detection independently with no shared mutable state.
-	static constexpr idx_t BATCH_SIZE = 64;
-	static constexpr idx_t MAX_THREADS = 8;
-
 	struct GlobalState : public GlobalTableFunctionState {
-		// Reference DB loaded at init, shared read-only across threads.
 		miint::VsearchChimeraWrapper wrapper;
 
-		// Pre-materialized query IDs (lightweight — just strings, no sequences).
-		std::vector<std::string> all_query_ids;
-		std::atomic<idx_t> next_batch_offset {0};
+		// Lazy streaming of query sequences.
+		std::unique_ptr<QuerySequenceStream> query_stream;
 
-		// Query table name and schema for per-thread ReadBatchByIds calls.
-		std::string query_table;
-		SequenceTableSchema query_schema;
+		// Buffered results from the last detect_batch call.
+		std::vector<miint::UchimeResult> result_buffer;
+		idx_t result_offset = 0;
 
 		idx_t MaxThreads() const override {
-			return MAX_THREADS;
+			return 1;
 		}
-	};
-
-	struct LocalState : public LocalTableFunctionState {
-		// Per-thread vsearch detection handle (wraps chimera_info_s).
-		// Initialized in InitLocal after the global DB is ready.
-		std::optional<miint::VsearchChimeraWrapper::DetectHandle> handle;
-
-		std::vector<miint::UchimeResult> result_buffer;
-		idx_t buffer_offset = 0;
 	};
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
 	                                     vector<LogicalType> &return_types, vector<std::string> &names);
 
 	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
-
-	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
-	                                                     GlobalTableFunctionState *global_state);
 
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 

--- a/src/include/vsearch_utils.hpp
+++ b/src/include/vsearch_utils.hpp
@@ -2,6 +2,7 @@
 
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace miint {
 
@@ -27,5 +28,31 @@ inline std::string normalize_rna(const std::string &seq) {
 	}
 	return out;
 }
+
+// Prepared batch of sequences for vsearch C batch APIs.
+// Owns the normalized sequence data; pointer arrays are valid for its lifetime.
+struct VsearchBatchArgs {
+	std::vector<std::string> seqs_normalized;
+	std::vector<const char *> seq_ptrs;
+	std::vector<const char *> head_ptrs;
+	std::vector<int> lens;
+	std::vector<int> sizes;
+	int count = 0;
+
+	VsearchBatchArgs(const std::vector<std::string> &labels, const std::vector<std::string> &sequences) {
+		count = static_cast<int>(labels.size());
+		seqs_normalized.resize(count);
+		seq_ptrs.resize(count);
+		head_ptrs.resize(count);
+		lens.resize(count);
+		sizes.assign(count, 1);
+		for (int i = 0; i < count; i++) {
+			seqs_normalized[i] = normalize_rna(sequences[i]);
+			seq_ptrs[i] = seqs_normalized[i].c_str();
+			head_ptrs[i] = labels[i].c_str();
+			lens[i] = static_cast<int>(seqs_normalized[i].size());
+		}
+	}
+};
 
 } // namespace miint

--- a/src/search_sequences.cpp
+++ b/src/search_sequences.cpp
@@ -156,41 +156,29 @@ unique_ptr<GlobalTableFunctionState> SearchSequencesTableFunction::InitGlobal(Cl
 	auto ref = LoadSingleEndSequences(context, data.ref_table, "search_sequences_vsearch");
 	gstate->wrapper.set_database(ref.labels, ref.sequences);
 
-	// Create lazy streaming reader for query sequences.
-	// Thread-safe — multiple Execute threads call FetchSubBatch() concurrently.
-	// No upfront materialization of query IDs.
+	// Lazy streaming reader — one STANDARD_VECTOR_SIZE chunk per Execute call.
 	gstate->query_stream =
-	    std::make_unique<QuerySequenceStream>(context, data.query_table, data.query_schema, BATCH_SIZE);
+	    std::make_unique<QuerySequenceStream>(context, data.query_table, data.query_schema, STANDARD_VECTOR_SIZE);
 
 	return gstate;
 }
 
-unique_ptr<LocalTableFunctionState> SearchSequencesTableFunction::InitLocal(ExecutionContext &context,
-                                                                            TableFunctionInitInput &input,
-                                                                            GlobalTableFunctionState *global_state) {
-	auto &gstate = global_state->Cast<GlobalState>();
-	auto lstate = make_uniq<LocalState>();
-	lstate->handle.emplace(gstate.wrapper.create_search_handle());
-	return lstate;
-}
-
 void SearchSequencesTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
-	auto &lstate = data_p.local_state->Cast<LocalState>();
 
 	while (true) {
-		// 1. Drain buffered results
-		if (lstate.buffer_offset < lstate.result_buffer.size()) {
-			idx_t remaining = lstate.result_buffer.size() - lstate.buffer_offset;
+		// 1. Drain buffered results from last batch
+		if (gstate.result_offset < gstate.result_buffer.size()) {
+			idx_t remaining = gstate.result_buffer.size() - gstate.result_offset;
 			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputSearchResults(output, lstate.result_buffer, lstate.buffer_offset, count);
-			lstate.buffer_offset += count;
+			OutputSearchResults(output, gstate.result_buffer, gstate.result_offset, count);
+			gstate.result_offset += count;
 			return;
 		}
 
-		// 2. Buffer exhausted — fetch next batch from stream.
-		lstate.result_buffer.clear();
-		lstate.buffer_offset = 0;
+		// 2. Buffer exhausted — fetch next chunk and search via batch API.
+		gstate.result_buffer.clear();
+		gstate.result_offset = 0;
 
 		auto query_batch = gstate.query_stream->FetchSubBatch();
 		if (query_batch.empty()) {
@@ -198,22 +186,13 @@ void SearchSequencesTableFunction::Execute(ClientContext &context, TableFunction
 			return;
 		}
 
-		// 3. Run search on each query in the batch.
-		// Skip empty sequences — vsearch crashes on zero-length queries.
-		for (idx_t i = 0; i < query_batch.size(); i++) {
-			if (query_batch.sequences1[i].empty()) {
-				continue;
-			}
-			auto results = lstate.handle->search(query_batch.read_ids[i], query_batch.sequences1[i]);
-			for (auto &r : results) {
-				lstate.result_buffer.push_back(std::move(r));
-			}
-		}
+		// 3. Search entire chunk via vsearch's internal thread pool.
+		gstate.wrapper.search_batch(query_batch.read_ids, query_batch.sequences1, gstate.result_buffer);
 	}
 }
 
 TableFunction SearchSequencesTableFunction::GetFunction() {
-	auto tf = TableFunction("search_sequences_vsearch", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal, InitLocal);
+	auto tf = TableFunction("search_sequences_vsearch", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal);
 
 	tf.named_parameters["db"] = LogicalType::VARCHAR;
 	tf.named_parameters["id"] = LogicalType::DOUBLE;

--- a/src/uchime_ref.cpp
+++ b/src/uchime_ref.cpp
@@ -4,8 +4,6 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_size.hpp"
-#include "duckdb/main/connection.hpp"
-#include "duckdb/main/database.hpp"
 
 #include <algorithm>
 
@@ -69,90 +67,47 @@ unique_ptr<GlobalTableFunctionState> UchimeRefTableFunction::InitGlobal(ClientCo
 	auto gstate = make_uniq<GlobalState>();
 
 	gstate->wrapper = miint::VsearchChimeraWrapper(data.params);
-	gstate->query_table = data.query_table;
-	gstate->query_schema = data.query_schema;
 
 	auto ref = LoadSingleEndSequences(context, data.ref_table, "detect_chimera_uchime");
 	gstate->wrapper.set_reference(ref.labels, ref.sequences);
 
-	// Materialize all query IDs (lightweight — just strings, no sequences).
-	// This allows lock-free atomic batch claiming in Execute().
-	// NULL read_ids are rejected — every query must have an identifier.
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection id_conn(db);
-	auto id_result = id_conn.Query("SELECT read_id FROM " + KeywordHelper::WriteOptionallyQuoted(data.query_table));
-	if (id_result->HasError()) {
-		throw InvalidInputException("Failed to read query table '%s': %s", data.query_table, id_result->GetError());
-	}
-	auto &id_mat = id_result->Cast<MaterializedQueryResult>();
-	while (auto chunk = id_mat.Fetch()) {
-		for (idx_t i = 0; i < chunk->size(); i++) {
-			auto val = chunk->GetValue(0, i);
-			if (val.IsNull()) {
-				throw InvalidInputException("Query table '%s' contains NULL read_id values", data.query_table);
-			}
-			gstate->all_query_ids.push_back(val.GetValue<std::string>());
-		}
-	}
+	// Lazy streaming reader — one STANDARD_VECTOR_SIZE chunk per Execute call.
+	gstate->query_stream =
+	    std::make_unique<QuerySequenceStream>(context, data.query_table, data.query_schema, STANDARD_VECTOR_SIZE);
 
 	return gstate;
 }
 
-unique_ptr<LocalTableFunctionState> UchimeRefTableFunction::InitLocal(ExecutionContext &context,
-                                                                      TableFunctionInitInput &input,
-                                                                      GlobalTableFunctionState *global_state) {
-	auto &gstate = global_state->Cast<GlobalState>();
-	auto lstate = make_uniq<LocalState>();
-	lstate->handle.emplace(gstate.wrapper.create_detect_handle());
-	return lstate;
-}
-
 void UchimeRefTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
-	auto &lstate = data_p.local_state->Cast<LocalState>();
 
 	while (true) {
-		// 1. Drain buffered results
-		if (lstate.buffer_offset < lstate.result_buffer.size()) {
-			idx_t remaining = lstate.result_buffer.size() - lstate.buffer_offset;
+		// 1. Drain buffered results from last batch
+		if (gstate.result_offset < gstate.result_buffer.size()) {
+			idx_t remaining = gstate.result_buffer.size() - gstate.result_offset;
 			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputUchimeResults(output, lstate.result_buffer, lstate.buffer_offset, count);
-			lstate.buffer_offset += count;
+			OutputUchimeResults(output, gstate.result_buffer, gstate.result_offset, count);
+			gstate.result_offset += count;
 			return;
 		}
 
-		// 2. Buffer exhausted — claim next batch of query IDs atomically (no mutex).
-		lstate.result_buffer.clear();
-		lstate.buffer_offset = 0;
+		// 2. Buffer exhausted — fetch next chunk and detect via batch API.
+		gstate.result_buffer.clear();
+		gstate.result_offset = 0;
 
-		idx_t offset = gstate.next_batch_offset.fetch_add(BATCH_SIZE);
-		if (offset >= gstate.all_query_ids.size()) {
+		auto query_batch = gstate.query_stream->FetchSubBatch();
+		if (query_batch.empty()) {
 			output.SetCardinality(0);
 			return;
 		}
 
-		// 3. Fetch sequences for claimed IDs via ReadBatchByIds (temp table JOIN).
-		miint::SequenceRecordBatch query_batch;
-		ReadBatchByIds(context, gstate.query_table, gstate.query_schema, gstate.all_query_ids, offset, BATCH_SIZE,
-		               query_batch);
-
-		if (query_batch.empty()) {
-			// Batch claimed valid IDs but join returned nothing — skip and try next batch.
-			// This can happen if the table was modified between InitGlobal and Execute.
-			continue;
-		}
-
-		// 4. Run chimera detection on each query in the batch
-		lstate.result_buffer.reserve(query_batch.size());
-		for (idx_t i = 0; i < query_batch.size(); i++) {
-			auto result = lstate.handle->detect(query_batch.read_ids[i], query_batch.sequences1[i]);
-			lstate.result_buffer.push_back(std::move(result));
-		}
+		// 3. Detect chimeras for entire chunk via vsearch's internal thread pool.
+		gstate.wrapper.detect_batch(query_batch.read_ids, query_batch.sequences1, gstate.result_buffer);
 	}
 }
 
 TableFunction UchimeRefTableFunction::GetFunction() {
-	auto tf = TableFunction("detect_chimera_uchime", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal, InitLocal);
+	auto tf = TableFunction("detect_chimera_uchime", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal);
 
 	tf.named_parameters["db"] = LogicalType::VARCHAR;
 	tf.named_parameters["minh"] = LogicalType::DOUBLE;


### PR DESCRIPTION
Update vsearch submodule to b960647d which adds cluster_assign_batch, search_batch, and chimera_detect_batch. These internally parallelize across opt_threads, matching CLI throughput.

- VsearchClusterWrapper: replace cluster_assign_single loop with cluster_assign_batch (single call for all sequences)
- VsearchSearchWrapper: add search_batch method using vsearch's internal thread pool; table function streams STANDARD_VECTOR_SIZE chunks through it instead of per-query SearchHandle dispatch
- VsearchChimeraWrapper: add detect_batch method; uchime_ref table function streams STANDARD_VECTOR_SIZE chunks instead of per-thread DetectHandle with BATCH_SIZE=64
- VsearchBatchArgs helper in vsearch_utils.hpp for DRY batch prep

Performance (200 LTP 16S queries, 500 refs, 12 cores):
  cluster_fast 97%: 933ms -> 390ms (2.4x faster, within 30ms of CLI)
  usearch_global:   389ms -> 232ms (1.7x faster, within 25ms of CLI)
  uchime_ref:      1005ms -> 628ms (1.6x faster, within 89ms of CLI)