### PR TITLE
Add SEQUENCE_DATA parameter to COPY FORMAT SAM/BAM

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,11 +159,12 @@ Custom formats for exporting query results to bioinformatics files:
   - Similar structure to FASTQ without quality scores
 
 - **FORMAT SAM / FORMAT BAM**: `src/copy_sam.cpp`
-  - Parameters: INCLUDE_HEADER, REFERENCE_LENGTHS, COMPRESSION (SAM only), COMPRESSION_LEVEL (BAM only)
+  - Parameters: INCLUDE_HEADER, REFERENCE_LENGTHS, SEQUENCE_DATA, COMPRESSION (SAM only), COMPRESSION_LEVEL (BAM only)
   - Requires reference_lengths table for header generation
   - BAM format always requires headers (binary format specification)
   - COMPRESSION_LEVEL for BAM: 0-9, default 6 (BGZF compression)
-  - Currently writes SEQ/QUAL as `*` (future enhancement opportunity)
+  - SEQUENCE_DATA: optional table/view with read_fastx schema (read_id, sequence1, qual1, and optionally sequence2, qual2) to populate SEQ/QUAL at write time. Handles reverse complement, hard clipping, paired-end selection. Without this parameter, writes SEQ/QUAL as `*`.
+  - Sequence data reader: `src/sequence_data_reader.cpp`
 
 - **Common utilities**: `src/copy_format_common.cpp`
   - Shared buffering and compression infrastructure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ set(EXTENSION_SOURCES
     src/copy_newick.cpp
     src/Minimap2Aligner.cpp
     src/sequence_table_reader.cpp
+    src/sequence_data_reader.cpp
     src/align_minimap2.cpp
     src/align_minimap2_sharded.cpp
     src/save_minimap2_index.cpp

--- a/data/sam/seqdata_test.sam
+++ b/data/sam/seqdata_test.sam
@@ -1,0 +1,10 @@
+@SQ	SN:chr1	LN:1000
+@SQ	SN:chr2	LN:2000
+readA	0	chr1	10	60	10M	*	0	0	*	*
+readB	16	chr1	50	60	10M	*	0	0	*	*
+readC	0	chr2	100	60	2H8M	*	0	0	*	*
+readD	99	chr1	200	60	10M	=	300	110	*	*
+readD	147	chr1	300	60	10M	=	200	-110	*	*
+readE	4	*	0	0	*	*	0	0	*	*
+readF	0	chr1	400	60	8M2H	*	0	0	*	*
+readG	0	chr2	500	60	2H8M2H	*	0	0	*	*

--- a/docs/copy-formats.md
+++ b/docs/copy-formats.md
@@ -112,6 +112,7 @@ Write query results to SAM or BAM format files. Requires all mandatory SAM colum
 - `INCLUDE_HEADER` (default: true): Include header with reference sequences
   - **Note:** BAM format requires `INCLUDE_HEADER=true` (headers are mandatory in BAM files)
 - `REFERENCE_LENGTHS` (VARCHAR, required if INCLUDE_HEADER=true): Table or view name containing reference sequences. Must have at least 2 columns: first column = reference name (VARCHAR), second column = reference length (INTEGER/BIGINT). Column names don't matter. Views are fully supported and can include computed columns.
+- `SEQUENCE_DATA` (VARCHAR, optional): Table or view name containing original read sequences from `read_fastx`. When provided, writes actual SEQ and QUAL fields into the output instead of `*`. See [Sequence Data](#sequence-data) below.
 - `COMPRESSION` (default: auto, SAM only): Enable gzip compression (auto-detected from `.gz` extension)
 - `COMPRESSION_LEVEL` (BAM only): BGZF compression level 0-9 (default: 6). Higher = better compression, slower speed.
 
@@ -168,10 +169,53 @@ COPY (
   SELECT * FROM read_alignments('input.bam')
   WHERE mapq >= 30 AND alignment_is_primary(flags)
 ) TO 'filtered.bam' (FORMAT BAM, REFERENCE_LENGTHS 'ref_table');
+
+-- Write BAM with sequence data (SEQ and QUAL populated from FASTQ)
+CREATE TABLE sequences AS SELECT * FROM read_fastx('reads_R1.fastq', 'reads_R2.fastq');
+
+COPY (SELECT * FROM read_alignments('input.bam'))
+TO 'with_seq.bam' (FORMAT BAM, REFERENCE_LENGTHS 'ref_table', SEQUENCE_DATA 'sequences');
 ```
 
+### Sequence Data
+
+The `SEQUENCE_DATA` parameter allows writing actual SEQ and QUAL fields into SAM/BAM output by looking up original read sequences from a table or view. Without this parameter, SEQ and QUAL are written as `*`.
+
+This design avoids duplicating immutable sequence data across alignment records. The original FASTQ sequences are stored once and joined at write time.
+
+**Required columns in the SEQUENCE_DATA table:**
+- `read_id` (VARCHAR): Read identifier (must match alignment read_id values)
+- `sequence1` (VARCHAR): Forward-strand DNA sequence for read 1
+- `qual1` (LIST(UTINYINT)): Phred quality scores for read 1 (raw values 0-93, no ASCII offset)
+
+**Optional columns (for paired-end):**
+- `sequence2` (VARCHAR): Forward-strand DNA sequence for read 2
+- `qual2` (LIST(UTINYINT)): Phred quality scores for read 2
+
+These columns match the output schema of `read_fastx`, so the typical workflow is:
+
+```sql
+-- Load sequences
+CREATE TABLE sequences AS SELECT * FROM read_fastx('R1.fastq', 'R2.fastq');
+
+-- Load alignments
+CREATE TABLE alignments AS SELECT * FROM read_alignments('aligned.bam');
+
+-- Write with sequences
+COPY (SELECT * FROM alignments)
+TO 'output.bam' (FORMAT BAM, REFERENCE_LENGTHS 'ref_table', SEQUENCE_DATA 'sequences');
+```
+
+**Behavior:**
+- **Paired-end reads**: Uses SAM flag bit 0x80 (second in pair) to select `sequence2`/`qual2` vs `sequence1`/`qual1`
+- **Reverse strand**: When flag bit 0x10 is set, the sequence is reverse-complemented and quality scores are reversed
+- **Hard clipping**: CIGAR H operations trim the original sequence accordingly (leading H trims from start, trailing H from end)
+- **CIGAR validation**: After hard clipping, sequence length must match the sum of query-consuming CIGAR operations (M, I, S, =, X)
+- **NULL quality**: If `qual1`/`qual2` is NULL, sequence is written but quality is marked as missing
+- **Missing reads**: An error is thrown if any alignment's `read_id` is not found in the SEQUENCE_DATA table
+
 **Notes:**
-- SEQ and QUAL fields are always written as `*` in current implementation
+- The SEQUENCE_DATA table is loaded entirely into memory at initialization. For very large datasets, ensure sufficient RAM is available.
 - Reference lengths must be provided explicitly when writing headers - they cannot be inferred from the data
 - All optional tags present in the input are preserved in the output
 - BAM files always require headers (binary format specification)

--- a/src/copy_sam.cpp
+++ b/src/copy_sam.cpp
@@ -1,5 +1,7 @@
 #include "copy_sam.hpp"
 #include "reference_table_reader.hpp"
+#include "sequence_data_reader.hpp"
+#include "sequence_utils.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
@@ -136,6 +138,7 @@ struct SAMCopyBindData : public FunctionData {
 	string file_path;
 	vector<string> names;
 	std::optional<string> reference_lengths_table;
+	std::optional<string> sequence_data_table;
 	SAMColumnIndices indices; // Cached column indices
 
 	unique_ptr<FunctionData> Copy() const override {
@@ -147,6 +150,7 @@ struct SAMCopyBindData : public FunctionData {
 		result->file_path = file_path;
 		result->names = names;
 		result->reference_lengths_table = reference_lengths_table;
+		result->sequence_data_table = sequence_data_table;
 		result->indices = indices;
 		return std::move(result);
 	}
@@ -155,7 +159,8 @@ struct SAMCopyBindData : public FunctionData {
 		auto &other = other_p.Cast<SAMCopyBindData>();
 		return include_header == other.include_header && use_gzip == other.use_gzip && format == other.format &&
 		       compression_level == other.compression_level && file_path == other.file_path &&
-		       reference_lengths_table == other.reference_lengths_table;
+		       reference_lengths_table == other.reference_lengths_table &&
+		       sequence_data_table == other.sequence_data_table;
 	}
 };
 
@@ -272,6 +277,25 @@ static unique_ptr<FunctionData> SAMCopyBindInternal(ClientContext &context, Copy
 			if (entry->type != CatalogType::TABLE_ENTRY && entry->type != CatalogType::VIEW_ENTRY) {
 				throw BinderException("'%s' is not a table or view", result->reference_lengths_table.value());
 			}
+		} else if (StringUtil::CIEquals(option.first, "sequence_data")) {
+			const auto &table_value = option.second[0];
+			if (table_value.type().id() != LogicalTypeId::VARCHAR) {
+				throw BinderException("SEQUENCE_DATA must be a VARCHAR (table or view name)");
+			}
+
+			result->sequence_data_table = table_value.ToString();
+
+			// Validate table or view exists
+			EntryLookupInfo sd_lookup(CatalogType::TABLE_ENTRY, result->sequence_data_table.value(),
+			                          QueryErrorContext());
+			auto sd_entry =
+			    Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, sd_lookup, OnEntryNotFound::RETURN_NULL);
+			if (!sd_entry) {
+				throw BinderException("Table or view '%s' does not exist", result->sequence_data_table.value());
+			}
+			if (sd_entry->type != CatalogType::TABLE_ENTRY && sd_entry->type != CatalogType::VIEW_ENTRY) {
+				throw BinderException("'%s' is not a table or view", result->sequence_data_table.value());
+			}
 		} else {
 			throw BinderException("Unknown option for COPY FORMAT SAM: %s", option.first);
 		}
@@ -331,6 +355,7 @@ struct SAMCopyGlobalState : public GlobalFunctionData {
 	SAMHeaderPtr header;
 	std::atomic<bool> header_written {false};
 	bool include_header = true;
+	std::optional<SequenceDataMap> sequence_data;
 };
 
 static unique_ptr<GlobalFunctionData> SAMCopyInitializeGlobal(ClientContext &context, FunctionData &bind_data,
@@ -382,6 +407,11 @@ static unique_ptr<GlobalFunctionData> SAMCopyInitializeGlobal(ClientContext &con
 	// If no reference_lengths provided, header remains empty
 	// References will be added dynamically as we encounter them during writing
 
+	// Load sequence data if provided
+	if (fdata.sequence_data_table.has_value()) {
+		gstate->sequence_data = ReadSequenceDataTable(context, fdata.sequence_data_table.value());
+	}
+
 	return std::move(gstate);
 }
 
@@ -392,6 +422,8 @@ struct SAMCopyLocalState : public LocalFunctionData {
 	BAMRecordPtr record;
 	std::vector<uint32_t> cigar_buffer;
 	size_t cigar_buffer_capacity = 0;
+	std::string seq_buffer;
+	std::vector<uint8_t> qual_buffer;
 
 	SAMCopyLocalState() {
 		record = BAMRecordPtr(bam_init1());
@@ -492,6 +524,89 @@ static inline void AppendStringTag(bam1_t *record, const char *tag_name, const s
 		if (bam_aux_append(record, tag_name, 'Z', (int)value.size() + 1,
 		                   reinterpret_cast<const uint8_t *>(value.c_str())) < 0) {
 			throw IOException("Failed to append %s tag to BAM record for read: %s", tag_name, read_id);
+		}
+	}
+}
+
+//===--------------------------------------------------------------------===//
+// Sequence/Quality Preparation
+//===--------------------------------------------------------------------===//
+
+// Prepare SEQ and QUAL for a single alignment record by looking up the original
+// FASTQ sequence, applying hard clipping and reverse complement as needed.
+static void PrepareSeqQual(const SequenceDataMap &seq_data, const std::string &read_id, uint16_t flags,
+                           const std::vector<uint32_t> &cigar, std::string &out_seq, std::vector<uint8_t> &out_qual) {
+	auto it = seq_data.find(read_id);
+	if (it == seq_data.end()) {
+		throw InvalidInputException("Read '%s' not found in SEQUENCE_DATA table", read_id);
+	}
+
+	const auto &entry = it->second;
+
+	// Pick read1 vs read2 based on paired-end flag
+	bool is_read2 = (flags & 0x80) != 0;
+	const std::string &raw_seq = is_read2 ? entry.sequence2 : entry.sequence1;
+	const std::vector<uint8_t> &raw_qual = is_read2 ? entry.qual2 : entry.qual1;
+
+	if (raw_seq.empty()) {
+		throw InvalidInputException("Read '%s' has no %s sequence in SEQUENCE_DATA table", read_id,
+		                            is_read2 ? "sequence2" : "sequence1");
+	}
+
+	// Validate sequence and quality lengths match (when quality is present)
+	if (!raw_qual.empty() && raw_qual.size() != raw_seq.size()) {
+		throw InvalidInputException("Sequence and quality lengths differ for read '%s' %s (seq=%llu, qual=%llu)",
+		                            read_id, is_read2 ? "R2" : "R1", static_cast<uint64_t>(raw_seq.size()),
+		                            static_cast<uint64_t>(raw_qual.size()));
+	}
+
+	// Determine hard clipping from CIGAR
+	int64_t leading_clip = 0;
+	int64_t trailing_clip = 0;
+	if (!cigar.empty()) {
+		if (bam_cigar_op(cigar.front()) == BAM_CHARD_CLIP) {
+			leading_clip = bam_cigar_oplen(cigar.front());
+		}
+		if (cigar.size() > 1 && bam_cigar_op(cigar.back()) == BAM_CHARD_CLIP) {
+			trailing_clip = bam_cigar_oplen(cigar.back());
+		}
+	}
+
+	int64_t full_len = static_cast<int64_t>(raw_seq.size());
+	int64_t clipped_len = full_len - leading_clip - trailing_clip;
+
+	if (clipped_len <= 0) {
+		throw InvalidInputException("Hard clipping (%lld + %lld) exceeds sequence length (%lld) for read '%s'",
+		                            leading_clip, trailing_clip, full_len, read_id);
+	}
+
+	out_seq = raw_seq.substr(leading_clip, clipped_len);
+	if (!raw_qual.empty()) {
+		out_qual.assign(raw_qual.begin() + leading_clip, raw_qual.begin() + leading_clip + clipped_len);
+	} else {
+		out_qual.clear();
+	}
+
+	// Reverse complement if on reverse strand
+	if (flags & 0x10) {
+		out_seq = miint::dna_reverse_complement(out_seq);
+		std::reverse(out_qual.begin(), out_qual.end());
+	}
+
+	// Validate: SEQ length must match sum of query-consuming CIGAR ops (skip for unmapped)
+	if (!cigar.empty()) {
+		int64_t expected_len = 0;
+		for (auto c : cigar) {
+			int op = bam_cigar_op(c);
+			// Query-consuming operations: M(0), I(1), S(4), =(7), X(8)
+			if (op == BAM_CMATCH || op == BAM_CINS || op == BAM_CSOFT_CLIP || op == BAM_CEQUAL || op == BAM_CDIFF) {
+				expected_len += bam_cigar_oplen(c);
+			}
+		}
+		if (static_cast<int64_t>(out_seq.size()) != expected_len) {
+			throw InvalidInputException(
+			    "After hard clipping, sequence length (%lld) does not match CIGAR query length (%lld) for read '%s'",
+			    static_cast<int64_t>(out_seq.size()), expected_len, read_id);
 		}
 	}
 }
@@ -650,44 +765,59 @@ static void SAMCopySink(ExecutionContext &context, FunctionData &bind_data, Glob
 			                            mate_position, read_id);
 		}
 
-		// Get reference TIDs
-		int32_t tid = GetReferenceTID(gstate.header.get(), reference);
+		// Prepare SEQ and QUAL (thread-local, no lock needed)
+		size_t l_seq = 0;
+		const char *final_seq = nullptr;
+		const char *final_qual = nullptr;
 
-		// Handle mate_reference: "=" means same as reference
-		int32_t mtid;
-		if (mate_reference == "=") {
-			mtid = tid;
-		} else {
-			mtid = GetReferenceTID(gstate.header.get(), mate_reference);
+		if (gstate.sequence_data.has_value()) {
+			PrepareSeqQual(gstate.sequence_data.value(), read_id, flags, lstate.cigar_buffer, lstate.seq_buffer,
+			               lstate.qual_buffer);
+			l_seq = lstate.seq_buffer.size();
+			final_seq = lstate.seq_buffer.c_str();
+			final_qual =
+			    lstate.qual_buffer.empty() ? nullptr : reinterpret_cast<const char *>(lstate.qual_buffer.data());
 		}
 
-		// Build bam1_t record
-		// Note: SEQ and QUAL are "*" (represented as NULL/0-length in bam_set1)
-		// l_qname is the length WITHOUT null terminator (bam_set1 adds it internally)
-		if (bam_set1(lstate.record.get(), read_id.length(), read_id.c_str(), flags, tid,
-		             static_cast<hts_pos_t>(position - 1), // Convert to 0-based
-		             mapq, lstate.cigar_buffer.size(), lstate.cigar_buffer.data(), mtid,
-		             static_cast<hts_pos_t>(mate_position - 1), // Convert to 0-based
-		             static_cast<hts_pos_t>(template_length), 0, "*", "*", 0) < 0) {
-			throw IOException("Failed to build BAM record for read: " + read_id);
-		}
-
-		// Add optional tags
-		AppendIntegerTag(lstate.record.get(), "AS", tag_as_ptr, tag_as_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "XS", tag_xs_ptr, tag_xs_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "YS", tag_ys_ptr, tag_ys_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "XN", tag_xn_ptr, tag_xn_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "XM", tag_xm_ptr, tag_xm_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "XO", tag_xo_ptr, tag_xo_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "XG", tag_xg_ptr, tag_xg_data, i, read_id);
-		AppendIntegerTag(lstate.record.get(), "NM", tag_nm_ptr, tag_nm_data, i, read_id);
-		AppendStringTag(lstate.record.get(), "YT", tag_yt_ptr, tag_yt_data, i, read_id);
-		AppendStringTag(lstate.record.get(), "MD", tag_md_ptr, tag_md_data, i, read_id);
-		AppendStringTag(lstate.record.get(), "SA", tag_sa_ptr, tag_sa_data, i, read_id);
-
-		// Write record (with lock for thread safety on file I/O)
+		// Lock for TID resolution (may mutate header) + record build + write
 		{
 			lock_guard<mutex> glock(gstate.write_lock);
+
+			// Get reference TIDs (may add to header for headerless SAM)
+			int32_t tid = GetReferenceTID(gstate.header.get(), reference);
+
+			// Handle mate_reference: "=" means same as reference
+			int32_t mtid;
+			if (mate_reference == "=") {
+				mtid = tid;
+			} else {
+				mtid = GetReferenceTID(gstate.header.get(), mate_reference);
+			}
+
+			// Build bam1_t record
+			// l_qname is the length WITHOUT null terminator (bam_set1 adds it internally)
+			if (bam_set1(lstate.record.get(), read_id.length(), read_id.c_str(), flags, tid,
+			             static_cast<hts_pos_t>(position - 1), // Convert to 0-based
+			             mapq, lstate.cigar_buffer.size(), lstate.cigar_buffer.data(), mtid,
+			             static_cast<hts_pos_t>(mate_position - 1), // Convert to 0-based
+			             static_cast<hts_pos_t>(template_length), l_seq, final_seq, final_qual, 0) < 0) {
+				throw IOException("Failed to build BAM record for read: " + read_id);
+			}
+
+			// Add optional tags
+			AppendIntegerTag(lstate.record.get(), "AS", tag_as_ptr, tag_as_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "XS", tag_xs_ptr, tag_xs_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "YS", tag_ys_ptr, tag_ys_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "XN", tag_xn_ptr, tag_xn_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "XM", tag_xm_ptr, tag_xm_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "XO", tag_xo_ptr, tag_xo_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "XG", tag_xg_ptr, tag_xg_data, i, read_id);
+			AppendIntegerTag(lstate.record.get(), "NM", tag_nm_ptr, tag_nm_data, i, read_id);
+			AppendStringTag(lstate.record.get(), "YT", tag_yt_ptr, tag_yt_data, i, read_id);
+			AppendStringTag(lstate.record.get(), "MD", tag_md_ptr, tag_md_data, i, read_id);
+			AppendStringTag(lstate.record.get(), "SA", tag_sa_ptr, tag_sa_data, i, read_id);
+
+			// Write record
 			if (sam_write1(gstate.sam_file.get(), gstate.header.get(), lstate.record.get()) < 0) {
 				throw IOException("Failed to write SAM record for read: " + read_id);
 			}

--- a/src/include/sequence_data_reader.hpp
+++ b/src/include/sequence_data_reader.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "duckdb/main/client_context.hpp"
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace duckdb {
+
+// A single read's sequence and quality data (forward strand, as stored in FASTQ).
+struct SequenceDataEntry {
+	std::string sequence1;
+	std::vector<uint8_t> qual1; // raw Phred (0-93), no ASCII offset
+	std::string sequence2;      // empty if single-end
+	std::vector<uint8_t> qual2;
+};
+
+using SequenceDataMap = std::unordered_map<std::string, SequenceDataEntry>;
+
+// Schema info for a sequence data table.
+struct SequenceDataSchema {
+	bool has_sequence2 = false;
+	bool has_qual2 = false;
+};
+
+// Validate that a table/view has the required read_fastx schema columns:
+// Required: read_id (VARCHAR), sequence1 (VARCHAR), qual1 (LIST(UTINYINT)).
+// Optional: sequence2 (VARCHAR), qual2 (LIST(UTINYINT)) — only needed for paired-end.
+// Throws BinderException on missing required columns or wrong types.
+SequenceDataSchema ValidateSequenceDataSchema(ClientContext &context, const std::string &table_name);
+
+// Read all sequence data from a table/view into memory, keyed by read_id.
+// Uses a separate Connection to avoid deadlocking the caller's context.
+// Throws on duplicate read_id, NULL read_id, or NULL sequence1.
+SequenceDataMap ReadSequenceDataTable(ClientContext &context, const std::string &table_name);
+
+} // namespace duckdb

--- a/src/sequence_data_reader.cpp
+++ b/src/sequence_data_reader.cpp
@@ -1,0 +1,238 @@
+#include "sequence_data_reader.hpp"
+#include "catalog_utils.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/query_result.hpp"
+
+namespace duckdb {
+
+SequenceDataSchema ValidateSequenceDataSchema(ClientContext &context, const std::string &table_name) {
+	auto info = GetTableOrViewColumns(context, table_name, "Sequence data table");
+	auto &col_names = info.names;
+	auto &col_types = info.types;
+
+	// Build case-insensitive name-to-index map
+	std::unordered_map<string, idx_t> name_to_idx;
+	for (idx_t i = 0; i < col_names.size(); i++) {
+		name_to_idx[StringUtil::Lower(col_names[i])] = i;
+	}
+
+	auto require_varchar = [&](const string &col_name) {
+		auto it = name_to_idx.find(col_name);
+		if (it == name_to_idx.end()) {
+			throw BinderException("Sequence data table '%s' missing required column '%s'", table_name, col_name);
+		}
+		if (col_types[it->second].id() != LogicalTypeId::VARCHAR) {
+			throw BinderException("Column '%s' in sequence data table '%s' must be VARCHAR", col_name, table_name);
+		}
+	};
+
+	auto require_list_utinyint = [&](const string &col_name) {
+		auto it = name_to_idx.find(col_name);
+		if (it == name_to_idx.end()) {
+			throw BinderException("Sequence data table '%s' missing required column '%s'", table_name, col_name);
+		}
+		auto &t = col_types[it->second];
+		if (t.id() != LogicalTypeId::LIST || ListType::GetChildType(t).id() != LogicalTypeId::UTINYINT) {
+			throw BinderException("Column '%s' in sequence data table '%s' must be LIST(UTINYINT)", col_name,
+			                      table_name);
+		}
+	};
+
+	auto has_varchar = [&](const string &col_name) -> bool {
+		auto it = name_to_idx.find(col_name);
+		if (it == name_to_idx.end()) {
+			return false;
+		}
+		if (col_types[it->second].id() != LogicalTypeId::VARCHAR) {
+			throw BinderException("Column '%s' in sequence data table '%s' must be VARCHAR", col_name, table_name);
+		}
+		return true;
+	};
+
+	auto has_list_utinyint = [&](const string &col_name) -> bool {
+		auto it = name_to_idx.find(col_name);
+		if (it == name_to_idx.end()) {
+			return false;
+		}
+		auto &t = col_types[it->second];
+		if (t.id() != LogicalTypeId::LIST || ListType::GetChildType(t).id() != LogicalTypeId::UTINYINT) {
+			throw BinderException("Column '%s' in sequence data table '%s' must be LIST(UTINYINT)", col_name,
+			                      table_name);
+		}
+		return true;
+	};
+
+	// Required columns
+	require_varchar("read_id");
+	require_varchar("sequence1");
+	require_list_utinyint("qual1");
+
+	// Optional columns (for paired-end)
+	SequenceDataSchema schema;
+	schema.has_sequence2 = has_varchar("sequence2");
+	schema.has_qual2 = has_list_utinyint("qual2");
+
+	return schema;
+}
+
+// Extract a LIST(UTINYINT) value as vector<uint8_t>.
+// Returns empty vector for NULL values.
+static std::vector<uint8_t> ExtractQualVector(DataChunk &chunk, idx_t col_idx, UnifiedVectorFormat &qual_data,
+                                              idx_t row) {
+	auto qual_row = qual_data.sel->get_index(row);
+	if (!qual_data.validity.RowIsValid(qual_row)) {
+		return {};
+	}
+
+	auto &qual_vec = chunk.data[col_idx];
+	auto &qual_list = ListVector::GetEntry(qual_vec);
+	auto qual_list_data = FlatVector::GetData<uint8_t>(qual_list);
+	auto qual_entries = UnifiedVectorFormat::GetData<list_entry_t>(qual_data);
+
+	idx_t length = qual_entries[qual_row].length;
+	idx_t offset = qual_entries[qual_row].offset;
+
+	return std::vector<uint8_t>(qual_list_data + offset, qual_list_data + offset + length);
+}
+
+SequenceDataMap ReadSequenceDataTable(ClientContext &context, const std::string &table_name) {
+	SequenceDataMap result;
+
+	auto schema = ValidateSequenceDataSchema(context, table_name);
+
+	// Separate connection to avoid deadlocking the current context
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+
+	// Build query based on which columns exist
+	std::string columns = "read_id, sequence1, qual1";
+	if (schema.has_sequence2) {
+		columns += ", sequence2";
+	}
+	if (schema.has_qual2) {
+		columns += ", qual2";
+	}
+	std::string query = "SELECT " + columns + " FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
+	auto query_result = conn.Query(query);
+
+	if (query_result->HasError()) {
+		throw InvalidInputException("Failed to read from sequence data table '%s': %s", table_name,
+		                            query_result->GetError());
+	}
+
+	auto &materialized = query_result->Cast<MaterializedQueryResult>();
+	idx_t row_number = 0;
+
+	// Column indices in our SELECT — dynamic based on schema
+	constexpr idx_t COL_READ_ID = 0;
+	constexpr idx_t COL_SEQ1 = 1;
+	constexpr idx_t COL_QUAL1 = 2;
+	idx_t col_seq2 = DConstants::INVALID_INDEX;
+	idx_t col_qual2 = DConstants::INVALID_INDEX;
+	idx_t next_col = 3;
+	if (schema.has_sequence2) {
+		col_seq2 = next_col++;
+	}
+	if (schema.has_qual2) {
+		col_qual2 = next_col++;
+	}
+
+	// Temp vectors for two-pass extraction (strings first, then lists).
+	// ListVector::GetEntry() can corrupt string pointers, so all strings
+	// must be copied to std::string before any list extraction.
+	std::vector<std::string> temp_read_ids;
+	std::vector<std::string> temp_seq1;
+	std::vector<std::string> temp_seq2;
+	std::vector<bool> temp_seq2_valid;
+
+	while (true) {
+		auto chunk = materialized.Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+
+		UnifiedVectorFormat read_id_data, seq1_data, qual1_data;
+		chunk->data[COL_READ_ID].ToUnifiedFormat(chunk->size(), read_id_data);
+		chunk->data[COL_SEQ1].ToUnifiedFormat(chunk->size(), seq1_data);
+		chunk->data[COL_QUAL1].ToUnifiedFormat(chunk->size(), qual1_data);
+
+		UnifiedVectorFormat seq2_data, qual2_data;
+		const string_t *seq2_ptr = nullptr;
+		if (schema.has_sequence2) {
+			chunk->data[col_seq2].ToUnifiedFormat(chunk->size(), seq2_data);
+			seq2_ptr = UnifiedVectorFormat::GetData<string_t>(seq2_data);
+		}
+		if (schema.has_qual2) {
+			chunk->data[col_qual2].ToUnifiedFormat(chunk->size(), qual2_data);
+		}
+
+		auto read_id_ptr = UnifiedVectorFormat::GetData<string_t>(read_id_data);
+		auto seq1_ptr = UnifiedVectorFormat::GetData<string_t>(seq1_data);
+
+		// Pass 1: extract all strings
+		temp_read_ids.clear();
+		temp_seq1.clear();
+		temp_seq2.clear();
+		temp_seq2_valid.clear();
+
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			row_number++;
+			auto rid_idx = read_id_data.sel->get_index(i);
+			auto s1_idx = seq1_data.sel->get_index(i);
+
+			if (!read_id_data.validity.RowIsValid(rid_idx)) {
+				throw InvalidInputException("NULL read_id at row %llu in sequence data table '%s'", row_number,
+				                            table_name);
+			}
+			if (!seq1_data.validity.RowIsValid(s1_idx)) {
+				throw InvalidInputException("NULL sequence1 at row %llu in sequence data table '%s'", row_number,
+				                            table_name);
+			}
+
+			temp_read_ids.push_back(read_id_ptr[rid_idx].GetString());
+			temp_seq1.push_back(seq1_ptr[s1_idx].GetString());
+
+			if (schema.has_sequence2) {
+				auto s2_idx = seq2_data.sel->get_index(i);
+				if (seq2_data.validity.RowIsValid(s2_idx)) {
+					temp_seq2.push_back(seq2_ptr[s2_idx].GetString());
+					temp_seq2_valid.push_back(true);
+				} else {
+					temp_seq2.emplace_back();
+					temp_seq2_valid.push_back(false);
+				}
+			} else {
+				temp_seq2.emplace_back();
+				temp_seq2_valid.push_back(false);
+			}
+		}
+
+		// Pass 2: extract list columns (safe now that strings are copied)
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			SequenceDataEntry entry;
+			entry.sequence1 = std::move(temp_seq1[i]);
+			entry.qual1 = ExtractQualVector(*chunk, COL_QUAL1, qual1_data, i);
+			entry.sequence2 = std::move(temp_seq2[i]);
+			if (temp_seq2_valid[i] && schema.has_qual2) {
+				entry.qual2 = ExtractQualVector(*chunk, col_qual2, qual2_data, i);
+			}
+
+			auto &read_id = temp_read_ids[i];
+			auto [it, inserted] = result.emplace(read_id, std::move(entry));
+			if (!inserted) {
+				throw InvalidInputException("Duplicate read_id '%s' in sequence data table '%s'", read_id, table_name);
+			}
+		}
+	}
+
+	if (result.empty()) {
+		throw InvalidInputException("Sequence data table '%s' is empty", table_name);
+	}
+
+	return result;
+}
+
+} // namespace duckdb

--- a/test/sql/copy_sam_sequence_data.test
+++ b/test/sql/copy_sam_sequence_data.test
@@ -1,0 +1,295 @@
+# name: test/sql/copy_sam_sequence_data.test
+# description: Test COPY FORMAT SAM/BAM with SEQUENCE_DATA parameter
+# group: [sql]
+
+require miint
+
+# ===================================================================
+# Setup: create reference lengths, alignment data, and sequence data
+# ===================================================================
+
+statement ok
+CREATE TABLE ref_lens AS SELECT * FROM (VALUES ('chr1', 1000), ('chr2', 2000)) t(name, length);
+
+# Load alignment data (no SEQ/QUAL in this SAM file)
+statement ok
+CREATE TABLE alignments AS SELECT * FROM read_alignments('data/sam/seqdata_test.sam');
+
+# Create sequence data table with read_fastx schema
+# readA: forward 10M
+# readB: reverse 10M (will be reverse-complemented)
+# readC: forward 2H8M (leading hard clip)
+# readD: paired (R1 forward, R2 reverse)
+# readE: unmapped
+# readF: forward 8M2H (trailing hard clip)
+# readG: forward 2H6M2H (combined hard clips)
+statement ok
+CREATE TABLE seq_data AS SELECT * FROM (VALUES
+    ('readA', 'AAACCCGGGT', [40,40,40,40,40,37,37,37,37,37]::UTINYINT[], NULL::VARCHAR, NULL::UTINYINT[]),
+    ('readB', 'ACGTAACCGG', [40,39,38,37,36,35,34,33,32,31]::UTINYINT[], NULL::VARCHAR, NULL::UTINYINT[]),
+    ('readC', 'TTAAAACCCC', [36,36,35,35,34,34,33,33,32,32]::UTINYINT[], NULL::VARCHAR, NULL::UTINYINT[]),
+    ('readD', 'AAAACCCCGG', [40,40,40,40,37,37,37,37,35,35]::UTINYINT[], 'TTTTAAAACG', [40,39,38,37,36,35,34,33,32,31]::UTINYINT[]),
+    ('readE', 'NNNNNNNNNN', [0,0,0,0,0,0,0,0,0,0]::UTINYINT[], NULL::VARCHAR, NULL::UTINYINT[]),
+    ('readF', 'AAACCCGGGT', [40,40,40,40,40,37,37,37,37,37]::UTINYINT[], NULL::VARCHAR, NULL::UTINYINT[]),
+    ('readG', 'TTAAAACCCCGG', [36,36,35,35,34,34,33,33,32,32,31,31]::UTINYINT[], NULL::VARCHAR, NULL::UTINYINT[])
+) t(read_id, sequence1, qual1, sequence2, qual2);
+
+# ===================================================================
+# Test 1: Error - SEQUENCE_DATA table does not exist
+# ===================================================================
+statement error
+COPY alignments TO '__TEST_DIR__/err1.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'nonexistent_table');
+----
+does not exist
+
+# ===================================================================
+# Test 2: Without SEQUENCE_DATA (existing behavior preserved)
+# ===================================================================
+statement ok
+COPY alignments TO '__TEST_DIR__/no_seqdata.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens');
+
+# ===================================================================
+# Test 3: Write SAM with SEQUENCE_DATA
+# ===================================================================
+statement ok
+COPY alignments TO '__TEST_DIR__/with_seqdata.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'seq_data');
+
+# ===================================================================
+# Test 4: Verify forward strand (readA: flag 0, 10M)
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readA';
+----
+AAACCCGGGT	[40, 40, 40, 40, 40, 37, 37, 37, 37, 37]
+
+# ===================================================================
+# Test 5: Verify reverse strand (readB: flag 16, 10M)
+# revcomp(ACGTAACCGG) = CCGGTTACGT
+# qual reversed: [31,32,33,34,35,36,37,38,39,40]
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readB';
+----
+CCGGTTACGT	[31, 32, 33, 34, 35, 36, 37, 38, 39, 40]
+
+# ===================================================================
+# Test 6: Verify leading hard clip (readC: flag 0, 2H8M)
+# Original: TTAAAACCCC (10bp), clip first 2 -> AAAACCCC (8bp)
+# qual: [35,35,34,34,33,33,32,32]
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readC';
+----
+AAAACCCC	[35, 35, 34, 34, 33, 33, 32, 32]
+
+# ===================================================================
+# Test 7: Verify paired-end R1 (readD: flag 99, forward, 10M)
+# Uses sequence1: AAAACCCCGG
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readD' AND flags=99;
+----
+AAAACCCCGG	[40, 40, 40, 40, 37, 37, 37, 37, 35, 35]
+
+# ===================================================================
+# Test 8: Verify paired-end R2 (readD: flag 147, reverse, 10M)
+# Uses sequence2: TTTTAAAACG, revcomp -> CGTTTTAAAA
+# qual reversed: [31,32,33,34,35,36,37,38,39,40]
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readD' AND flags=147;
+----
+CGTTTTAAAA	[31, 32, 33, 34, 35, 36, 37, 38, 39, 40]
+
+# ===================================================================
+# Test 9: Verify unmapped (readE: flag 4, no CIGAR)
+# SEQ = original sequence, no reverse complement
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readE';
+----
+NNNNNNNNNN	[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+# ===================================================================
+# Test 10: Verify trailing hard clip (readF: flag 0, 8M2H)
+# Original: AAACCCGGGT (10bp), clip last 2 -> AAACCCGG (8bp)
+# qual: [40,40,40,40,40,37,37,37]
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readF';
+----
+AAACCCGG	[40, 40, 40, 40, 40, 37, 37, 37]
+
+# ===================================================================
+# Test 11: Verify combined hard clips (readG: flag 0, 2H8M2H)
+# Original: TTAAAACCCCGG (12bp), clip first 2 + last 2 -> AAAACCCC (8bp)
+# qual positions 2..9: [35,35,34,34,33,33,32,32]
+# ===================================================================
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.sam', include_seq_qual=true) WHERE read_id='readG';
+----
+AAAACCCC	[35, 35, 34, 34, 33, 33, 32, 32]
+
+# ===================================================================
+# Test 12: Missing read_id in SEQUENCE_DATA throws error
+# ===================================================================
+statement ok
+CREATE TABLE partial_seqs AS SELECT * FROM seq_data WHERE read_id = 'readA';
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_missing.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'partial_seqs');
+----
+not found in SEQUENCE_DATA
+
+# ===================================================================
+# Test 13: BAM format roundtrip with SEQUENCE_DATA
+# ===================================================================
+statement ok
+COPY alignments TO '__TEST_DIR__/with_seqdata.bam' (FORMAT BAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'seq_data');
+
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.bam', include_seq_qual=true) WHERE read_id='readA';
+----
+AAACCCGGGT	[40, 40, 40, 40, 40, 37, 37, 37, 37, 37]
+
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqdata.bam', include_seq_qual=true) WHERE read_id='readB';
+----
+CCGGTTACGT	[31, 32, 33, 34, 35, 36, 37, 38, 39, 40]
+
+# ===================================================================
+# Test 14: View as SEQUENCE_DATA source
+# ===================================================================
+statement ok
+CREATE VIEW seq_view AS SELECT * FROM seq_data;
+
+statement ok
+COPY alignments TO '__TEST_DIR__/with_seqview.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'seq_view');
+
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/with_seqview.sam', include_seq_qual=true) WHERE read_id='readA';
+----
+AAACCCGGGT	[40, 40, 40, 40, 40, 37, 37, 37, 37, 37]
+
+# ===================================================================
+# Test 15: INCLUDE_HEADER=false with SEQUENCE_DATA (headerless SAM)
+# ===================================================================
+statement ok
+COPY alignments TO '__TEST_DIR__/noheader_seqdata.sam' (FORMAT SAM, INCLUDE_HEADER false, SEQUENCE_DATA 'seq_data');
+
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/noheader_seqdata.sam', reference_lengths='ref_lens', include_seq_qual=true) WHERE read_id='readA';
+----
+AAACCCGGGT	[40, 40, 40, 40, 40, 37, 37, 37, 37, 37]
+
+# ===================================================================
+# Test 16: Duplicate read_id in SEQUENCE_DATA throws error
+# ===================================================================
+statement ok
+CREATE TABLE dup_seqs AS
+    SELECT 'readA' AS read_id, 'AAACCCGGGT' AS sequence1, [40,40,40,40,40,37,37,37,37,37]::UTINYINT[] AS qual1
+    UNION ALL
+    SELECT 'readA', 'TTTCCCGGGA', [31,31,31,31,31,31,31,31,31,31]::UTINYINT[];
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_dup.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'dup_seqs');
+----
+Duplicate read_id
+
+# ===================================================================
+# Test 17: NULL read_id in SEQUENCE_DATA throws error
+# ===================================================================
+statement ok
+CREATE TABLE null_rid_seqs AS
+    SELECT NULL::VARCHAR AS read_id, 'AAACCCGGGT' AS sequence1, [40,40,40,40,40,37,37,37,37,37]::UTINYINT[] AS qual1;
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_nullrid.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'null_rid_seqs');
+----
+NULL read_id
+
+# ===================================================================
+# Test 18: NULL sequence1 in SEQUENCE_DATA throws error
+# ===================================================================
+statement ok
+CREATE TABLE null_seq_seqs AS
+    SELECT 'readA' AS read_id, NULL::VARCHAR AS sequence1, [40,40,40,40,40,37,37,37,37,37]::UTINYINT[] AS qual1;
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_nullseq.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'null_seq_seqs');
+----
+NULL sequence1
+
+# ===================================================================
+# Test 19: Wrong schema - missing qual1 column
+# ===================================================================
+statement ok
+CREATE TABLE bad_schema AS SELECT 'readA' AS read_id, 'AAACCCGGGT' AS sequence1;
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_schema.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'bad_schema');
+----
+missing required column 'qual1'
+
+# ===================================================================
+# Test 20: Wrong schema - qual1 is wrong type (LIST(INTEGER) instead of LIST(UTINYINT))
+# ===================================================================
+statement ok
+CREATE TABLE bad_qual_type AS SELECT 'readA' AS read_id, 'AAACCCGGGT' AS sequence1, [40,40,40]::INTEGER[] AS qual1;
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_qualtype.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'bad_qual_type');
+----
+must be LIST(UTINYINT)
+
+# ===================================================================
+# Test 21: Empty SEQUENCE_DATA table throws error
+# ===================================================================
+statement ok
+CREATE TABLE empty_seqs AS SELECT * FROM seq_data WHERE false;
+
+statement error
+COPY alignments TO '__TEST_DIR__/err_empty.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'empty_seqs');
+----
+is empty
+
+# ===================================================================
+# Test 22: Single-end table (no sequence2/qual2 columns) works
+# ===================================================================
+statement ok
+CREATE TABLE se_seqs AS SELECT read_id, sequence1, qual1 FROM seq_data;
+
+# Only write the non-paired reads (readD is paired, needs sequence2)
+statement ok
+CREATE TABLE se_alignments AS SELECT * FROM alignments WHERE read_id != 'readD';
+
+statement ok
+COPY se_alignments TO '__TEST_DIR__/se_seqdata.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'se_seqs');
+
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/se_seqdata.sam', include_seq_qual=true) WHERE read_id='readA';
+----
+AAACCCGGGT	[40, 40, 40, 40, 40, 37, 37, 37, 37, 37]
+
+# ===================================================================
+# Test 23: NULL quality (sequence present, qual1 is NULL)
+# bam_set1 should write quality as missing (0xFF bytes)
+# ===================================================================
+statement ok
+CREATE TABLE null_qual_seqs AS SELECT * FROM (VALUES
+    ('readA', 'AAACCCGGGT', NULL::UTINYINT[]),
+    ('readB', 'ACGTAACCGG', NULL::UTINYINT[]),
+    ('readC', 'TTAAAACCCC', NULL::UTINYINT[]),
+    ('readE', 'NNNNNNNNNN', NULL::UTINYINT[]),
+    ('readF', 'AAACCCGGGT', NULL::UTINYINT[]),
+    ('readG', 'TTAAAACCCCGG', NULL::UTINYINT[])
+) t(read_id, sequence1, qual1);
+
+statement ok
+COPY se_alignments TO '__TEST_DIR__/null_qual.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_lens', SEQUENCE_DATA 'null_qual_seqs');
+
+# When quality is missing, read_alignments returns empty list for qual
+query IT
+SELECT sequence, qual FROM read_alignments('__TEST_DIR__/null_qual.sam', include_seq_qual=true) WHERE read_id='readA';
+----
+AAACCCGGGT	[]


### PR DESCRIPTION
Allows writing actual SEQ and QUAL fields into SAM/BAM output by looking up original read sequences from a table with read_fastx schema at write time, avoiding duplication of immutable sequence data across alignment records.

Handles reverse complement (flag 0x10), paired-end selection (flag 0x80), hard clipping from CIGAR, and CIGAR query length validation. Also fixes a pre-existing thread safety issue where GetReferenceTID could mutate the shared header outside the write lock.

Closes #29

cc @jianshu93