### PR TITLE
Alignment slice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -593,6 +593,8 @@ set(EXTENSION_SOURCES
     src/compress_intervals.cpp
     src/CoverageDepthCalculator.cpp
     src/compute_coverage_depth.cpp
+    src/AlignmentSlicer.cpp
+    src/alignment_slice.cpp
     src/copy_format_common.cpp
     src/table_function_common.cpp
     src/copy_fastq.cpp
@@ -801,6 +803,8 @@ set(TEST_SOURCES
     test/cpp/test_IntervalCompressor.cpp
     src/CoverageDepthCalculator.cpp
     test/cpp/test_CoverageDepthCalculator.cpp
+    src/AlignmentSlicer.cpp
+    test/cpp/test_AlignmentSlicer.cpp
     src/NewickTree.cpp
     test/cpp/test_NewickParser.cpp
     test/cpp/test_InsertFullyResolved.cpp

--- a/data/sam/slice_test.sam
+++ b/data/sam/slice_test.sam
@@ -1,0 +1,9 @@
+@SQ	SN:ref1	LN:200
+read_m	0	ref1	10	60	10M	*	0	0	ACGTACGTAC	*	NM:i:0	MD:Z:10
+read_eq	0	ref1	30	60	5=5X	*	0	0	AAAAABBBBB	*	NM:i:5	MD:Z:5A4
+read_ins	0	ref1	50	60	5M3I5M	*	0	0	ACGTANNNACGTG	*	NM:i:3
+read_del	0	ref1	70	60	5M3D5M	*	0	0	ACGTAACGTG	*	NM:i:3	MD:Z:5^TTT5
+read_clip	0	ref1	90	60	3S7M	*	0	0	NNNACGTACG	*
+read_intron	0	ref1	110	60	5M20N5M	*	0	0	ACGTAACGTG	*
+read_hclip	0	ref1	140	60	5H5M5H	*	0	0	ACGTG	*
+read_outside	0	ref1	180	60	5M	*	0	0	ACGTG	*

--- a/docs/scalar-functions.md
+++ b/docs/scalar-functions.md
@@ -73,6 +73,12 @@ Calculate sequence identity between read and reference using three different met
    - Use case: Filtering alignments (recommended)
    - Note: More robust to structural variations
 
+4. **`'cigar'`**: Identity from extended CIGAR operations only (no tags needed)
+   - Formula: `match_ops / alignment_columns` where match_ops = count of `=` ops
+   - Requires: CIGAR with `=`/`X` ops (not `M`). NM and MD tags are ignored.
+   - Returns NULL if CIGAR uses `M` (ambiguous) or mixes `M` with `=`/`X` (inconsistent)
+   - Use case: Computing identity on trimmed alignments from `alignment_slice`, where tags have been invalidated
+
 **Returns:** DOUBLE between 0.0 and 1.0, or NULL for unmapped reads or missing required tags
 
 **Example:**
@@ -94,6 +100,10 @@ SELECT read_id,
   alignment_seq_identity(cigar, tag_nm, tag_md, 'gap_compressed') AS gap_comp
 FROM read_alignments('alignments.sam')
 WHERE tag_nm IS NOT NULL AND tag_md IS NOT NULL;
+
+-- Compute identity on sliced alignments (tags NULLed, cigar method still works)
+SELECT read_id, alignment_seq_identity(cigar, tag_nm, tag_md, 'cigar') AS identity
+FROM alignment_slice('my_alignments', 1000, 2000);
 ```
 
 **Reference:** [On the definition of sequence identity](https://lh3.github.io/2018/11/25/on-the-definition-of-sequence-identity) by Heng Li

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -163,7 +163,7 @@ FROM alignment_slice('chr1_alns', 1000, 2000);
 **Notes:**
 - The function reads from the input table via a separate connection, so uncommitted changes in the current transaction may not be visible
 - Multi-region slicing (different regions per reference) is not yet supported; use separate queries per region
-- `alignment_seq_identity` works on sliced output CIGARs, but tags like NM and MD are NULLed after trimming, so only CIGAR-based identity methods (`gap_compressed`) are available
+- `alignment_seq_identity` with the `'cigar'` method works on sliced output because it reads identity directly from `=`/`X` CIGAR ops without needing tags. Other methods (`gap_compressed`, `blast`, `gap_excluded`) require NM or MD tags which are NULLed after trimming.
 
 ## `read_fastx(filename, [sequence2=filename], [include_filepath=false], [qual_offset=33])`
 Read FASTA/FASTQ sequence files.

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -30,6 +30,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`search_sequences_vsearch`](#search_sequences_vsearchquery_table-dbref_table-idthreshold-options) - Global sequence search
 - [`cluster_sequences_vsearch`](#cluster_sequences_vsearchinput_table-idthreshold-options) - Greedy sequence clustering
 - [`deblur`](#deblurinput_table-options) - Deblur amplicon sequence denoising
+- [`alignment_slice`](#alignment_slicetable_name-start-stop-include_deletionsfalse) - Slice alignments to a genomic region
 
 ## `read_alignments(filename, [reference_lengths='table_name'], [include_filepath=false], [include_seq_qual=false])`
 Read SAM/BAM alignment files.
@@ -113,6 +114,56 @@ SELECT * FROM read_sam('alignments.sam');
 - Data with headers works without `reference_lengths`
 - Headerless data requires `reference_lengths` parameter
 - User must know whether their stdin data contains headers
+
+## `alignment_slice(table_name, start, stop, [include_deletions=false])`
+
+Slice alignment data from a table or view to a genomic region. Each alignment is trimmed to the specified region `[start, stop)`, with trimmed portions represented as hard clips (H) in the output CIGAR.
+
+**Parameters:**
+- `table_name` (VARCHAR): Name of a table or view containing alignment data
+- `start` (BIGINT): Region start position (1-based, inclusive)
+- `stop` (BIGINT): Region stop position (1-based, exclusive)
+- `include_deletions` (BOOLEAN, default `false`): Whether deletion (D) operations count as overlap evidence. When `false`, reads whose only overlap with the region is through deletions are excluded.
+
+**Coordinates:** 1-based half-open `[start, stop)`, consistent with `position` and `stop_position` from `read_alignments`.
+
+**Required input columns:** `cigar` (VARCHAR), `position` (BIGINT), `stop_position` (BIGINT)
+
+**Output schema:** Same columns as found in the input table (from the recognized alignment column set), with adjusted values for overlapping reads.
+
+**Behavior:**
+- Reads that don't overlap the region are excluded
+- Soft clips (S) do not count as overlap evidence
+- Trimmed portions of the CIGAR become hard clips (H)
+- Tags (`tag_as` through `tag_sa`) are set to NULL when trimming occurs
+- `template_length` is set to NULL when trimming occurs
+- `mapq` and mate fields are preserved
+- If the input table has a `reference` column, all rows must have the same reference (single-region slicing)
+- Rows with NULL `cigar`, `position`, or `stop_position` are skipped
+
+**Examples:**
+
+```sql
+-- Load alignments and filter to a single reference
+CREATE VIEW chr1_alns AS
+  SELECT * FROM read_alignments('sample.bam')
+  WHERE reference = 'chr1';
+
+-- Slice to a region of interest
+SELECT * FROM alignment_slice('chr1_alns', 1000, 2000);
+
+-- Include reads that overlap only via deletions
+SELECT * FROM alignment_slice('chr1_alns', 1000, 2000, include_deletions := true);
+
+-- Composable: compute coverage depth on sliced alignments
+SELECT compute_coverage_depth(position, stop_position, cigar, 1000, 'exclude_deletions')
+FROM alignment_slice('chr1_alns', 1000, 2000);
+```
+
+**Notes:**
+- The function reads from the input table via a separate connection, so uncommitted changes in the current transaction may not be visible
+- Multi-region slicing (different regions per reference) is not yet supported; use separate queries per region
+- `alignment_seq_identity` works on sliced output CIGARs, but tags like NM and MD are NULLed after trimming, so only CIGAR-based identity methods (`gap_compressed`) are available
 
 ## `read_fastx(filename, [sequence2=filename], [include_filepath=false], [qual_offset=33])`
 Read FASTA/FASTQ sequence files.

--- a/src/AlignmentSlicer.cpp
+++ b/src/AlignmentSlicer.cpp
@@ -1,0 +1,273 @@
+#include "AlignmentSlicer.hpp"
+#include "alignment_functions_internal.hpp"
+
+#include <algorithm>
+#include <sstream>
+
+namespace miint {
+
+AlignmentSlicer::AlignmentSlicer(int64_t region_start, int64_t region_stop, bool include_deletions)
+    : region_start(region_start), region_stop(region_stop), include_deletions(include_deletions) {
+	if (region_start < 1) {
+		throw InvalidInputException("alignment_slice: region start must be >= 1, got " + std::to_string(region_start));
+	}
+	if (region_start > region_stop) {
+		throw InvalidInputException("alignment_slice: region start (" + std::to_string(region_start) +
+		                            ") must be <= region stop (" + std::to_string(region_stop) + ")");
+	}
+}
+
+SliceResult AlignmentSlicer::Slice(const SliceInput &input) const {
+	SliceResult result;
+	result.overlaps = false;
+	result.position = 0;
+	result.stop_position = 0;
+
+	// Guard against invalid position (0 means unmapped in SAM)
+	if (input.position < 1) {
+		return result;
+	}
+
+	// Parse CIGAR
+	auto ops = ParseCigarOperations(input.cigar);
+	if (ops.empty()) {
+		return result; // Unmapped or empty CIGAR
+	}
+
+	// Empty region — nothing can overlap
+	if (region_start == region_stop) {
+		return result;
+	}
+
+	// Walk CIGAR operations, tracking reference position and query position
+	int64_t ref_pos = input.position; // 1-based current reference position
+	int64_t left_query_trim = 0;      // query bases trimmed from left
+	int64_t right_query_trim = 0;     // query bases trimmed from right
+	int64_t left_hard_clip = 0;       // existing H clips on left
+	int64_t right_hard_clip = 0;      // existing H clips on right
+
+	bool has_query_overlap = false; // M/=/X/I within region
+	bool has_del_overlap = false;   // D within region
+
+	// Phase tracking: BEFORE we've entered the region, WITHIN, AFTER we've passed it
+	enum Phase { BEFORE, WITHIN, AFTER };
+	Phase phase = BEFORE;
+
+	// Leading S ops are deferred until the first ref-consuming op resolves whether
+	// left trimming is needed. If no M/=/X trimming happens on the left, leading S
+	// is preserved; otherwise it becomes part of the left hard clip.
+	std::vector<CigarOperation> pending_leading_s;
+	int64_t pending_leading_s_query = 0;
+	bool leading_s_resolved = false;
+
+	// Collect trimmed CIGAR ops (excluding H clips, which we track separately)
+	std::vector<CigarOperation> trimmed_ops;
+
+	for (const auto &op : ops) {
+		// Determine how many reference and query bases this op consumes
+		int64_t ref_consumed = 0;
+		int64_t query_consumed = 0;
+
+		switch (op.op) {
+		case 'M':
+		case '=':
+		case 'X':
+			ref_consumed = op.length;
+			query_consumed = op.length;
+			break;
+		case 'I':
+			query_consumed = op.length;
+			break;
+		case 'D':
+		case 'N':
+			ref_consumed = op.length;
+			break;
+		case 'S':
+			query_consumed = op.length;
+			break;
+		case 'H':
+			// Track existing hard clips
+			if (!leading_s_resolved && trimmed_ops.empty() && phase == BEFORE) {
+				left_hard_clip += op.length;
+			} else {
+				right_hard_clip += op.length;
+			}
+			continue; // Don't advance ref_pos or query_pos
+		case 'P':
+			// Padding: doesn't consume ref or query
+			// Keep it if we're in the WITHIN phase
+			if (phase == WITHIN) {
+				trimmed_ops.push_back(op);
+			}
+			continue;
+		default:
+			continue;
+		}
+
+		// Handle S operations (no reference consumption)
+		if (op.op == 'S') {
+			if (!leading_s_resolved) {
+				// Defer leading S decision
+				pending_leading_s.push_back(op);
+				pending_leading_s_query += op.length;
+			} else if (phase == AFTER) {
+				right_query_trim += op.length;
+			} else {
+				// WITHIN: keep soft clip
+				trimmed_ops.push_back(op);
+			}
+			continue;
+		}
+
+		// Resolve pending leading S when we hit the first non-S, non-H, non-P op.
+		// If the first ref-consuming op starts at or after region_start, no left
+		// trimming is needed and leading S is kept. Otherwise, leading S is trimmed.
+		// We do NOT set phase here — the actual op handler below determines phase
+		// based on whether the op overlaps the region.
+		if (!leading_s_resolved) {
+			leading_s_resolved = true;
+			if (ref_pos >= region_start) {
+				// No left trimming — keep leading S
+				for (const auto &s : pending_leading_s) {
+					trimmed_ops.push_back(s);
+				}
+			} else {
+				// Left trimming will happen — trim leading S
+				left_query_trim += pending_leading_s_query;
+			}
+		}
+
+		// Handle I operations (no reference consumption)
+		if (op.op == 'I') {
+			if (ref_pos >= region_start && ref_pos < region_stop) {
+				// Insertion is at a ref position within the region
+				trimmed_ops.push_back(op);
+				has_query_overlap = true;
+				phase = WITHIN;
+			} else if (ref_pos < region_start) {
+				left_query_trim += op.length;
+			} else {
+				right_query_trim += op.length;
+				if (phase == WITHIN) {
+					phase = AFTER;
+				}
+			}
+			continue;
+		}
+
+		// Reference-consuming operations: M, =, X, D, N
+		int64_t op_ref_start = ref_pos;
+		int64_t op_ref_end = ref_pos + ref_consumed; // exclusive
+
+		if (op_ref_end <= region_start) {
+			// Entirely before region
+			left_query_trim += query_consumed;
+			// phase stays BEFORE
+		} else if (op_ref_start >= region_stop) {
+			// Entirely after region
+			right_query_trim += query_consumed;
+			if (phase == WITHIN) {
+				phase = AFTER;
+			}
+		} else {
+			// Overlaps region — may need splitting
+			int64_t bases_before = std::max(int64_t(0), region_start - op_ref_start);
+			int64_t bases_after = std::max(int64_t(0), op_ref_end - region_stop);
+			int64_t bases_within = ref_consumed - bases_before - bases_after;
+
+			if (bases_before > 0 && query_consumed > 0) {
+				// For M/=/X: query and ref consumed 1:1
+				left_query_trim += bases_before;
+			}
+
+			if (bases_within > 0) {
+				trimmed_ops.push_back({op.op, bases_within});
+				if (op.op == 'M' || op.op == '=' || op.op == 'X') {
+					has_query_overlap = true;
+				} else if (op.op == 'D') {
+					has_del_overlap = true;
+				}
+				// N within region is kept in CIGAR but doesn't count as overlap
+				phase = WITHIN;
+			}
+
+			if (bases_after > 0) {
+				if (query_consumed > 0) {
+					right_query_trim += bases_after;
+				}
+				if (phase == WITHIN) {
+					phase = AFTER;
+				}
+			}
+		}
+
+		ref_pos += ref_consumed;
+	}
+
+	// Determine overlap
+	result.overlaps = has_query_overlap || (include_deletions && has_del_overlap);
+	if (!result.overlaps) {
+		return result;
+	}
+
+	// Build final CIGAR string
+	int64_t total_left_H = left_hard_clip + left_query_trim;
+	int64_t total_right_H = right_hard_clip + right_query_trim;
+
+	std::vector<CigarOperation> final_ops;
+	if (total_left_H > 0) {
+		final_ops.push_back({'H', total_left_H});
+	}
+	final_ops.insert(final_ops.end(), trimmed_ops.begin(), trimmed_ops.end());
+	if (total_right_H > 0) {
+		final_ops.push_back({'H', total_right_H});
+	}
+
+	// Merge adjacent same-type operations
+	std::vector<CigarOperation> merged;
+	for (const auto &op : final_ops) {
+		if (!merged.empty() && merged.back().op == op.op) {
+			merged.back().length += op.length;
+		} else {
+			merged.push_back(op);
+		}
+	}
+
+	// Convert to CIGAR string
+	std::ostringstream cigar_ss;
+	for (const auto &op : merged) {
+		cigar_ss << op.length << op.op;
+	}
+	result.cigar = cigar_ss.str();
+
+	// Compute adjusted positions.
+	// position: if the alignment starts before the region, it was trimmed to region_start.
+	// stop_position: if the alignment extends past region_stop, it was trimmed to region_stop.
+	// When no trimming occurs on a side, the original value is preserved (and is already
+	// within the region, since we only get here for overlapping alignments).
+	result.position = std::max(input.position, region_start);
+	result.stop_position = std::min(input.stop_position, region_stop);
+
+	// Trim sequence and quality
+	if (!input.sequence.empty()) {
+		int64_t seq_len = static_cast<int64_t>(input.sequence.size());
+		int64_t start = left_query_trim;
+		int64_t end = seq_len - right_query_trim;
+		if (start < end && start >= 0 && end <= seq_len) {
+			result.sequence = input.sequence.substr(start, end - start);
+		}
+	}
+
+	if (!input.quality.empty()) {
+		int64_t qual_len = static_cast<int64_t>(input.quality.size());
+		int64_t start = left_query_trim;
+		int64_t end = qual_len - right_query_trim;
+		if (start < end && start >= 0 && end <= qual_len) {
+			result.quality = std::vector<uint8_t>(input.quality.begin() + start, input.quality.begin() + end);
+		}
+	}
+
+	return result;
+}
+
+} // namespace miint

--- a/src/alignment_functions.cpp
+++ b/src/alignment_functions.cpp
@@ -154,9 +154,33 @@ static void AlignmentSeqIdentityScalarFunction(DataChunk &args, ExpressionState 
 			int64_t numerator = m - n + g;
 			identity = static_cast<double>(numerator) / static_cast<double>(denominator);
 
+		} else if (type_str == "cigar") {
+			// cigar: identity from extended CIGAR ops (= and X) only.
+			// Requires CIGAR to use =/X (not M). Does not need NM or MD tags.
+			// Formula: match_ops / alignment_columns
+			// Returns NULL if:
+			//   - CIGAR uses only M (ambiguous — can't distinguish matches from mismatches)
+			//   - CIGAR mixes M with =/X (inconsistent)
+			if (cigar_stats.match_ops + cigar_stats.mismatch_ops == 0) {
+				// No = or X ops observed (M-only, or degenerate S/N/P-only CIGAR)
+				result_validity.SetInvalid(i);
+				continue;
+			}
+
+			// If M ops are present alongside =/X, the CIGAR is inconsistent — return NULL
+			int64_t m_only = cigar_stats.matches - cigar_stats.match_ops - cigar_stats.mismatch_ops;
+			if (m_only > 0) {
+				result_validity.SetInvalid(i);
+				continue;
+			}
+
+			// alignment_columns is guaranteed > 0 here because =/X ops exist
+			identity = static_cast<double>(cigar_stats.match_ops) / static_cast<double>(cigar_stats.alignment_columns);
+
 		} else {
-			throw InvalidInputException("Invalid type parameter for alignment_seq_identity. "
-			                            "Must be 'gap_excluded', 'blast', or 'gap_compressed'.");
+			throw InvalidInputException("Invalid type parameter for alignment_seq_identity: '%s'. "
+			                            "Must be 'gap_excluded', 'blast', 'gap_compressed', or 'cigar'.",
+			                            type_str);
 		}
 
 		result_data[i] = identity;

--- a/src/alignment_slice.cpp
+++ b/src/alignment_slice.cpp
@@ -1,0 +1,324 @@
+#include "alignment_slice.hpp"
+#include "catalog_utils.hpp"
+#include "AlignmentSlicer.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/helper.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+
+namespace duckdb {
+
+using ColRole = AlignmentSliceTableFunction::ColRole;
+
+const vector<AlignmentSliceTableFunction::ColumnInfo> &AlignmentSliceTableFunction::GetRecognizedColumns() {
+	// name, type, required, is_tag, invalidate_on_trim
+	static const vector<ColumnInfo> columns = {
+	    {"read_id", LogicalType::VARCHAR, false, false, false},
+	    {"flags", LogicalType::USMALLINT, false, false, false},
+	    {"reference", LogicalType::VARCHAR, false, false, false},
+	    {"position", LogicalType::BIGINT, true, false, false},
+	    {"stop_position", LogicalType::BIGINT, true, false, false},
+	    {"mapq", LogicalType::UTINYINT, false, false, false},
+	    {"cigar", LogicalType::VARCHAR, true, false, false},
+	    {"mate_reference", LogicalType::VARCHAR, false, false, false},
+	    {"mate_position", LogicalType::BIGINT, false, false, false},
+	    {"template_length", LogicalType::BIGINT, false, false, true},
+	    {"tag_as", LogicalType::BIGINT, false, true, false},
+	    {"tag_xs", LogicalType::BIGINT, false, true, false},
+	    {"tag_ys", LogicalType::BIGINT, false, true, false},
+	    {"tag_xn", LogicalType::BIGINT, false, true, false},
+	    {"tag_xm", LogicalType::BIGINT, false, true, false},
+	    {"tag_xo", LogicalType::BIGINT, false, true, false},
+	    {"tag_xg", LogicalType::BIGINT, false, true, false},
+	    {"tag_nm", LogicalType::BIGINT, false, true, false},
+	    {"tag_yt", LogicalType::VARCHAR, false, true, false},
+	    {"tag_md", LogicalType::VARCHAR, false, true, false},
+	    {"tag_sa", LogicalType::VARCHAR, false, true, false},
+	    {"sequence", LogicalType::VARCHAR, false, false, false},
+	    {"qual", LogicalType::LIST(LogicalType::UTINYINT), false, false, false},
+	};
+	return columns;
+}
+
+unique_ptr<FunctionData> AlignmentSliceTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                           vector<LogicalType> &return_types, vector<string> &names) {
+	auto data = make_uniq<Data>();
+
+	// Extract positional parameters
+	data->table_name = input.inputs[0].GetValue<string>();
+	data->region_start = input.inputs[1].GetValue<int64_t>();
+	data->region_stop = input.inputs[2].GetValue<int64_t>();
+
+	// Extract named parameters
+	data->include_deletions = false;
+	if (input.named_parameters.count("include_deletions")) {
+		data->include_deletions = input.named_parameters.at("include_deletions").GetValue<bool>();
+	}
+
+	// Validate region
+	if (data->region_start < 1) {
+		throw BinderException("alignment_slice: region start must be >= 1, got %lld", data->region_start);
+	}
+	if (data->region_start > data->region_stop) {
+		throw BinderException("alignment_slice: region start (%lld) must be <= region stop (%lld)", data->region_start,
+		                      data->region_stop);
+	}
+
+	// Discover input table schema
+	auto table_info = GetTableOrViewColumns(context, data->table_name, "Alignment table");
+	auto &col_names = table_info.names;
+
+	// Build case-insensitive name-to-index map for input columns
+	std::unordered_map<string, idx_t> input_name_to_idx;
+	for (idx_t i = 0; i < col_names.size(); i++) {
+		input_name_to_idx[StringUtil::Lower(col_names[i])] = i;
+	}
+
+	// Match recognized columns against input schema.
+	// Track which input columns are present so we can build a targeted SELECT.
+	auto &recognized = GetRecognizedColumns();
+	// input_col_present[col.name] = index in input table, or -1 if absent
+	std::unordered_map<string, int> input_col_present;
+	for (const auto &col : recognized) {
+		auto found = input_name_to_idx.find(col.name);
+		if (found != input_name_to_idx.end()) {
+			input_col_present[col.name] = static_cast<int>(found->second);
+		} else if (col.required) {
+			throw BinderException("alignment_slice: input table '%s' missing required column '%s'", data->table_name,
+			                      col.name);
+		} else {
+			input_col_present[col.name] = -1;
+		}
+	}
+
+	// Build SELECT query with only the columns we need (avoids pulling unnecessary columns).
+	// Track the mapping from recognized column name to index in the SELECT result.
+	vector<string> select_cols;
+	std::unordered_map<string, int> select_col_idx; // col.name -> index in SELECT result
+	for (const auto &col : recognized) {
+		if (input_col_present[col.name] >= 0) {
+			select_col_idx[col.name] = static_cast<int>(select_cols.size());
+			select_cols.push_back(KeywordHelper::WriteOptionallyQuoted(col.name));
+		}
+	}
+	data->select_query = "SELECT " + StringUtil::Join(select_cols, ", ") + " FROM " +
+	                     KeywordHelper::WriteOptionallyQuoted(data->table_name);
+
+	// Store slicer-relevant indices into the SELECT result
+	data->select_cigar_idx = select_col_idx.at("cigar");
+	data->select_pos_idx = select_col_idx.at("position");
+	data->select_stop_pos_idx = select_col_idx.at("stop_position");
+	data->select_seq_idx = select_col_idx.count("sequence") ? select_col_idx.at("sequence") : -1;
+	data->select_qual_idx = select_col_idx.count("qual") ? select_col_idx.at("qual") : -1;
+	data->select_ref_idx = select_col_idx.count("reference") ? select_col_idx.at("reference") : -1;
+
+	// Build output schema: recognized columns present in input, in recognized order.
+	// Precompute per-column roles for fast dispatch in Execute (no string comparisons).
+	for (const auto &col : recognized) {
+		if (input_col_present[col.name] >= 0) {
+			data->output_names.push_back(col.name);
+			data->output_types.push_back(col.type);
+			data->output_input_idx.push_back(select_col_idx.at(col.name));
+
+			ColRole role;
+			if (col.is_tag || col.invalidate_on_trim) {
+				role = ColRole::TAG_OR_INVALIDATE;
+			} else if (col.name == "cigar") {
+				role = ColRole::CIGAR;
+			} else if (col.name == "position") {
+				role = ColRole::POSITION;
+			} else if (col.name == "stop_position") {
+				role = ColRole::STOP_POSITION;
+			} else if (col.name == "sequence") {
+				role = ColRole::SEQUENCE;
+			} else if (col.name == "qual") {
+				role = ColRole::QUAL;
+			} else {
+				role = ColRole::PASS_THROUGH;
+			}
+			data->output_roles.push_back(role);
+		}
+	}
+
+	names = data->output_names;
+	return_types = data->output_types;
+
+	return data;
+}
+
+unique_ptr<GlobalTableFunctionState> AlignmentSliceTableFunction::InitGlobal(ClientContext &context,
+                                                                             TableFunctionInitInput &input) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto gstate = make_uniq<GlobalState>();
+
+	// Create the slicer
+	gstate->slicer = make_uniq<miint::AlignmentSlicer>(data.region_start, data.region_stop, data.include_deletions);
+
+	// Separate connection avoids deadlocking the current context.
+	// SendQuery streams chunks lazily — only one chunk in memory at a time.
+	auto &db = DatabaseInstance::GetDatabase(context);
+	gstate->conn = make_uniq<Connection>(db);
+	gstate->query_result = gstate->conn->SendQuery(data.select_query);
+
+	return gstate;
+}
+
+void AlignmentSliceTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<Data>();
+	auto &gstate = data_p.global_state->Cast<GlobalState>();
+
+	idx_t out_row = 0;
+	idx_t num_out_cols = data.output_names.size();
+
+	while (out_row < STANDARD_VECTOR_SIZE) {
+		// Fetch next chunk from stream if needed
+		if (!gstate.current_chunk || gstate.chunk_offset >= gstate.current_chunk->size()) {
+			if (gstate.stream_exhausted) {
+				break;
+			}
+			gstate.current_chunk = gstate.query_result->Fetch();
+			gstate.chunk_offset = 0;
+			if (!gstate.current_chunk || gstate.current_chunk->size() == 0) {
+				gstate.stream_exhausted = true;
+				break;
+			}
+		}
+
+		auto &chunk = *gstate.current_chunk;
+		idx_t i = gstate.chunk_offset;
+		gstate.chunk_offset++;
+
+		// Single-reference check (before NULL skip — all rows must be same reference)
+		if (data.select_ref_idx >= 0) {
+			auto ref_val = chunk.data[data.select_ref_idx].GetValue(i);
+			if (!ref_val.IsNull()) {
+				string ref_name = ref_val.GetValue<string>();
+				if (!gstate.has_seen_reference) {
+					gstate.seen_reference = ref_name;
+					gstate.has_seen_reference = true;
+				} else if (ref_name != gstate.seen_reference) {
+					throw InvalidInputException("alignment_slice: multiple references found in input ('%s' and '%s'). "
+					                            "Filter to a single reference before slicing.",
+					                            gstate.seen_reference, ref_name);
+				}
+			}
+		}
+
+		// Extract required fields, skip rows with NULLs
+		auto cigar_val = chunk.data[data.select_cigar_idx].GetValue(i);
+		auto pos_val = chunk.data[data.select_pos_idx].GetValue(i);
+		auto stop_pos_val = chunk.data[data.select_stop_pos_idx].GetValue(i);
+
+		if (cigar_val.IsNull() || pos_val.IsNull() || stop_pos_val.IsNull()) {
+			continue;
+		}
+
+		string cigar = cigar_val.GetValue<string>();
+		int64_t position = pos_val.GetValue<int64_t>();
+		int64_t stop_position = stop_pos_val.GetValue<int64_t>();
+
+		// Build SliceInput
+		miint::SliceInput slice_input;
+		slice_input.cigar = cigar;
+		slice_input.position = position;
+		slice_input.stop_position = stop_position;
+
+		if (data.select_seq_idx >= 0) {
+			auto seq_val = chunk.data[data.select_seq_idx].GetValue(i);
+			if (!seq_val.IsNull()) {
+				slice_input.sequence = seq_val.GetValue<string>();
+			}
+		}
+
+		if (data.select_qual_idx >= 0) {
+			auto qual_val = chunk.data[data.select_qual_idx].GetValue(i);
+			if (!qual_val.IsNull()) {
+				auto qual_list = ListValue::GetChildren(qual_val);
+				for (const auto &q : qual_list) {
+					slice_input.quality.push_back(q.GetValue<uint8_t>());
+				}
+			}
+		}
+
+		// Slice
+		auto result = gstate.slicer->Slice(slice_input);
+		if (!result.overlaps) {
+			continue;
+		}
+
+		// Determine if trimming occurred by comparing CIGAR (the canonical check —
+		// position comparison can miss cases where only CIGAR changes, e.g. soft clips)
+		bool was_trimmed = (result.cigar != cigar);
+
+		// Build output row using precomputed roles (no string comparisons)
+		for (idx_t col = 0; col < num_out_cols; col++) {
+			int src_idx = data.output_input_idx[col];
+
+			switch (data.output_roles[col]) {
+			case ColRole::TAG_OR_INVALIDATE:
+				if (was_trimmed) {
+					FlatVector::SetNull(output.data[col], out_row, true);
+				} else {
+					output.data[col].SetValue(out_row, chunk.data[src_idx].GetValue(i));
+				}
+				break;
+			case ColRole::CIGAR:
+				output.data[col].SetValue(out_row, Value(result.cigar));
+				break;
+			case ColRole::POSITION:
+				output.data[col].SetValue(out_row, Value::BIGINT(result.position));
+				break;
+			case ColRole::STOP_POSITION:
+				output.data[col].SetValue(out_row, Value::BIGINT(result.stop_position));
+				break;
+			case ColRole::SEQUENCE:
+				if (!result.sequence.empty()) {
+					output.data[col].SetValue(out_row, Value(result.sequence));
+				} else if (!slice_input.sequence.empty()) {
+					// Slicer returned empty from non-empty input (length mismatch) — NULL
+					FlatVector::SetNull(output.data[col], out_row, true);
+				} else {
+					output.data[col].SetValue(out_row, chunk.data[src_idx].GetValue(i));
+				}
+				break;
+			case ColRole::QUAL:
+				if (!result.quality.empty()) {
+					vector<Value> qual_vals;
+					for (auto q : result.quality) {
+						qual_vals.push_back(Value::UTINYINT(q));
+					}
+					output.data[col].SetValue(out_row, Value::LIST(LogicalType::UTINYINT, std::move(qual_vals)));
+				} else if (!slice_input.quality.empty()) {
+					FlatVector::SetNull(output.data[col], out_row, true);
+				} else {
+					output.data[col].SetValue(out_row, chunk.data[src_idx].GetValue(i));
+				}
+				break;
+			case ColRole::PASS_THROUGH:
+				output.data[col].SetValue(out_row, chunk.data[src_idx].GetValue(i));
+				break;
+			}
+		}
+
+		out_row++;
+	}
+
+	output.SetCardinality(out_row);
+}
+
+void AlignmentSliceTableFunction::Register(ExtensionLoader &loader) {
+	auto tf = TableFunction("alignment_slice", {LogicalType::VARCHAR, LogicalType::BIGINT, LogicalType::BIGINT},
+	                        Execute, Bind, InitGlobal);
+	tf.named_parameters["include_deletions"] = LogicalType::BOOLEAN;
+	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
+	loader.RegisterFunction(tf);
+}
+
+} // namespace duckdb

--- a/src/include/AlignmentSlicer.hpp
+++ b/src/include/AlignmentSlicer.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace miint {
+
+struct SliceInput {
+	std::string cigar;
+	int64_t position;             // 1-based
+	int64_t stop_position;        // 1-based, exclusive
+	std::string sequence;         // may be empty (not available)
+	std::vector<uint8_t> quality; // may be empty (not available)
+};
+
+struct SliceResult {
+	bool overlaps; // false = exclude from output
+	std::string cigar;
+	int64_t position;      // adjusted, 1-based
+	int64_t stop_position; // adjusted, 1-based exclusive
+	std::string sequence;
+	std::vector<uint8_t> quality;
+};
+
+class AlignmentSlicer {
+public:
+	// region_start and region_stop are 1-based, half-open [start, stop)
+	AlignmentSlicer(int64_t region_start, int64_t region_stop, bool include_deletions);
+
+	SliceResult Slice(const SliceInput &input) const;
+
+private:
+	int64_t region_start;
+	int64_t region_stop;
+	bool include_deletions;
+};
+
+} // namespace miint

--- a/src/include/alignment_slice.hpp
+++ b/src/include/alignment_slice.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "AlignmentSlicer.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/main/query_result.hpp"
+
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+class AlignmentSliceTableFunction {
+public:
+	struct ColumnInfo {
+		std::string name;
+		LogicalType type;
+		bool required;           // cigar, position, stop_position are required
+		bool is_tag;             // tag columns are NULLed after trimming
+		bool invalidate_on_trim; // template_length is NULLed on any trim
+	};
+
+	// Per-output-column role, precomputed at bind time for fast dispatch in Execute
+	enum class ColRole : uint8_t {
+		PASS_THROUGH,      // copy from input unchanged
+		CIGAR,             // set from slicer result
+		POSITION,          // set from slicer result
+		STOP_POSITION,     // set from slicer result
+		SEQUENCE,          // set from slicer result (with NULL handling)
+		QUAL,              // set from slicer result (with NULL handling)
+		TAG_OR_INVALIDATE, // NULL when trimmed, pass through otherwise
+	};
+
+	struct Data : public TableFunctionData {
+		std::string table_name;
+		int64_t region_start;
+		int64_t region_stop;
+		bool include_deletions;
+
+		// Output schema (only recognized columns present in input)
+		vector<string> output_names;
+		vector<LogicalType> output_types;
+
+		// Per-output-column metadata, parallel to output_names:
+		vector<int> output_input_idx; // index into the SELECT result columns
+		vector<ColRole> output_roles; // precomputed role for fast dispatch in Execute
+
+		// Indices into the SELECT result for columns needed by the slicer
+		int select_cigar_idx = -1;
+		int select_pos_idx = -1;
+		int select_stop_pos_idx = -1;
+		int select_seq_idx = -1;
+		int select_qual_idx = -1;
+		int select_ref_idx = -1;
+
+		// The SELECT query to execute (built at bind time, selects only needed columns)
+		string select_query;
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		// Connection must outlive the StreamQueryResult (it streams lazily)
+		unique_ptr<Connection> conn;
+		unique_ptr<QueryResult> query_result;
+		unique_ptr<DataChunk> current_chunk;
+		idx_t chunk_offset = 0;        // current position within current_chunk
+		bool stream_exhausted = false; // true after Fetch() returns null
+
+		// The slicer instance
+		unique_ptr<miint::AlignmentSlicer> slicer;
+
+		// Single-reference enforcement state
+		string seen_reference;
+		bool has_seen_reference = false;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<string> &names);
+
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static void Register(ExtensionLoader &loader);
+
+private:
+	static const vector<ColumnInfo> &GetRecognizedColumns();
+};
+
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -3,6 +3,7 @@
 #include "miint_extension.hpp"
 #include <csignal>
 #include <alignment_flag_functions.hpp>
+#include <alignment_slice.hpp>
 #include <alignment_functions.hpp>
 #include <compress_intervals.hpp>
 #include <compute_coverage_depth.hpp>
@@ -193,6 +194,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	AlignmentQueryCoverageFunction::Register(loader);
 	CompressIntervalsFunction::Register(loader);
 	ComputeCoverageDepthFunction::Register(loader);
+	AlignmentSliceTableFunction::Register(loader);
 	SequenceFunctions::Register(loader);
 	FormulaFunction::Register(loader);
 	MassQLFunction::Register(loader);

--- a/test/cpp/test_AlignmentSlicer.cpp
+++ b/test/cpp/test_AlignmentSlicer.cpp
@@ -1,0 +1,856 @@
+#include <catch2/catch_test_macros.hpp>
+#include <AlignmentSlicer.hpp>
+#include <alignment_functions_internal.hpp>
+
+using namespace miint;
+
+// Helper to create a simple SliceInput (no sequence/quality)
+static SliceInput make_input(const std::string &cigar, int64_t pos, int64_t stop_pos) {
+	return {cigar, pos, stop_pos, "", {}};
+}
+
+// Helper to create SliceInput with sequence and quality
+static SliceInput make_input_sq(const std::string &cigar, int64_t pos, int64_t stop_pos, const std::string &seq,
+                                const std::vector<uint8_t> &qual) {
+	return {cigar, pos, stop_pos, seq, qual};
+}
+
+// =====================================================================
+// 1a. Overlap detection tests
+// =====================================================================
+
+TEST_CASE("AlignmentSlicer overlap - M operations", "[alignment_slicer][overlap]") {
+	SECTION("M overlaps region") {
+		// 10M at pos 5 covers [5,15). Region [8,12) overlaps.
+		AlignmentSlicer slicer(8, 12, false);
+		auto result = slicer.Slice(make_input("10M", 5, 15));
+		REQUIRE(result.overlaps);
+	}
+
+	SECTION("M fully before region") {
+		// 5M at pos 1 covers [1,6). Region [10,20) — no overlap.
+		AlignmentSlicer slicer(10, 20, false);
+		auto result = slicer.Slice(make_input("5M", 1, 6));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("M fully after region") {
+		// 5M at pos 25 covers [25,30). Region [10,20) — no overlap.
+		AlignmentSlicer slicer(10, 20, false);
+		auto result = slicer.Slice(make_input("5M", 25, 30));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("M at left boundary") {
+		// 5M at pos 10 covers [10,15). Region [10,20) — overlaps.
+		AlignmentSlicer slicer(10, 20, false);
+		auto result = slicer.Slice(make_input("5M", 10, 15));
+		REQUIRE(result.overlaps);
+	}
+
+	SECTION("M just past right boundary") {
+		// 5M at pos 20 covers [20,25). Region [10,20) — no overlap (stop is exclusive).
+		AlignmentSlicer slicer(10, 20, false);
+		auto result = slicer.Slice(make_input("5M", 20, 25));
+		REQUIRE_FALSE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - = and X operations", "[alignment_slicer][overlap]") {
+	SECTION("= overlaps") {
+		// 5=5M at pos 5 covers [5,15). Region [6,8) overlaps.
+		AlignmentSlicer slicer(6, 8, false);
+		auto result = slicer.Slice(make_input("5=5M", 5, 15));
+		REQUIRE(result.overlaps);
+	}
+
+	SECTION("X overlaps") {
+		// 3M5X at pos 1 covers [1,9). Region [5,8) overlaps via X at [4,9).
+		AlignmentSlicer slicer(5, 8, false);
+		auto result = slicer.Slice(make_input("3M5X", 1, 9));
+		REQUIRE(result.overlaps);
+	}
+
+	SECTION("= fully before") {
+		AlignmentSlicer slicer(10, 20, false);
+		auto result = slicer.Slice(make_input("5=", 1, 6));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("X fully after") {
+		AlignmentSlicer slicer(10, 20, false);
+		auto result = slicer.Slice(make_input("5X", 25, 30));
+		REQUIRE_FALSE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - I operations", "[alignment_slicer][overlap]") {
+	SECTION("I at region boundary - M provides overlap") {
+		// 5M2I5M at pos 1. 5M covers [1,6), I at ref_pos 6, 5M covers [6,11).
+		// Region [6,12): the second 5M overlaps.
+		AlignmentSlicer slicer(6, 12, false);
+		auto result = slicer.Slice(make_input("5M2I5M", 1, 11));
+		REQUIRE(result.overlaps);
+	}
+
+	SECTION("I before region - last M overlaps") {
+		// 3M2I3M at pos 1. 3M covers [1,4), I at ref_pos 4, 3M covers [4,7).
+		// Region [7,20): no M overlaps [7,20) since second 3M covers [4,7).
+		// Actually second 3M covers ref [4,7), so stop is 7. Region starts at 7 (exclusive). No overlap!
+		AlignmentSlicer slicer(7, 20, false);
+		auto result = slicer.Slice(make_input("3M2I3M", 1, 7));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("M at pos 5 is in region [5,6)") {
+		// 1M2I at pos 5. M covers [5,6). Region [5,6) — M overlaps.
+		AlignmentSlicer slicer(5, 6, false);
+		auto result = slicer.Slice(make_input("1M2I", 5, 6));
+		REQUIRE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - D operations", "[alignment_slicer][overlap]") {
+	SECTION("D-only overlap, exclude deletions") {
+		// 3M5D3M at pos 1. 3M covers [1,4), 5D covers [4,9), 3M covers [9,12).
+		// Region [5,9): only D overlaps. With include_deletions=false, no overlap.
+		AlignmentSlicer slicer(5, 9, false);
+		auto result = slicer.Slice(make_input("3M5D3M", 1, 12));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("D-only overlap, include deletions") {
+		AlignmentSlicer slicer(5, 9, true);
+		auto result = slicer.Slice(make_input("3M5D3M", 1, 12));
+		REQUIRE(result.overlaps);
+	}
+
+	SECTION("D with M overlap") {
+		// 3M5D3M at pos 1. Region [2,5): M at [1,4) overlaps [2,5).
+		AlignmentSlicer slicer(2, 5, false);
+		auto result = slicer.Slice(make_input("3M5D3M", 1, 12));
+		REQUIRE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - N operations", "[alignment_slicer][overlap]") {
+	SECTION("N-only overlap, exclude deletions") {
+		// 3M10N3M at pos 1. 3M covers [1,4), 10N covers [4,14), 3M covers [14,17).
+		// Region [5,12): only N overlaps. N never counts as overlap.
+		AlignmentSlicer slicer(5, 12, false);
+		auto result = slicer.Slice(make_input("3M10N3M", 1, 17));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("N-only overlap, include deletions - still no overlap") {
+		// N never counts as overlap regardless of include_deletions flag.
+		AlignmentSlicer slicer(5, 12, true);
+		auto result = slicer.Slice(make_input("3M10N3M", 1, 17));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("N with M overlap") {
+		// Region [1,5): first 3M at [1,4) overlaps.
+		AlignmentSlicer slicer(1, 5, false);
+		auto result = slicer.Slice(make_input("3M10N3M", 1, 17));
+		REQUIRE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - S operations", "[alignment_slicer][overlap]") {
+	SECTION("S only overlap") {
+		// 5S5M at pos 10. S doesn't consume ref. 5M covers [10,15).
+		// Region [5,10): no M in region (M starts at 10, region stops at 10 exclusive).
+		AlignmentSlicer slicer(5, 10, false);
+		auto result = slicer.Slice(make_input("5S5M", 10, 15));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("S before M in region") {
+		// 3S5M at pos 4. S doesn't consume ref. 5M covers [4,9).
+		// Region [4,9): M overlaps.
+		AlignmentSlicer slicer(4, 9, false);
+		auto result = slicer.Slice(make_input("3S5M", 4, 9));
+		REQUIRE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - H operations", "[alignment_slicer][overlap]") {
+	SECTION("H only - no query overlap") {
+		// 5H5M at pos 5. H doesn't consume ref. 5M covers [5,10).
+		// Region [1,5): no M in region.
+		AlignmentSlicer slicer(1, 5, false);
+		auto result = slicer.Slice(make_input("5H5M", 5, 10));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("H with M overlap") {
+		// 5H5M at pos 5. 5M covers [5,10). Region [5,10) overlaps.
+		AlignmentSlicer slicer(5, 10, false);
+		auto result = slicer.Slice(make_input("5H5M", 5, 10));
+		REQUIRE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer overlap - P operation", "[alignment_slicer][overlap]") {
+	// 5M1P5M at pos 1. P is padding, ignored. 5M covers [1,6), 5M covers [6,11).
+	// Region [3,8) overlaps.
+	AlignmentSlicer slicer(3, 8, false);
+	auto result = slicer.Slice(make_input("5M1P5M", 1, 11));
+	REQUIRE(result.overlaps);
+}
+
+TEST_CASE("AlignmentSlicer overlap - unmapped", "[alignment_slicer][overlap]") {
+	AlignmentSlicer slicer(1, 100, false);
+	auto result = slicer.Slice(make_input("*", 0, 0));
+	REQUIRE_FALSE(result.overlaps);
+}
+
+TEST_CASE("AlignmentSlicer overlap - complex CIGAR with all ops", "[alignment_slicer][overlap]") {
+	// 2H3S5M2I3M3D4M10N2M3S2H at pos 10
+	// Walk: H(2) doesn't consume ref. S(3) doesn't consume ref.
+	// 5M covers [10,15). 2I at ref 15. 3M covers [15,18). 3D covers [18,21).
+	// 4M covers [21,25). 10N covers [25,35). 2M covers [35,37). S(3) doesn't consume ref. H(2) doesn't.
+	// Region [12,25): 5M at [10,15) partially overlaps, 3M at [15,18) fully in, etc.
+	AlignmentSlicer slicer(12, 25, false);
+	auto result = slicer.Slice(make_input("2H3S5M2I3M3D4M10N2M3S2H", 10, 37));
+	REQUIRE(result.overlaps);
+}
+
+// =====================================================================
+// 1b. CIGAR trimming tests
+// =====================================================================
+
+TEST_CASE("AlignmentSlicer trim - M operations", "[alignment_slicer][trim]") {
+	SECTION("No trim needed") {
+		// 10M at pos 5, region [1,100). Fully within.
+		AlignmentSlicer slicer(1, 100, false);
+		auto result = slicer.Slice(make_input("10M", 5, 15));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "10M");
+		REQUIRE(result.position == 5);
+		REQUIRE(result.stop_position == 15);
+	}
+
+	SECTION("Trim left") {
+		// 10M at pos 1 covers [1,11). Region [4,100). Trim 3 from left.
+		AlignmentSlicer slicer(4, 100, false);
+		auto result = slicer.Slice(make_input("10M", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H7M");
+		REQUIRE(result.position == 4);
+		REQUIRE(result.stop_position == 11);
+	}
+
+	SECTION("Trim right") {
+		// 10M at pos 1 covers [1,11). Region [1,6). Trim 5 from right.
+		AlignmentSlicer slicer(1, 6, false);
+		auto result = slicer.Slice(make_input("10M", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M5H");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 6);
+	}
+
+	SECTION("Trim both sides") {
+		// 10M at pos 1 covers [1,11). Region [4,8). Trim 3 left, 3 right.
+		AlignmentSlicer slicer(4, 8, false);
+		auto result = slicer.Slice(make_input("10M", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H4M3H");
+		REQUIRE(result.position == 4);
+		REQUIRE(result.stop_position == 8);
+	}
+
+	SECTION("Trim removes entire first M op") {
+		// 3M5M at pos 1 covers [1,9). Region [4,100). First 3M fully before.
+		AlignmentSlicer slicer(4, 100, false);
+		auto result = slicer.Slice(make_input("3M5M", 1, 9));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H5M");
+		REQUIRE(result.position == 4);
+		REQUIRE(result.stop_position == 9);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - = and X operations", "[alignment_slicer][trim]") {
+	SECTION("= trim left") {
+		// 10= at pos 1 covers [1,11). Region [4,100). Trim 3 from left.
+		AlignmentSlicer slicer(4, 100, false);
+		auto result = slicer.Slice(make_input("10=", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H7=");
+		REQUIRE(result.position == 4);
+		REQUIRE(result.stop_position == 11);
+	}
+
+	SECTION("X trim right") {
+		// 10X at pos 1 covers [1,11). Region [1,6).
+		AlignmentSlicer slicer(1, 6, false);
+		auto result = slicer.Slice(make_input("10X", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5X5H");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 6);
+	}
+
+	SECTION("Mixed =/X trim both") {
+		// 5=5X at pos 1 covers [1,11). Region [3,8).
+		// 5= at [1,6): trim 2 from left → 3=. 5X at [6,11): trim 3 from right → 2X.
+		// Wait: region [3,8). 5= covers [1,6). In region: [3,6) = 3=, before: 2.
+		// 5X covers [6,11). In region: [6,8) = 2X, after: 3.
+		AlignmentSlicer slicer(3, 8, false);
+		auto result = slicer.Slice(make_input("5=5X", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "2H3=2X3H");
+		REQUIRE(result.position == 3);
+		REQUIRE(result.stop_position == 8);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - I operations", "[alignment_slicer][trim]") {
+	SECTION("I within region kept") {
+		// 5M3I5M at pos 1. 5M covers [1,6), I at ref 6, 5M covers [6,11).
+		// Region [4,100). Trim 3 from left of first M.
+		// Result: 3H2M3I5M, pos=4, stop=11
+		AlignmentSlicer slicer(4, 100, false);
+		auto result = slicer.Slice(make_input("5M3I5M", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H2M3I5M");
+		REQUIRE(result.position == 4);
+		REQUIRE(result.stop_position == 11);
+	}
+
+	SECTION("I at trim boundary") {
+		// 5M2I5M at pos 1. 5M covers [1,6), I at ref 6, 5M covers [6,11).
+		// Region [6,100). First 5M fully before. I at ref 6 — in region. Keep I and second 5M.
+		// Left trim: 5 query bases from first M.
+		// Result: 5H2I5M, pos=6, stop=11
+		AlignmentSlicer slicer(6, 100, false);
+		auto result = slicer.Slice(make_input("5M2I5M", 1, 11));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5H2I5M");
+		REQUIRE(result.position == 6);
+		REQUIRE(result.stop_position == 11);
+	}
+
+	SECTION("I before region trimmed") {
+		// 2M3I5M at pos 1. 2M covers [1,3), I at ref 3, 5M covers [3,8).
+		// Region [3,8). 2M fully before → left_query_trim=2. I at ref 3 — in region [3,8)? Yes.
+		// Keep I, keep 5M.
+		// Result: 2H3I5M, pos=3, stop=8
+		AlignmentSlicer slicer(3, 8, false);
+		auto result = slicer.Slice(make_input("2M3I5M", 1, 8));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "2H3I5M");
+		REQUIRE(result.position == 3);
+		REQUIRE(result.stop_position == 8);
+	}
+
+	SECTION("I after region trimmed") {
+		// 5M2I3M at pos 1. 5M covers [1,6), I at ref 6, 3M covers [6,9).
+		// Region [1,6). 5M fully in. I at ref 6 — not in [1,6). Trimmed.
+		// 3M fully after. right_query_trim = 2(I) + 3(M) = 5.
+		// Result: 5M5H, pos=1, stop=6
+		AlignmentSlicer slicer(1, 6, false);
+		auto result = slicer.Slice(make_input("5M2I3M", 1, 9));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M5H");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 6);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - D operations", "[alignment_slicer][trim]") {
+	SECTION("D fully within") {
+		// 5M3D5M at pos 1. 5M [1,6), 3D [6,9), 5M [9,14). Region [1,14).
+		AlignmentSlicer slicer(1, 14, true);
+		auto result = slicer.Slice(make_input("5M3D5M", 1, 14));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M3D5M");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 14);
+	}
+
+	SECTION("D spans left boundary") {
+		// 5M3D5M at pos 1. 5M [1,6), 3D [6,9), 5M [9,14).
+		// Region [7,14). 5M before. 3D: before=1 (pos 6), within=2 (pos 7,8). 5M in region.
+		// left_query_trim = 5 (from first M).
+		// Result: 5H2D5M, pos=7, stop=14
+		AlignmentSlicer slicer(7, 14, true);
+		auto result = slicer.Slice(make_input("5M3D5M", 1, 14));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5H2D5M");
+		REQUIRE(result.position == 7);
+		REQUIRE(result.stop_position == 14);
+	}
+
+	SECTION("D spans right boundary") {
+		// 5M3D5M at pos 1. 5M [1,6), 3D [6,9), 5M [9,14).
+		// Region [1,7). 5M in region. 3D: within=1 (pos 6), after=2 (pos 7,8). 5M after.
+		// right_query_trim = 5 (from last M).
+		// Result: 5M1D5H, pos=1, stop=7
+		AlignmentSlicer slicer(1, 7, true);
+		auto result = slicer.Slice(make_input("5M3D5M", 1, 14));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M1D5H");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 7);
+	}
+
+	SECTION("D trimmed both sides") {
+		// 3M10D3M at pos 1. 3M [1,4), 10D [4,14), 3M [14,17).
+		// Region [5,12). 3M before → left_query_trim=3. 10D: before=1, within=7, after=2. 3M after →
+		// right_query_trim=3. Result: 3H7D3H, pos=5, stop=12
+		AlignmentSlicer slicer(5, 12, true);
+		auto result = slicer.Slice(make_input("3M10D3M", 1, 17));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H7D3H");
+		REQUIRE(result.position == 5);
+		REQUIRE(result.stop_position == 12);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - N operations", "[alignment_slicer][trim]") {
+	SECTION("N fully within") {
+		// 5M100N5M at pos 1. 5M [1,6), 100N [6,106), 5M [106,111).
+		// Region [1,111). All within.
+		AlignmentSlicer slicer(1, 111, false);
+		auto result = slicer.Slice(make_input("5M100N5M", 1, 111));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M100N5M");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 111);
+	}
+
+	SECTION("N spans left boundary") {
+		// 5M100N5M at pos 1. 5M [1,6), 100N [6,106), 5M [106,111).
+		// Region [50,111). 5M before → left_query_trim=5. 100N: before=44 (6..49), within=56 (50..105).
+		// 5M in region.
+		// Result: 5H56N5M, pos=50, stop=111
+		AlignmentSlicer slicer(50, 111, false);
+		auto result = slicer.Slice(make_input("5M100N5M", 1, 111));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5H56N5M");
+		REQUIRE(result.position == 50);
+		REQUIRE(result.stop_position == 111);
+	}
+
+	SECTION("N spans right boundary") {
+		// 5M100N5M at pos 1. 5M [1,6), 100N [6,106), 5M [106,111).
+		// Region [1,50). 5M in region. 100N: within=44 (6..49), after=56 (50..105). 5M after → right_query_trim=5.
+		// Result: 5M44N5H, pos=1, stop=50
+		AlignmentSlicer slicer(1, 50, false);
+		auto result = slicer.Slice(make_input("5M100N5M", 1, 111));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M44N5H");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 50);
+	}
+
+	SECTION("Region inside N only") {
+		// 5M100N5M at pos 1. Region [20,80). 5M before, N spans, 5M after.
+		// N-only overlap → not overlapping (N never counts).
+		AlignmentSlicer slicer(20, 80, false);
+		auto result = slicer.Slice(make_input("5M100N5M", 1, 111));
+		REQUIRE_FALSE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - S operations", "[alignment_slicer][trim]") {
+	SECTION("Leading S, M fully in region") {
+		// 3S5M at pos 4. S doesn't consume ref. 5M covers [4,9).
+		// Region [4,9). M fully in. S kept (it's at the start, M is in region).
+		AlignmentSlicer slicer(4, 9, false);
+		auto result = slicer.Slice(make_input("3S5M", 4, 9));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3S5M");
+		REQUIRE(result.position == 4);
+		REQUIRE(result.stop_position == 9);
+	}
+
+	SECTION("Leading S, trim into M") {
+		// 3S5M at pos 4. 5M covers [4,9). Region [6,9).
+		// 2M trimmed from left → left_query_trim = 3(S) + 2(M) = 5. 3M remains.
+		// Result: 5H3M, pos=6, stop=9
+		AlignmentSlicer slicer(6, 9, false);
+		auto result = slicer.Slice(make_input("3S5M", 4, 9));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5H3M");
+		REQUIRE(result.position == 6);
+		REQUIRE(result.stop_position == 9);
+	}
+
+	SECTION("Trailing S, M fully in region") {
+		// 5M3S at pos 1. 5M covers [1,6). S doesn't consume ref.
+		// Region [1,6). M fully in. S kept (trailing, M was all in region).
+		AlignmentSlicer slicer(1, 6, false);
+		auto result = slicer.Slice(make_input("5M3S", 1, 6));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5M3S");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 6);
+	}
+
+	SECTION("Trailing S, trim from M") {
+		// 5M3S at pos 1. 5M covers [1,6). Region [1,4).
+		// 3M kept, 2M trimmed right. S after trimmed M → right_query_trim = 2(M) + 3(S) = 5.
+		// Result: 3M5H, pos=1, stop=4
+		AlignmentSlicer slicer(1, 4, false);
+		auto result = slicer.Slice(make_input("5M3S", 1, 6));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3M5H");
+		REQUIRE(result.position == 1);
+		REQUIRE(result.stop_position == 4);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - H operations (existing)", "[alignment_slicer][trim]") {
+	SECTION("Existing H + additional trim") {
+		// 3H10M2H at pos 5. 10M covers [5,15).
+		// Region [8,12). Trim 3M left, 3M right. Plus existing 3H left, 2H right.
+		// left H = 3(existing) + 3(trimmed) = 6. right H = 3(trimmed) + 2(existing) = 5.
+		// Wait: 10M at [5,15). Region [8,12). Before: 3 (pos 5,6,7). After: 3 (pos 12,13,14).
+		// Within: 4 (pos 8,9,10,11). left_query_trim=3. right_query_trim=3.
+		// left H = 3 + 3 = 6. right H = 3 + 2 = 5.
+		// Result: 6H4M5H, pos=8, stop=12
+		AlignmentSlicer slicer(8, 12, false);
+		auto result = slicer.Slice(make_input("3H10M2H", 5, 15));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "6H4M5H");
+		REQUIRE(result.position == 8);
+		REQUIRE(result.stop_position == 12);
+	}
+
+	SECTION("Existing H, no additional trim") {
+		// 3H10M2H at pos 5. Region [1,100). Fully within.
+		AlignmentSlicer slicer(1, 100, false);
+		auto result = slicer.Slice(make_input("3H10M2H", 5, 15));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H10M2H");
+		REQUIRE(result.position == 5);
+		REQUIRE(result.stop_position == 15);
+	}
+}
+
+TEST_CASE("AlignmentSlicer trim - P operation", "[alignment_slicer][trim]") {
+	// 5M1P5M at pos 1. P is padding, doesn't consume ref or query.
+	// 5M [1,6), P, 5M [6,11). Region [1,11). All within.
+	AlignmentSlicer slicer(1, 11, false);
+	auto result = slicer.Slice(make_input("5M1P5M", 1, 11));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.cigar == "5M1P5M");
+	REQUIRE(result.position == 1);
+	REQUIRE(result.stop_position == 11);
+}
+
+TEST_CASE("AlignmentSlicer trim - complex multi-op", "[alignment_slicer][trim]") {
+	SECTION("Multi-op left trim") {
+		// 3M2I5M3D4M at pos 1.
+		// 3M covers [1,4) (query 0-2). 2I at ref 4 (query 3-4). 5M covers [4,9) (query 5-9).
+		// 3D covers [9,12). 4M covers [12,16) (query 10-13).
+		// Region [5,100). 3M before (left_query_trim+=3). I at ref 4 — before region [5,100). left_query_trim+=2.
+		// 5M at [4,9): split. Before: 1 (pos 4). Within: 4 (pos 5-8). left_query_trim+=1.
+		// Total left_query_trim = 3+2+1 = 6. 4M within. 3D within. 4M within.
+		// Result: 6H4M3D4M, pos=5, stop=16
+		AlignmentSlicer slicer(5, 100, false);
+		auto result = slicer.Slice(make_input("3M2I5M3D4M", 1, 16));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "6H4M3D4M");
+		REQUIRE(result.position == 5);
+		REQUIRE(result.stop_position == 16);
+	}
+
+	SECTION("Full complex trim with all op types") {
+		// 2H3S5M2I3M3D4M10N2M3S2H at pos 10
+		// Walk:
+		// 2H: existing left H=2, no ref/query consumed
+		// 3S: query 0-2, no ref consumed
+		// 5M: ref [10,15), query 3-7
+		// 2I: ref stays at 15, query 8-9
+		// 3M: ref [15,18), query 10-12
+		// 3D: ref [18,21), no query
+		// 4M: ref [21,25), query 13-16
+		// 10N: ref [25,35), no query
+		// 2M: ref [35,37), query 17-18
+		// 3S: query 19-21, no ref consumed
+		// 2H: existing right H=2, no ref/query consumed
+		//
+		// Region [12,25).
+		// 2H: left H existing = 2
+		// 3S: before region (we haven't entered yet) → left_query_trim += 3
+		// 5M [10,15): before=2 (10,11), within=3 (12,13,14). left_query_trim += 2. Keep 3M.
+		// 2I at ref 15: in [12,25)? Yes. Keep 2I.
+		// 3M [15,18): fully within. Keep 3M.
+		// 3D [18,21): fully within. Keep 3D.
+		// 4M [21,25): fully within [12,25)? [21,25) is within [12,25). Yes. Keep 4M.
+		// 10N [25,35): starts at 25 which is >= 25 (region stop). After.
+		// 2M [35,37): after → right_query_trim += 2
+		// 3S: after → right_query_trim += 3
+		// 2H: existing right H = 2
+		//
+		// left_query_trim = 3(S) + 2(M partial) = 5
+		// right_query_trim = 2(M) + 3(S) = 5
+		// left H = 2(existing) + 5(trimmed) = 7
+		// right H = 5(trimmed) + 2(existing) = 7
+		// CIGAR: 7H3M2I3M3D4M7H
+		// pos = max(10, 12) = 12
+		// stop = min(37, 25) = 25
+		AlignmentSlicer slicer(12, 25, false);
+		auto result = slicer.Slice(make_input("2H3S5M2I3M3D4M10N2M3S2H", 10, 37));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "7H3M2I3M3D4M7H");
+		REQUIRE(result.position == 12);
+		REQUIRE(result.stop_position == 25);
+	}
+}
+
+// =====================================================================
+// 1c. Sequence/quality trimming tests
+// =====================================================================
+
+TEST_CASE("AlignmentSlicer seq/qual trim - M operations", "[alignment_slicer][seqqual]") {
+	SECTION("No trim") {
+		AlignmentSlicer slicer(1, 6, false);
+		auto result = slicer.Slice(make_input_sq("5M", 1, 6, "ACGTG", {30, 31, 32, 33, 34}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "ACGTG");
+		REQUIRE(result.quality == std::vector<uint8_t>({30, 31, 32, 33, 34}));
+	}
+
+	SECTION("Left trim 2") {
+		AlignmentSlicer slicer(3, 6, false);
+		auto result = slicer.Slice(make_input_sq("5M", 1, 6, "ACGTG", {30, 31, 32, 33, 34}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "GTG");
+		REQUIRE(result.quality == std::vector<uint8_t>({32, 33, 34}));
+	}
+
+	SECTION("Right trim 2") {
+		AlignmentSlicer slicer(1, 4, false);
+		auto result = slicer.Slice(make_input_sq("5M", 1, 6, "ACGTG", {30, 31, 32, 33, 34}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "ACG");
+		REQUIRE(result.quality == std::vector<uint8_t>({30, 31, 32}));
+	}
+
+	SECTION("Both trim") {
+		AlignmentSlicer slicer(2, 4, false);
+		auto result = slicer.Slice(make_input_sq("5M", 1, 6, "ACGTG", {30, 31, 32, 33, 34}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "CG");
+		REQUIRE(result.quality == std::vector<uint8_t>({31, 32}));
+	}
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - = and X operations", "[alignment_slicer][seqqual]") {
+	SECTION("= op trim") {
+		AlignmentSlicer slicer(3, 6, false);
+		auto result = slicer.Slice(make_input_sq("5=", 1, 6, "ACGTG", {30, 31, 32, 33, 34}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "GTG");
+		REQUIRE(result.quality == std::vector<uint8_t>({32, 33, 34}));
+	}
+
+	SECTION("X op trim") {
+		AlignmentSlicer slicer(3, 6, false);
+		auto result = slicer.Slice(make_input_sq("5X", 1, 6, "ACGTG", {30, 31, 32, 33, 34}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "GTG");
+		REQUIRE(result.quality == std::vector<uint8_t>({32, 33, 34}));
+	}
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - I operations", "[alignment_slicer][seqqual]") {
+	SECTION("I kept in region") {
+		// 3M2I3M at pos 1. 3M [1,4) query 0-2. 2I at ref 4, query 3-4. 3M [4,7) query 5-7.
+		// Region [2,7). Trim 1M left → left_query_trim=1.
+		// Seq: ABCDEFGH (8 chars: 3M + 2I + 3M)
+		AlignmentSlicer slicer(2, 7, false);
+		auto result = slicer.Slice(make_input_sq("3M2I3M", 1, 7, "ABCDEFGH", {30, 31, 32, 33, 34, 35, 36, 37}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "BCDEFGH");
+		REQUIRE(result.quality == std::vector<uint8_t>({31, 32, 33, 34, 35, 36, 37}));
+	}
+
+	SECTION("I trimmed before region") {
+		// 2M3I5M at pos 1. 2M [1,3) query 0-1. 3I at ref 3, query 2-4. 5M [3,8) query 5-9.
+		// Region [3,8). 2M before → left_query_trim=2. I at ref 3 — in region.
+		// Seq: ABCDEFGHIJ (10 chars: 2M + 3I + 5M). Trim 2 from left.
+		AlignmentSlicer slicer(3, 8, false);
+		auto result =
+		    slicer.Slice(make_input_sq("2M3I5M", 1, 8, "ABCDEFGHIJ", {30, 31, 32, 33, 34, 35, 36, 37, 38, 39}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "CDEFGHIJ");
+		REQUIRE(result.quality == std::vector<uint8_t>({32, 33, 34, 35, 36, 37, 38, 39}));
+	}
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - D doesn't affect seq", "[alignment_slicer][seqqual]") {
+	// 3M3D3M at pos 1. 3M [1,4), 3D [4,7), 3M [7,10). Seq: ABCDEF (6 chars, D has no query bases).
+	// Region [1,10). All within.
+	AlignmentSlicer slicer(1, 10, true);
+	auto result = slicer.Slice(make_input_sq("3M3D3M", 1, 10, "ABCDEF", {30, 31, 32, 33, 34, 35}));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.sequence == "ABCDEF");
+	REQUIRE(result.quality == std::vector<uint8_t>({30, 31, 32, 33, 34, 35}));
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - N doesn't affect seq", "[alignment_slicer][seqqual]") {
+	// 3M5N3M at pos 1. 3M [1,4), 5N [4,9), 3M [9,12). Seq: ABCDEF (6 chars).
+	// Region [1,12). All within.
+	AlignmentSlicer slicer(1, 12, false);
+	auto result = slicer.Slice(make_input_sq("3M5N3M", 1, 12, "ABCDEF", {30, 31, 32, 33, 34, 35}));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.sequence == "ABCDEF");
+	REQUIRE(result.quality == std::vector<uint8_t>({30, 31, 32, 33, 34, 35}));
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - S operations", "[alignment_slicer][seqqual]") {
+	SECTION("Leading S trimmed with partial M") {
+		// 3S5M at pos 4. Seq: ABCDEFGH (8 chars: 3S + 5M).
+		// Region [6,9). S is before, 2M trimmed. left_query_trim = 3(S) + 2(M) = 5.
+		AlignmentSlicer slicer(6, 9, false);
+		auto result = slicer.Slice(make_input_sq("3S5M", 4, 9, "ABCDEFGH", {30, 31, 32, 33, 34, 35, 36, 37}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "FGH");
+		REQUIRE(result.quality == std::vector<uint8_t>({35, 36, 37}));
+	}
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - H doesn't affect seq", "[alignment_slicer][seqqual]") {
+	// 3H5M2H at pos 5. H not in seq. Seq: ABCDE (5 chars, only M).
+	// Region [7,10). Trim 2M left.
+	AlignmentSlicer slicer(7, 10, false);
+	auto result = slicer.Slice(make_input_sq("3H5M2H", 5, 10, "ABCDE", {30, 31, 32, 33, 34}));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.sequence == "CDE");
+	REQUIRE(result.quality == std::vector<uint8_t>({32, 33, 34}));
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - empty seq passthrough", "[alignment_slicer][seqqual]") {
+	AlignmentSlicer slicer(3, 6, false);
+	auto result = slicer.Slice(make_input_sq("5M", 1, 6, "", {}));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.sequence.empty());
+	REQUIRE(result.quality.empty());
+}
+
+TEST_CASE("AlignmentSlicer seq/qual trim - complex with all ops", "[alignment_slicer][seqqual]") {
+	// 2H3S5M2I3M3D4M10N2M3S2H at pos 10
+	// Query-consuming ops: S(3) M(5) I(2) M(3) M(4) M(2) S(3) = 22 query bases
+	// H doesn't appear in sequence.
+	// Region [12,25). From the trim test: left_query_trim=5 (3S + 2M), right_query_trim=5 (2M + 3S)
+	// Seq has 22 chars. After trimming: 22 - 5 - 5 = 12 chars.
+	std::string seq = "ABCDEFGHIJKLMNOPQRSTUV"; // 22 chars
+	std::vector<uint8_t> qual;
+	for (uint8_t i = 0; i < 22; i++) {
+		qual.push_back(30 + i);
+	}
+
+	AlignmentSlicer slicer(12, 25, false);
+	auto result = slicer.Slice(make_input_sq("2H3S5M2I3M3D4M10N2M3S2H", 10, 37, seq, qual));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.sequence == "FGHIJKLMNOPQ"); // chars 5..16 (0-indexed)
+	REQUIRE(result.quality.size() == 12);
+	REQUIRE(result.quality[0] == 35);  // 30+5
+	REQUIRE(result.quality[11] == 46); // 30+16
+}
+
+// =====================================================================
+// 1d. Edge case tests
+// =====================================================================
+
+TEST_CASE("AlignmentSlicer edge cases", "[alignment_slicer][edge]") {
+	SECTION("Region start > stop throws") {
+		REQUIRE_THROWS_AS(AlignmentSlicer(10, 5, false), miint::InvalidInputException);
+	}
+
+	SECTION("Region start < 1 throws") {
+		REQUIRE_THROWS_AS(AlignmentSlicer(0, 10, false), miint::InvalidInputException);
+	}
+
+	SECTION("Empty region (start == stop) - no reads overlap") {
+		AlignmentSlicer slicer(5, 5, false);
+		auto result = slicer.Slice(make_input("10M", 1, 11));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("Position < 1 (unmapped) returns no overlap") {
+		AlignmentSlicer slicer(1, 100, false);
+		auto result = slicer.Slice(make_input("10M", 0, 10));
+		REQUIRE_FALSE(result.overlaps);
+	}
+
+	SECTION("Negative position returns no overlap") {
+		AlignmentSlicer slicer(1, 100, false);
+		auto result = slicer.Slice(make_input("10M", -1, 9));
+		REQUIRE_FALSE(result.overlaps);
+	}
+}
+
+// =====================================================================
+// Additional coverage: reviewer-identified gaps
+// =====================================================================
+
+TEST_CASE("AlignmentSlicer - pure insertion-only overlap", "[alignment_slicer][overlap]") {
+	// Policy: an insertion at a ref position within the region counts as overlap.
+	// Insertions don't consume reference but represent query bases inserted at
+	// a specific reference coordinate. If that coordinate is in the region,
+	// the insertion is evidence of the query interacting with the region.
+	SECTION("I-only at region boundary - M before region") {
+		// 5M2I at pos 1. 5M covers [1,6). I at ref 6. Region [6,10).
+		// 5M fully before region. I at ref 6 is in [6,10). M is NOT in region.
+		// Only the I is in the region. Does this overlap?
+		// Yes — the insertion is at a reference coordinate within the region.
+		AlignmentSlicer slicer(6, 10, false);
+		auto result = slicer.Slice(make_input("5M2I", 1, 6));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "5H2I");
+		REQUIRE(result.position == 6);
+		REQUIRE(result.stop_position == 6);
+	}
+
+	SECTION("I-only NOT in region") {
+		// 5M2I at pos 1. I at ref 6. Region [7,10). I not in region.
+		AlignmentSlicer slicer(7, 10, false);
+		auto result = slicer.Slice(make_input("5M2I", 1, 6));
+		REQUIRE_FALSE(result.overlaps);
+	}
+}
+
+TEST_CASE("AlignmentSlicer - sequence/quality length mismatch", "[alignment_slicer][edge]") {
+	// When sequence length doesn't match CIGAR-implied query length, the trim
+	// indices may exceed sequence bounds. In this case, sequence/quality are
+	// returned empty (not crashed). This is a defensive behavior for corrupt input.
+	SECTION("Sequence shorter than CIGAR implies") {
+		// 10M implies 10 query bases, but only 3 provided
+		AlignmentSlicer slicer(4, 8, false);
+		auto result = slicer.Slice(make_input_sq("10M", 1, 11, "ABC", {30, 31, 32}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.cigar == "3H4M3H");
+		// Sequence/quality should be empty (trim exceeds bounds)
+		REQUIRE(result.sequence.empty());
+		REQUIRE(result.quality.empty());
+	}
+
+	SECTION("Sequence matches CIGAR - normal case") {
+		AlignmentSlicer slicer(4, 8, false);
+		auto result = slicer.Slice(make_input_sq("10M", 1, 11, "ABCDEFGHIJ", {30, 31, 32, 33, 34, 35, 36, 37, 38, 39}));
+		REQUIRE(result.overlaps);
+		REQUIRE(result.sequence == "DEFG");
+		REQUIRE(result.quality == std::vector<uint8_t>({33, 34, 35, 36}));
+	}
+}
+
+TEST_CASE("AlignmentSlicer - leading S with I as first non-S op", "[alignment_slicer][overlap]") {
+	// 3S2I5M at pos 5. S(3) pending. I(2) at ref 5. M(5) at [5,10).
+	// Region [5,10). I at ref 5 is in region. S should be kept.
+	AlignmentSlicer slicer(5, 10, false);
+	auto result = slicer.Slice(make_input_sq("3S2I5M", 5, 10, "ABCDEFGHIJ", {30, 31, 32, 33, 34, 35, 36, 37, 38, 39}));
+	REQUIRE(result.overlaps);
+	REQUIRE(result.cigar == "3S2I5M");
+	REQUIRE(result.position == 5);
+	REQUIRE(result.stop_position == 10);
+	REQUIRE(result.sequence == "ABCDEFGHIJ");
+}

--- a/test/sql/alignment_functions.test
+++ b/test/sql/alignment_functions.test
@@ -200,14 +200,122 @@ SELECT alignment_seq_identity(NULL, NULL, NULL, NULL) IS NULL;
 true
 
 ###############################################################################
+# CIGAR METHOD (identity from =/X ops, no tags needed)
+###############################################################################
+
+# Perfect match: 10= (all matches, no mismatches)
+# match_ops=10, alignment_columns=10. 10/10 = 1.0
+query R
+SELECT alignment_seq_identity('10=', NULL, NULL, 'cigar')::FLOAT;
+----
+1.0
+
+# Mixed =/X: 5=2X3= (8 matches, 2 mismatches)
+# match_ops=8, alignment_columns=10. 8/10 = 0.8
+query R
+SELECT alignment_seq_identity('5=2X3=', NULL, NULL, 'cigar')::FLOAT;
+----
+0.8
+
+# With insertions: 5=2I3= (8 matches in 10 alignment columns)
+# match_ops=8, alignment_columns=8+2=10. 8/10 = 0.8
+query R
+SELECT alignment_seq_identity('5=2I3=', NULL, NULL, 'cigar')::FLOAT;
+----
+0.8
+
+# With deletions: 5=3D5= (10 matches in 13 alignment columns)
+# match_ops=10, alignment_columns=10+3=13. 10/13 ≈ 0.769
+query R
+SELECT alignment_seq_identity('5=3D5=', NULL, NULL, 'cigar')::FLOAT;
+----
+0.769
+
+# All mismatches: 10X
+# match_ops=0, alignment_columns=10. 0/10 = 0.0
+query R
+SELECT alignment_seq_identity('10X', NULL, NULL, 'cigar')::FLOAT;
+----
+0.0
+
+# Complex: 3=1X2=1I3=2D2=1X1= (from Heng Li's blog example rewritten with =/X)
+# match_ops = 3+2+3+2+1 = 11
+# mismatch_ops = 1+1 = 2
+# insertions = 1
+# deletions = 2
+# alignment_columns = 11+2+1+2 = 16
+# 11/16 = 0.6875
+query R
+SELECT alignment_seq_identity('3=1X2=1I3=2D2=1X1=', NULL, NULL, 'cigar')::FLOAT;
+----
+0.688
+
+# With soft clips (ignored in identity): 3S5=2X3=3S
+# match_ops=8, alignment_columns=10. 8/10 = 0.8
+query R
+SELECT alignment_seq_identity('3S5=2X3=3S', NULL, NULL, 'cigar')::FLOAT;
+----
+0.8
+
+# With hard clips: 5H5=5X5H
+# match_ops=5, alignment_columns=10. 5/10 = 0.5
+query R
+SELECT alignment_seq_identity('5H5=5X5H', NULL, NULL, 'cigar')::FLOAT;
+----
+0.5
+
+# With N operation (intron skip, ignored): 5=100N5=
+# match_ops=10, alignment_columns=10. 10/10 = 1.0
+query R
+SELECT alignment_seq_identity('5=100N5=', NULL, NULL, 'cigar')::FLOAT;
+----
+1.0
+
+# M-only CIGAR should return NULL (ambiguous - can't distinguish matches from mismatches)
+query I
+SELECT alignment_seq_identity('10M', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+# Mixed M and = should return NULL (inconsistent)
+query I
+SELECT alignment_seq_identity('5M5=', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+# Mixed M and X should return NULL (inconsistent)
+query I
+SELECT alignment_seq_identity('5M5X', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+# NM and MD are ignored for cigar method (can be NULL)
+query R
+SELECT alignment_seq_identity('5=5X', NULL, NULL, 'cigar')::FLOAT;
+----
+0.5
+
+# Unmapped CIGAR should return NULL
+query I
+SELECT alignment_seq_identity('*', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+# NULL CIGAR should return NULL
+query I
+SELECT alignment_seq_identity(NULL, NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+###############################################################################
 # ERROR HANDLING
 ###############################################################################
 
-# Invalid type parameter
+# Invalid type parameter (error message includes the bad value)
 statement error
 SELECT alignment_seq_identity('10M', 0, '', 'invalid_type');
 ----
-Invalid Input Error: Invalid type parameter for alignment_seq_identity
+Invalid Input Error: Invalid type parameter for alignment_seq_identity: 'invalid_type'
 
 ###############################################################################
 # COMPLEX CIGAR PATTERNS
@@ -273,6 +381,39 @@ SELECT COUNT(*) FROM read_sam('data/sam/foo_has_header.sam')
 WHERE alignment_seq_identity(cigar, tag_nm, tag_md, 'gap_excluded') IS NULL;
 ----
 4
+
+###############################################################################
+# INTEGRATION: cigar method with alignment_slice
+###############################################################################
+
+# read_eq in slice_test.sam has CIGAR 5=5X. After slicing, tags are NULLed
+# but cigar method still works because it only needs the CIGAR string.
+statement ok
+CREATE TABLE slice_eq AS SELECT * FROM read_alignments('data/sam/slice_test.sam') WHERE read_id = 'read_eq'
+
+# Verify it has =/X ops
+query T
+SELECT cigar FROM slice_eq;
+----
+5=5X
+
+# cigar method works on the original
+query R
+SELECT alignment_seq_identity(cigar, tag_nm, tag_md, 'cigar')::FLOAT FROM slice_eq;
+----
+0.5
+
+# Slice to region [32,37) — trims into the = and X regions
+# 5= covers [30,35), 5X covers [35,40). Region [32,37):
+# = trimmed: 2 before, 3 within. X trimmed: 2 within, 3 after.
+# CIGAR: 2H3=2X3H. match_ops=3, alignment_columns=5. 3/5 = 0.6
+statement ok
+CREATE TABLE sliced_eq AS SELECT * FROM alignment_slice('slice_eq', 32, 37)
+
+query TR
+SELECT cigar, alignment_seq_identity(cigar, tag_nm, tag_md, 'cigar')::FLOAT FROM sliced_eq;
+----
+2H3=2X3H	0.6
 
 ###############################################################################
 # ALIGNMENT_QUERY_LENGTH - BASIC FUNCTIONALITY

--- a/test/sql/alignment_slice.test
+++ b/test/sql/alignment_slice.test
@@ -1,0 +1,391 @@
+# name: test/sql/alignment_slice.test
+# description: Test alignment_slice table function
+# group: [sql]
+
+require miint
+
+# =====================================================================
+# Phase 2: Bind and schema discovery error tests
+# =====================================================================
+
+# Error: nonexistent table
+statement error
+SELECT * FROM alignment_slice('nonexistent_table', 1, 10)
+----
+does not exist
+
+# Error: missing required columns
+statement ok
+CREATE TABLE bad_table (foo VARCHAR)
+
+statement error
+SELECT * FROM alignment_slice('bad_table', 1, 10)
+----
+missing required column
+
+# Error: region start > stop
+statement ok
+CREATE TABLE good_table (cigar VARCHAR, position BIGINT, stop_position BIGINT)
+
+statement error
+SELECT * FROM alignment_slice('good_table', 10, 5)
+----
+region start
+
+# Error: region start < 1
+statement error
+SELECT * FROM alignment_slice('good_table', 0, 5)
+----
+region start must be >= 1
+
+# Successful bind with empty table
+query III
+SELECT * FROM alignment_slice('good_table', 1, 10)
+----
+
+# =====================================================================
+# Phase 3: End-to-end slicing tests
+# =====================================================================
+
+# 3a. Pass-through (fully within region)
+statement ok
+CREATE TABLE t1 (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id VARCHAR)
+
+statement ok
+INSERT INTO t1 VALUES ('10M', 5, 15, 'r1')
+
+query TITT
+SELECT cigar, position, stop_position, read_id FROM alignment_slice('t1', 1, 20) ORDER BY read_id
+----
+10M	5	15	r1
+
+# 3b. Filtering (non-overlapping excluded)
+statement ok
+INSERT INTO t1 VALUES ('5M', 50, 55, 'r_far')
+
+query I
+SELECT count(*) FROM alignment_slice('t1', 1, 20)
+----
+1
+
+# 3c. Trimming through full pipeline
+statement ok
+CREATE TABLE t2 (cigar VARCHAR, position BIGINT, stop_position BIGINT, sequence VARCHAR, read_id VARCHAR)
+
+statement ok
+INSERT INTO t2 VALUES ('10M', 1, 11, 'ABCDEFGHIJ', 'trim_read')
+
+query TIIT
+SELECT cigar, position, stop_position, sequence FROM alignment_slice('t2', 4, 8)
+----
+3H4M3H	4	8	DEFG
+
+# 3d. Tag invalidation
+statement ok
+CREATE TABLE t3 (cigar VARCHAR, position BIGINT, stop_position BIGINT, tag_as BIGINT, tag_md VARCHAR)
+
+statement ok
+INSERT INTO t3 VALUES ('10M', 1, 11, 100, '10')
+
+# When trimmed, tags should be NULL
+query II
+SELECT tag_as, tag_md FROM alignment_slice('t3', 4, 8)
+----
+NULL	NULL
+
+# When NOT trimmed (fully within), tags should be preserved
+query II
+SELECT tag_as, tag_md FROM alignment_slice('t3', 1, 100)
+----
+100	10
+
+# 3e. template_length NULLed, mapq preserved
+statement ok
+CREATE TABLE t4_meta (cigar VARCHAR, position BIGINT, stop_position BIGINT, mapq UTINYINT, template_length BIGINT)
+
+statement ok
+INSERT INTO t4_meta VALUES ('10M', 1, 11, 60, 500)
+
+# When trimmed: mapq preserved, template_length NULLed
+query II
+SELECT mapq, template_length FROM alignment_slice('t4_meta', 4, 8)
+----
+60	NULL
+
+# When NOT trimmed: both preserved
+query II
+SELECT mapq, template_length FROM alignment_slice('t4_meta', 1, 100)
+----
+60	500
+
+# 3f. include_deletions parameter
+statement ok
+CREATE TABLE t5 (cigar VARCHAR, position BIGINT, stop_position BIGINT)
+
+statement ok
+INSERT INTO t5 VALUES ('3M5D3M', 1, 12)
+
+# D-only overlap region [5,9): excluded by default
+query I
+SELECT count(*) FROM alignment_slice('t5', 5, 9)
+----
+0
+
+# D-only overlap region [5,9): included with flag
+query I
+SELECT count(*) FROM alignment_slice('t5', 5, 9, include_deletions := true)
+----
+1
+
+# 3g. Single reference enforcement
+statement ok
+CREATE TABLE single_ref (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference VARCHAR)
+
+statement ok
+INSERT INTO single_ref VALUES ('5M', 1, 6, 'chr1'), ('5M', 10, 15, 'chr1')
+
+query I
+SELECT count(*) FROM alignment_slice('single_ref', 1, 20)
+----
+2
+
+# No reference column: OK (no check performed)
+statement ok
+CREATE TABLE no_ref (cigar VARCHAR, position BIGINT, stop_position BIGINT)
+
+statement ok
+INSERT INTO no_ref VALUES ('5M', 1, 6), ('5M', 10, 15)
+
+query I
+SELECT count(*) FROM alignment_slice('no_ref', 1, 20)
+----
+2
+
+# Multiple references: error
+statement ok
+CREATE TABLE multi_ref (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference VARCHAR)
+
+statement ok
+INSERT INTO multi_ref VALUES ('5M', 1, 6, 'chr1'), ('5M', 10, 15, 'chr2')
+
+statement error
+SELECT * FROM alignment_slice('multi_ref', 1, 20)
+----
+multiple references found
+
+# =====================================================================
+# Phase 4: Views, quality column, edge cases
+# =====================================================================
+
+# 4a. View support
+statement ok
+CREATE VIEW v1 AS SELECT * FROM t1 WHERE read_id = 'r1'
+
+query TITT
+SELECT cigar, position, stop_position, read_id FROM alignment_slice('v1', 1, 20)
+----
+10M	5	15	r1
+
+# 4b. qual column (LIST(UTINYINT)) trimming
+statement ok
+CREATE TABLE tq (cigar VARCHAR, position BIGINT, stop_position BIGINT, sequence VARCHAR, qual UTINYINT[])
+
+statement ok
+INSERT INTO tq VALUES ('5M', 1, 6, 'ACGTG', [30, 31, 32, 33, 34])
+
+query TT
+SELECT sequence, qual FROM alignment_slice('tq', 2, 5)
+----
+CGT	[31, 32, 33]
+
+# qual preserved when no trimming
+query TT
+SELECT sequence, qual FROM alignment_slice('tq', 1, 6)
+----
+ACGTG	[30, 31, 32, 33, 34]
+
+# 4c. NULL cigar/position/stop_position rows are skipped
+statement ok
+CREATE TABLE null_alns (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id VARCHAR)
+
+statement ok
+INSERT INTO null_alns VALUES (NULL, 5, 10, 'null_cigar'), ('5M', NULL, 10, 'null_pos'), ('5M', 5, NULL, 'null_stop'), ('5M', 5, 10, 'valid')
+
+query I
+SELECT count(*) FROM alignment_slice('null_alns', 1, 20)
+----
+1
+
+query T
+SELECT read_id FROM alignment_slice('null_alns', 1, 20)
+----
+valid
+
+# 4d. Empty region (start == stop) returns no rows
+query I
+SELECT count(*) FROM alignment_slice('t1', 5, 5)
+----
+0
+
+# 4e. All reads filtered out (none overlap)
+statement ok
+CREATE TABLE far_alns (cigar VARCHAR, position BIGINT, stop_position BIGINT)
+
+statement ok
+INSERT INTO far_alns VALUES ('5M', 100, 105), ('5M', 200, 205)
+
+query I
+SELECT count(*) FROM alignment_slice('far_alns', 1, 10)
+----
+0
+
+# 4f. Empty table returns no rows
+statement ok
+CREATE TABLE empty_alns (cigar VARCHAR, position BIGINT, stop_position BIGINT)
+
+query I
+SELECT count(*) FROM alignment_slice('empty_alns', 1, 100)
+----
+0
+
+# 4g. Reference column with NULL values (should not affect single-reference check)
+statement ok
+CREATE TABLE ref_with_nulls (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference VARCHAR)
+
+statement ok
+INSERT INTO ref_with_nulls VALUES ('5M', 1, 6, 'chr1'), ('5M', 10, 15, NULL), ('5M', 20, 25, 'chr1')
+
+query I
+SELECT count(*) FROM alignment_slice('ref_with_nulls', 1, 30)
+----
+3
+
+# 4h. Multi-ref check fires even when one ref row has NULL cigar
+statement ok
+CREATE TABLE multi_ref_null_cigar (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference VARCHAR)
+
+statement ok
+INSERT INTO multi_ref_null_cigar VALUES ('5M', 1, 6, 'chr1'), (NULL, 10, 15, 'chr2')
+
+statement error
+SELECT * FROM alignment_slice('multi_ref_null_cigar', 1, 20)
+----
+multiple references found
+
+# =====================================================================
+# Phase 5: Integration with real SAM data
+# =====================================================================
+
+# Load SAM data into a table
+statement ok
+CREATE TABLE sam_data AS SELECT * FROM read_alignments('data/sam/slice_test.sam', include_seq_qual := true)
+
+# Verify we loaded all reads
+query I
+SELECT count(*) FROM sam_data
+----
+8
+
+# Slice region [15, 25): should include read_m (trimmed), exclude far reads
+# read_m: pos=10, cigar=10M, covers [10,20). Region [15,25) overlaps [15,20).
+# Trim: 5 bases from left. CIGAR: 5H5M. pos=15, stop=20. seq trimmed.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 15, 25) ORDER BY read_id
+----
+read_m	5H5M	15	20
+
+# Slice region [50, 65): includes read_ins (with insertion)
+# read_ins: pos=50, cigar=5M3I5M, covers [50,60). Region [50,65) fully contains.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 50, 65) ORDER BY read_id
+----
+read_ins	5M3I5M	50	60
+
+# Slice region [53, 58): trims read_ins
+# 5M covers [50,55). 3I at ref 55. 5M covers [55,60).
+# Region [53,58): trim 3 from first M, 2 from last M. I at 55 is in region.
+# left_query_trim=3, right_query_trim=2. CIGAR: 3H2M3I3M2H.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 53, 58) ORDER BY read_id
+----
+read_ins	3H2M3I3M2H	53	58
+
+# Slice region [70, 85): includes read_del, test D handling
+# read_del: pos=70, cigar=5M3D5M, covers [70,83). Fully within.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 70, 85) ORDER BY read_id
+----
+read_del	5M3D5M	70	83
+
+# Region [76, 82) falls partially into D region of read_del
+# 5M [70,75). 3D [75,78). 5M [78,83).
+# Region [76,82): D partial within (1D trimmed from left, 76-77 = 2D within).
+# Second M: [78,83) partially in [76,82): 4M within, 1M after.
+# First M: fully before → left_query_trim=5.
+# With include_deletions: overlaps via D.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 76, 82, include_deletions := true) ORDER BY read_id
+----
+read_del	5H2D4M1H	76	82
+
+# Without include_deletions: also overlaps because second M is in region [78,82)
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 76, 82) ORDER BY read_id
+----
+read_del	5H2D4M1H	76	82
+
+# Verify alignment_seq_identity works on sliced output (composability)
+# read_m sliced to [15,20): CIGAR 5H5M, all matches. Should have identity 1.0.
+statement ok
+CREATE TABLE sliced_m AS SELECT * FROM alignment_slice('sam_data', 15, 20) WHERE read_id = 'read_m'
+
+# Tags are NULLed after trimming, but seq_identity from CIGAR alone (gap_compressed)
+# requires NM tag which is NULLed. Let's just verify the sliced output has valid CIGAR.
+query TI
+SELECT cigar, stop_position - position AS ref_len FROM sliced_m
+----
+5H5M	5
+
+# Slice region containing intron read
+# read_intron: pos=110, cigar=5M20N5M, covers [110,140). stop=110+5+20+5=140.
+# Region [108, 140): fully contains read_intron. read_hclip at pos=140 is outside (stop exclusive).
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 108, 140) ORDER BY read_id
+----
+read_intron	5M20N5M	110	140
+
+# Slice completely outside all reads returns empty
+query I
+SELECT count(*) FROM alignment_slice('sam_data', 190, 200)
+----
+0
+
+# Integration: read_clip (3S7M at pos 90, covers [90,97))
+# Region [92,96): trim 2M from left, 1M from right.
+# left_query_trim = 3(S) + 2(M) = 5. right_query_trim = 1(M).
+# CIGAR: 5H4M1H. pos=92, stop=96.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 92, 96) ORDER BY read_id
+----
+read_clip	5H4M1H	92	96
+
+# Integration: read_clip fully in region (no M trimming, S preserved)
+# Region [90,97): M fully within, leading S preserved.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 90, 97) ORDER BY read_id
+----
+read_clip	3S7M	90	97
+
+# Integration: read_hclip (5H5M5H at pos 140, covers [140,145))
+# Region [142,145): trim 2M from left. Existing H=5 + trimmed=2 = 7H.
+# CIGAR: 7H3M5H. pos=142, stop=145.
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 142, 145) ORDER BY read_id
+----
+read_hclip	7H3M5H	142	145
+
+# Integration: read_hclip fully in region (existing H preserved, no additional trim)
+query TIIT
+SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 140, 145) ORDER BY read_id
+----
+read_hclip	5H5M5H	140	145


### PR DESCRIPTION
Support for slicing alignment data. Fields are in the records are updated as necessary (e.g., CIGAR, nulling NM, etc). 

We also added support for calculating sequence identity directly from CIGAR

cc @jianshu93