### PR TITLE
Fix read_jplace_newick ignoring [n] edge IDs from pplacer/SEPP/gappa

### DIFF
--- a/data/jplace/bracket_edges.jplace
+++ b/data/jplace/bracket_edges.jplace
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "tree": "((A:0.1,B:0.2):0.3[0],(C:0.4,D:0.5):0.6[1]):0.0[2];",
+  "fields": ["edge_num", "likelihood", "like_weight_ratio", "distal_length", "pendant_length"],
+  "placements": [],
+  "metadata": {
+    "tool": "test-bracket-edge-ids"
+  }
+}

--- a/data/jplace/bracket_edges_with_comments.jplace
+++ b/data/jplace/bracket_edges_with_comments.jplace
@@ -1,0 +1,9 @@
+{
+  "version": 3,
+  "tree": "((A:0.1[0],B[a tip comment]:0.2[1]):0.3[2],(C:0.4[3],D:0.5[4]):0.6[5]):0.0[6];",
+  "fields": ["edge_num", "likelihood", "like_weight_ratio", "distal_length", "pendant_length"],
+  "placements": [],
+  "metadata": {
+    "tool": "test-mixed-comments-and-bracket-edges"
+  }
+}

--- a/src/include/read_jplace_newick.hpp
+++ b/src/include/read_jplace_newick.hpp
@@ -34,7 +34,6 @@ public:
 	};
 
 	struct LocalState : public LocalTableFunctionState {
-		bool has_file = false;
 		std::vector<ReadNewickTableFunction::NodeRow> current_rows;
 		size_t current_row_idx = 0;
 		std::string current_filepath;

--- a/src/read_jplace_newick.cpp
+++ b/src/read_jplace_newick.cpp
@@ -4,7 +4,49 @@
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 
+#include <cctype>
+
 namespace duckdb {
+
+// Convert jplace square-bracket edge numbers [n] to curly-brace syntax {n}
+// that the Newick parser understands. The Newick parser treats [...] as comments
+// and skips them, but jplace files use [integer] for edge numbering.
+// Only converts brackets whose content is a non-negative integer (digits only).
+// Non-integer bracket content (e.g., [some comment]) is left as-is for the
+// Newick parser to handle as a standard comment.
+// Note: jplace edge numbers are non-negative per spec (Matsen et al. 2012).
+static std::string ConvertBracketEdgeIds(const std::string &newick) {
+	std::string result;
+	result.reserve(newick.size());
+
+	size_t i = 0;
+	while (i < newick.size()) {
+		if (newick[i] == '[') {
+			// Check if content is a non-negative integer
+			size_t start = i + 1;
+			size_t j = start;
+			while (j < newick.size() && std::isdigit(static_cast<unsigned char>(newick[j]))) {
+				++j;
+			}
+			if (j > start && j < newick.size() && newick[j] == ']') {
+				// It's [digits] — convert to {digits}
+				result += '{';
+				result.append(newick, start, j - start);
+				result += '}';
+				i = j + 1;
+			} else {
+				// Not a pure integer — keep as-is (actual comment)
+				result += newick[i];
+				++i;
+			}
+		} else {
+			result += newick[i];
+			++i;
+		}
+	}
+
+	return result;
+}
 
 // Extract the "tree" string value from jplace JSON content.
 // The jplace format (Matsen et al., 2012) has a top-level "tree" key whose value
@@ -34,7 +76,9 @@ std::string ReadJplaceNewickTableFunction::ExtractTreeFromJplaceContent(const st
 		throw IOException("Jplace file '%s': 'tree' field value is not a string", path);
 	}
 
-	// Extract the JSON string value (handle escape sequences)
+	// Quick-and-dirty JSON string extraction: only handles \\ and \" escapes.
+	// Does NOT decode \n, \t, \uXXXX etc. — sufficient for Newick tree strings
+	// which contain no such escapes in practice.
 	pos++;
 	std::string result;
 	while (pos < content.size() && content[pos] != '"') {
@@ -51,7 +95,10 @@ std::string ReadJplaceNewickTableFunction::ExtractTreeFromJplaceContent(const st
 		throw IOException("Jplace file '%s': 'tree' field is empty", path);
 	}
 
-	return result;
+	// Convert [integer] edge IDs to {integer} syntax.
+	// Many jplace tools (pplacer, SEPP, gappa) use square brackets for edge numbering,
+	// but the Newick parser treats [...] as comments. Only pure integers are converted.
+	return ConvertBracketEdgeIds(result);
 }
 
 ReadJplaceNewickTableFunction::Data::Data(const std::vector<std::string> &paths, bool include_fp)

--- a/test/sql/read_jplace_newick.test
+++ b/test/sql/read_jplace_newick.test
@@ -132,3 +132,72 @@ query I
 SELECT COUNT(*) FROM read_jplace_newick('data/jplace/empty.jplace');
 ----
 3
+
+# =============================================================================
+# Square-bracket edge IDs (regression test)
+# Many jplace tools (pplacer, SEPP, gappa) use [n] instead of {n} for edge
+# numbering. The Newick parser must not treat these as comments.
+# Tree: ((A:0.1,B:0.2):0.3[0],(C:0.4,D:0.5):0.6[1]):0.0[2];
+# Same structure as test.jplace but with [...] instead of {...}
+# =============================================================================
+
+# Total node count matches curly-brace version
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/bracket_edges.jplace');
+----
+7
+
+# Edge IDs are NOT null — the [n] values must be parsed as edge identifiers
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/bracket_edges.jplace') WHERE edge_id IS NOT NULL;
+----
+3
+
+# Edge ID values match expected integers
+query II
+SELECT name, edge_id FROM read_jplace_newick('data/jplace/bracket_edges.jplace') WHERE edge_id IS NOT NULL ORDER BY edge_id;
+----
+(empty)	0
+(empty)	1
+(empty)	2
+
+# Branch lengths are preserved correctly alongside bracket edge IDs
+query TR
+SELECT name, branch_length FROM read_jplace_newick('data/jplace/bracket_edges.jplace') WHERE is_tip = true ORDER BY name;
+----
+A	0.1
+B	0.2
+C	0.4
+D	0.5
+
+# =============================================================================
+# Mixed: bracket edge IDs on tips + non-integer Newick comments
+# Tree: ((A:0.1[0],B[a tip comment]:0.2[1]):0.3[2],(C:0.4[3],D:0.5[4]):0.6[5]):0.0[6];
+# [0]-[6] are edge IDs (integers), [a tip comment] is a Newick comment (dropped)
+# =============================================================================
+
+# All 7 nodes present, edge IDs on every node (tips and internals)
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/bracket_edges_with_comments.jplace');
+----
+7
+
+query I
+SELECT COUNT(*) FROM read_jplace_newick('data/jplace/bracket_edges_with_comments.jplace') WHERE edge_id IS NOT NULL;
+----
+7
+
+# Tip edge IDs are parsed correctly — bracket IDs work on tips, not just internals
+query TI
+SELECT name, edge_id FROM read_jplace_newick('data/jplace/bracket_edges_with_comments.jplace') WHERE is_tip = true ORDER BY edge_id;
+----
+A	0
+B	1
+C	3
+D	4
+
+# Non-integer comment [a tip comment] on B is silently dropped (not in name or edge_id)
+query TI
+SELECT name, edge_id FROM read_jplace_newick('data/jplace/bracket_edges_with_comments.jplace') WHERE name = 'B';
+----
+B	1


### PR DESCRIPTION
The Newick parser treats [...] as comments, but many jplace tools use square brackets for edge numbering instead of curly braces. Added a preprocessing step that converts [integer] to {integer} before parsing, leaving non-integer bracket content as standard Newick comments.

Also removed dead has_file field from LocalState.