### PR TITLE
Add read_ena, read_ena_attributes, read_ena_fastq table functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -621,6 +621,11 @@ set(EXTENSION_SOURCES
     src/read_ncbi_fasta.cpp
     src/read_ncbi.cpp
     src/read_ncbi_annotation.cpp
+    src/ena_parser.cpp
+    src/ena_client.cpp
+    src/read_ena.cpp
+    src/read_ena_attributes.cpp
+    src/read_ena_fastq.cpp
     src/SFFReader.cpp
     src/read_sequences_sff.cpp
     src/WFA2Aligner.cpp
@@ -815,6 +820,8 @@ set(TEST_SOURCES
     src/zip_utils.cpp
     duckdb/third_party/miniz/miniz.cpp  # For ExtractFromZip tests
     test/cpp/test_ncbi_client.cpp
+    src/ena_parser.cpp
+    test/cpp/test_ENAClient.cpp
     src/SFFReader.cpp
     test/cpp/test_SFFReader.cpp
     src/WFA2Aligner.cpp

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -15,6 +15,9 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`read_ncbi`](#read_ncbiaccession-api_key) - NCBI accession metadata
 - [`read_ncbi_fasta`](#read_ncbi_fastaaccession-api_key-include_filepathfalse) - NCBI FASTA sequences
 - [`read_ncbi_annotation`](#read_ncbi_annotationaccession-api_key-include_filepathfalse) - NCBI genome annotations
+- [`read_ena`](#read_enaaccession-resultread_run-fields) - EBI/ENA metadata queries
+- [`read_ena_attributes`](#read_ena_attributesaccession) - EBI/ENA custom sample attributes
+- [`read_ena_fastq`](#read_ena_fastqaccession-include_filepathfalse-qual_offset33) - Stream FASTQ from EBI/ENA with accession columns
 - [`read_jplace`](#read_jplacepath) - Phylogenetic placement files
 - [`read_jplace_newick`](#read_jplace_newickpath-include_filepathfalse) - Newick tree from jplace files
 - [`read_newick`](#read_newickfilename-include_filepathfalse) - Newick phylogenetic trees
@@ -872,6 +875,153 @@ COPY (
 - Complex feature locations (join, complement) emit a warning and use outer bounds only
 - The `phase` column is set from the `codon_start` qualifier for CDS features
 - Source is detected from accession prefix: NC_/NM_/NP_ -> 'RefSeq', others -> 'GenBank' or 'NCBI'
+
+## `read_ena(accession, [result='read_run'], [fields])`
+
+Query metadata from the EBI European Nucleotide Archive (ENA) Portal API. Returns run, sample, or study metadata as a table of VARCHAR columns.
+
+**Requirements:**
+- Requires the `httpfs` extension (automatically loaded)
+- Network access to EBI servers (www.ebi.ac.uk)
+
+**Parameters:**
+- `accession` (VARCHAR or VARCHAR[]): ENA/SRA accession(s). Supports study (PRJNA\*, PRJEB\*, ERP\*, SRP\*), sample (SAMN\*, SAME\*), run (SRR\*, ERR\*), and experiment (SRX\*, ERX\*) accessions.
+- `result` (VARCHAR, optional, default 'read_run'): ENA result type. One of: `read_run`, `sample`, `study`. When the accession type doesn't match the result type (e.g., run accession with `result='study'`), the accession is automatically resolved.
+- `fields` (VARCHAR, optional): Comma-separated list of ENA field names to return. If omitted, a sensible default set is used per result type.
+
+**Output schema:**
+- All columns are VARCHAR, named according to the requested fields
+- Default `read_run` fields include: `run_accession`, `experiment_accession`, `sample_accession`, `study_accession`, `fastq_ftp`, `fastq_bytes`, `fastq_md5`, `library_strategy`, `library_layout`, `instrument_model`, `read_count`, `base_count`, and more
+- Default `sample` fields include: `sample_accession`, `scientific_name`, `tax_id`, `collection_date`, `country`, `lat`, `lon`, `depth`, and more
+- Default `study` fields include: `study_accession`, `study_title`, `study_description`, `center_name`, and more
+
+**Behavior:**
+- Queries the ENA Portal API (`/search` endpoint) with `format=tsv`
+- Accession type is auto-detected from prefix and mapped to the appropriate query parameter
+- Cross-type resolution: e.g., a run accession with `result='study'` first resolves to the study accession, then queries the study
+- Rate-limited to ~3 requests/second with retry on 429/500/502/503
+
+**Examples:**
+```sql
+-- Get all run metadata for a single run
+SELECT * FROM read_ena('ERR1074767');
+
+-- Get specific fields
+SELECT run_accession, library_layout, read_count
+FROM read_ena('ERR1074767', fields='run_accession,library_layout,read_count');
+
+-- Get sample metadata (auto-resolves run -> sample)
+SELECT * FROM read_ena('ERR1074767', result='sample');
+
+-- Get study info
+SELECT study_title FROM read_ena('PRJEB11419', result='study');
+
+-- Get all runs for a BioProject
+CREATE TABLE project_runs AS SELECT * FROM read_ena('PRJNA555783');
+```
+
+## `read_ena_attributes(accession)`
+
+Fetch custom sample attributes from EBI/ENA via the Browser XML API. Returns all submitter-defined key-value attributes that are not available through the Portal API's fixed schema.
+
+**Requirements:**
+- Requires the `httpfs` extension (automatically loaded)
+- Network access to EBI servers (www.ebi.ac.uk)
+
+**Parameters:**
+- `accession` (VARCHAR or VARCHAR[]): ENA/SRA accession(s). Supports study, sample, run, and experiment accessions. Non-sample accessions are automatically resolved to their associated sample accession(s).
+
+**Output schema:**
+- `sample_accession` (VARCHAR): BioSample accession (SAMN\*/SAME\*)
+- `tag` (VARCHAR): Attribute name (e.g., 'collection date', 'geographic location', custom fields)
+- `value` (VARCHAR): Attribute value
+
+**Behavior:**
+- Resolves non-sample accessions to sample accessions via the Portal API
+- Fetches XML from the Browser API in batches of 50 samples
+- Parses `<SAMPLE_ATTRIBUTE>` `<TAG>`/`<VALUE>` pairs
+- Returns ALL attributes including custom/submitter-defined ones (e.g., primer sequences, custom identifiers) that are not available via `read_ena`
+
+**Examples:**
+```sql
+-- Get all attributes for a run's sample
+SELECT * FROM read_ena_attributes('ERR1074767');
+
+-- Get attributes for a specific sample
+SELECT * FROM read_ena_attributes('SAMEA3610311');
+
+-- Find primer information
+SELECT tag, value FROM read_ena_attributes('ERR1074767')
+WHERE tag LIKE '%primer%' OR tag LIKE '%Primer%';
+
+-- Pivot attributes to wide format for a study
+SELECT sample_accession,
+       MAX(CASE WHEN tag = 'collection date' THEN value END) AS collection_date,
+       MAX(CASE WHEN tag = 'geographic location (country and/or sea)' THEN value END) AS country
+FROM read_ena_attributes('PRJEB11419')
+GROUP BY sample_accession;
+```
+
+## `read_ena_fastq(accession, [include_filepath=false], [qual_offset=33])`
+
+Stream FASTQ sequence data from EBI/ENA with run, sample, and experiment accession columns. Returns data in the same schema as `read_fastx` plus accession metadata columns, enabling direct association of sequence data with project metadata.
+
+**Requirements:**
+- Requires the `httpfs` extension (automatically loaded)
+- Network access to EBI servers (ftp.sra.ebi.ac.uk via HTTPS)
+
+**Parameters:**
+- `accession` (VARCHAR or VARCHAR[]): ENA/SRA accession(s). Supports study (bulk download all runs), sample, run, and experiment accessions.
+- `include_filepath` (BOOLEAN, optional, default false): Add filepath column with the HTTPS download URL(s). For paired-end runs, URLs are semicolon-separated.
+- `qual_offset` (BIGINT, optional, default 33): Quality score offset (33 for Phred+33/Sanger, 64 for Phred+64/Illumina 1.3+)
+
+**Output schema:**
+- `sequence_index` (BIGINT): 1-based sequence index (per run)
+- `read_id` (VARCHAR): FASTQ read identifier
+- `comment` (VARCHAR): FASTQ comment line (nullable)
+- `sequence1` (VARCHAR): Forward read sequence
+- `sequence2` (VARCHAR): Reverse read sequence (NULL for single-end)
+- `qual1` (UTINYINT[]): Forward quality scores
+- `qual2` (UTINYINT[]): Reverse quality scores (NULL for single-end)
+- `run_accession` (VARCHAR): SRR/ERR run accession
+- `sample_accession` (VARCHAR): SAMN/SAME BioSample accession
+- `experiment_accession` (VARCHAR): SRX/ERX experiment accession
+- `filepath` (VARCHAR, optional): HTTPS download URL(s)
+
+**Behavior:**
+- At bind time, queries ENA Portal API to discover runs, FASTQ URLs, and library layout (paired vs single-end)
+- Constructs HTTPS URLs from ENA's FTP paths
+- Streams FASTQ data through the same `SequenceReader`/`DuckDBSeqStream` infrastructure as `read_fastx`
+- Paired-end detection is automatic from the `library_layout` field
+- Supports parallel streaming across multiple runs (up to 8 concurrent)
+
+**Examples:**
+```sql
+-- Stream reads from a single run
+SELECT * FROM read_ena_fastq('ERR1074767') LIMIT 100;
+
+-- Stream all reads for a BioProject directly to Parquet
+COPY (SELECT * FROM read_ena_fastq('PRJNA555783'))
+  TO 'project_sequences.parquet' (FORMAT PARQUET);
+
+-- Join sequence data with metadata
+CREATE TABLE runs AS SELECT * FROM read_ena('PRJNA555783');
+CREATE TABLE seqs AS SELECT * FROM read_ena_fastq('PRJNA555783');
+
+SELECT s.run_accession, r.library_strategy, COUNT(*) AS read_count
+FROM seqs s
+JOIN runs r USING (run_accession)
+GROUP BY ALL;
+
+-- Stream with filepath for provenance tracking
+SELECT run_accession, read_id, filepath
+FROM read_ena_fastq('ERR1074767', include_filepath=true) LIMIT 5;
+```
+
+**Notes:**
+- For large projects, the FASTQ download can take significant time and bandwidth
+- The `run_accession` column enables easy JOIN back to metadata from `read_ena`
+- Quality scores are converted to numeric values using the specified offset (default Phred+33)
 
 ## `read_jplace(path)`
 

--- a/src/duckdb_seq_stream.cpp
+++ b/src/duckdb_seq_stream.cpp
@@ -72,4 +72,28 @@ int duckdb_seq_close(DuckDBSeqStream *stream) {
 
 } // namespace miint
 
+#include "table_function_common.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/file_system.hpp"
+#include <memory>
+
+namespace duckdb {
+
+miint::DuckDBSeqStream *CreateDuckDBSeqStream(FileSystem &fs, const std::string &path) {
+	auto stream = std::make_unique<miint::DuckDBSeqStream>();
+	auto handle = fs.OpenFile(path, FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ));
+	stream->handle = std::shared_ptr<FileHandle>(handle.release());
+	stream->is_gzipped = IsGzipped(path);
+	if (stream->is_gzipped) {
+		if (inflateInit2(&stream->zs, 16 + MAX_WBITS) != Z_OK) {
+			throw IOException("Failed to initialize zlib for: " + path);
+		}
+		stream->zs_initialized = true;
+	}
+	return stream.release();
+}
+
+} // namespace duckdb
+
 #endif // MIINT_STATIC_BUILD

--- a/src/ena_client.cpp
+++ b/src/ena_client.cpp
@@ -1,0 +1,70 @@
+#include "ena_client.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
+#include <thread>
+
+namespace miint {
+
+ENAClient::ENAClient(duckdb::DatabaseInstance &db)
+    : db(db), last_request_time(std::chrono::steady_clock::now() - std::chrono::seconds(1)) {
+}
+
+void ENAClient::RespectRateLimit() {
+	std::lock_guard<std::mutex> lock(rate_limit_mutex);
+	auto now = std::chrono::steady_clock::now();
+	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_request_time);
+	auto min_interval = std::chrono::milliseconds(static_cast<int>(1000.0 / RATE_LIMIT));
+	if (elapsed < min_interval) {
+		std::this_thread::sleep_for(min_interval - elapsed);
+	}
+	last_request_time = std::chrono::steady_clock::now();
+}
+
+bool ENAClient::IsRetryableStatus(int status) {
+	return status == 429 || status == 500 || status == 502 || status == 503;
+}
+
+std::string ENAClient::MakeRequest(const std::string &url) {
+	RespectRateLimit();
+
+	duckdb::HTTPHeaders headers(db);
+	auto &http_util = duckdb::HTTPUtil::Get(db);
+	auto params = http_util.InitializeParameters(db, url);
+
+	duckdb::GetRequestInfo get_request(url, headers, *params, nullptr, nullptr);
+	get_request.try_request = true;
+
+	int retry_delay_ms = INITIAL_RETRY_DELAY_MS;
+
+	for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		auto response = http_util.Request(get_request);
+
+		if (response->Success()) {
+			return response->body;
+		}
+
+		if (attempt < MAX_RETRIES && !response->HasRequestError() && IsRetryableStatus(int(response->status))) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
+			retry_delay_ms *= 2;
+			continue;
+		}
+
+		if (response->HasRequestError()) {
+			throw duckdb::IOException("ENA request failed: %s (URL: %s)", response->GetRequestError(), url);
+		}
+		throw duckdb::HTTPException(*response, "ENA request failed with HTTP %d (URL: %s)", int(response->status), url);
+	}
+
+	throw duckdb::IOException("ENA request failed after %d retries (URL: %s)", MAX_RETRIES, url);
+}
+
+std::string ENAClient::Search(const std::string &accession, const std::string &result_type, const std::string &fields) {
+	auto url = ENAParser::BuildSearchURL(accession, result_type, fields);
+	return MakeRequest(url);
+}
+
+std::string ENAClient::FetchXML(const std::vector<std::string> &accessions) {
+	auto url = ENAParser::BuildXMLURL(accessions);
+	return MakeRequest(url);
+}
+
+} // namespace miint

--- a/src/ena_parser.cpp
+++ b/src/ena_parser.cpp
@@ -1,0 +1,302 @@
+#include "ena_parser.hpp"
+#include <expat.h>
+#include <sstream>
+#include <stdexcept>
+
+namespace miint {
+
+// ---- Accession type detection ----
+
+ENAAccessionType ENAParser::DetectAccessionType(const std::string &accession) {
+	if (accession.empty()) {
+		return ENAAccessionType::UNKNOWN;
+	}
+
+	// Study: PRJNA*, PRJEB*, PRJDB*, ERP*, SRP*, DRP*
+	if (accession.rfind("PRJNA", 0) == 0 || accession.rfind("PRJEB", 0) == 0 || accession.rfind("PRJDB", 0) == 0) {
+		return ENAAccessionType::STUDY;
+	}
+	if (accession.rfind("ERP", 0) == 0 || accession.rfind("SRP", 0) == 0 || accession.rfind("DRP", 0) == 0) {
+		return ENAAccessionType::STUDY;
+	}
+
+	// Sample: SAMN*, SAME*, SAMD*
+	if (accession.rfind("SAMN", 0) == 0 || accession.rfind("SAME", 0) == 0 || accession.rfind("SAMD", 0) == 0) {
+		return ENAAccessionType::SAMPLE;
+	}
+
+	// Run: SRR*, ERR*, DRR*
+	if (accession.rfind("SRR", 0) == 0 || accession.rfind("ERR", 0) == 0 || accession.rfind("DRR", 0) == 0) {
+		return ENAAccessionType::RUN;
+	}
+
+	// Experiment: SRX*, ERX*, DRX*
+	if (accession.rfind("SRX", 0) == 0 || accession.rfind("ERX", 0) == 0 || accession.rfind("DRX", 0) == 0) {
+		return ENAAccessionType::EXPERIMENT;
+	}
+
+	return ENAAccessionType::UNKNOWN;
+}
+
+std::string ENAParser::QueryParamForAccessionType(ENAAccessionType type) {
+	switch (type) {
+	case ENAAccessionType::STUDY:
+		return "study_accession";
+	case ENAAccessionType::SAMPLE:
+		return "sample_accession";
+	case ENAAccessionType::RUN:
+		return "run_accession";
+	case ENAAccessionType::EXPERIMENT:
+		return "experiment_accession";
+	default:
+		return "accession";
+	}
+}
+
+// ---- Validation ----
+
+void ENAParser::ValidateAccession(const std::string &accession) {
+	for (char c : accession) {
+		if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' && c != '-' && c != '.') {
+			throw std::invalid_argument("Invalid character in accession: '" + accession + "'");
+		}
+	}
+}
+
+void ENAParser::ValidateFields(const std::string &fields) {
+	for (char c : fields) {
+		if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' && c != ',') {
+			throw std::invalid_argument("Invalid character in fields parameter: '" + fields + "'");
+		}
+	}
+}
+
+// ---- URL construction ----
+
+std::string ENAParser::BuildSearchURL(const std::string &accession, const std::string &result_type,
+                                      const std::string &fields) {
+	ValidateAccession(accession);
+	ValidateFields(fields);
+
+	auto acc_type = DetectAccessionType(accession);
+	auto query_param = QueryParamForAccessionType(acc_type);
+
+	std::ostringstream url;
+	url << PORTAL_BASE << "/search?"
+	    << "result=" << result_type << "&query=" << query_param << "%3D%22" << accession << "%22"
+	    << "&fields=" << fields << "&limit=0&format=tsv";
+	return url.str();
+}
+
+std::string ENAParser::BuildXMLURL(const std::vector<std::string> &accessions) {
+	for (const auto &acc : accessions) {
+		ValidateAccession(acc);
+	}
+
+	std::ostringstream url;
+	url << BROWSER_BASE << "/xml/";
+	for (size_t i = 0; i < accessions.size(); i++) {
+		if (i > 0) {
+			url << ",";
+		}
+		url << accessions[i];
+	}
+	return url.str();
+}
+
+// ---- TSV parsing ----
+
+static std::vector<std::string> SplitTabs(const std::string &line) {
+	std::vector<std::string> fields;
+	std::string::size_type start = 0;
+	while (true) {
+		auto pos = line.find('\t', start);
+		if (pos == std::string::npos) {
+			fields.push_back(line.substr(start));
+			break;
+		}
+		fields.push_back(line.substr(start, pos - start));
+		start = pos + 1;
+	}
+	return fields;
+}
+
+ENATSVResult ENAParser::ParseTSV(const std::string &tsv) {
+	ENATSVResult result;
+	if (tsv.empty()) {
+		return result;
+	}
+
+	std::istringstream stream(tsv);
+	std::string line;
+
+	// First line is header
+	if (!std::getline(stream, line)) {
+		return result;
+	}
+	if (!line.empty() && line.back() == '\r') {
+		line.pop_back();
+	}
+	result.column_names = SplitTabs(line);
+
+	// Remaining lines are data
+	while (std::getline(stream, line)) {
+		if (!line.empty() && line.back() == '\r') {
+			line.pop_back();
+		}
+		if (line.empty()) {
+			continue;
+		}
+		result.rows.push_back(SplitTabs(line));
+	}
+
+	return result;
+}
+
+// ---- XML parsing for sample attributes ----
+
+struct XMLParserState {
+	std::string current_sample_accession;
+	std::string current_tag;
+	std::string current_value;
+	std::string char_buffer;
+	bool in_tag = false;
+	bool in_value = false;
+	std::vector<SampleAttribute> attributes;
+};
+
+static void XMLCALL xml_start_element(void *user_data, const char *name, const char **attrs) {
+	auto *state = static_cast<XMLParserState *>(user_data);
+	std::string elem(name);
+
+	if (elem == "SAMPLE") {
+		for (int i = 0; attrs[i]; i += 2) {
+			if (std::string(attrs[i]) == "accession") {
+				state->current_sample_accession = attrs[i + 1];
+				break;
+			}
+		}
+	} else if (elem == "SAMPLE_ATTRIBUTE") {
+		state->current_tag.clear();
+		state->current_value.clear();
+	} else if (elem == "TAG") {
+		state->in_tag = true;
+		state->char_buffer.clear();
+	} else if (elem == "VALUE") {
+		state->in_value = true;
+		state->char_buffer.clear();
+	}
+}
+
+static void XMLCALL xml_end_element(void *user_data, const char *name) {
+	auto *state = static_cast<XMLParserState *>(user_data);
+	std::string elem(name);
+
+	if (elem == "TAG") {
+		state->current_tag = state->char_buffer;
+		state->in_tag = false;
+	} else if (elem == "VALUE") {
+		state->current_value = state->char_buffer;
+		state->in_value = false;
+	} else if (elem == "SAMPLE_ATTRIBUTE") {
+		if (!state->current_tag.empty()) {
+			state->attributes.push_back({state->current_sample_accession, state->current_tag, state->current_value});
+		}
+	}
+}
+
+static void XMLCALL xml_char_data(void *user_data, const char *s, int len) {
+	auto *state = static_cast<XMLParserState *>(user_data);
+	if (state->in_tag || state->in_value) {
+		state->char_buffer.append(s, static_cast<size_t>(len));
+	}
+}
+
+std::vector<SampleAttribute> ENAParser::ParseSampleAttributesXML(const std::string &xml) {
+	XMLParserState state;
+
+	XML_Parser parser = XML_ParserCreate(nullptr);
+	if (!parser) {
+		throw std::runtime_error("Failed to create XML parser");
+	}
+
+	// RAII guard ensures XML_ParserFree on all exit paths (including exceptions from callbacks)
+	struct ParserGuard {
+		XML_Parser p;
+		~ParserGuard() {
+			XML_ParserFree(p);
+		}
+	} guard {parser};
+
+	XML_SetUserData(parser, &state);
+	XML_SetElementHandler(parser, xml_start_element, xml_end_element);
+	XML_SetCharacterDataHandler(parser, xml_char_data);
+
+	if (XML_Parse(parser, xml.data(), static_cast<int>(xml.size()), XML_TRUE) == XML_STATUS_ERROR) {
+		auto error_msg = std::string(XML_ErrorString(XML_GetErrorCode(parser)));
+		throw std::runtime_error("XML parse error: " + error_msg);
+	}
+
+	return state.attributes;
+}
+
+// ---- FTP to HTTPS ----
+
+std::vector<std::string> ENAParser::FTPtoHTTPS(const std::string &ftp_field) {
+	std::vector<std::string> urls;
+	if (ftp_field.empty()) {
+		return urls;
+	}
+
+	std::string::size_type start = 0;
+	while (true) {
+		auto pos = ftp_field.find(';', start);
+		std::string path;
+		if (pos == std::string::npos) {
+			path = ftp_field.substr(start);
+		} else {
+			path = ftp_field.substr(start, pos - start);
+		}
+		if (!path.empty()) {
+			// Strip ftp:// prefix if present before prepending https://
+			if (path.rfind("ftp://", 0) == 0) {
+				path = path.substr(6);
+			}
+			urls.push_back("https://" + path);
+		}
+		if (pos == std::string::npos) {
+			break;
+		}
+		start = pos + 1;
+	}
+
+	return urls;
+}
+
+// ---- Default fields ----
+
+std::string ENAParser::DefaultFields(const std::string &result_type) {
+	if (result_type == "read_run") {
+		return "run_accession,experiment_accession,sample_accession,study_accession,"
+		       "fastq_ftp,fastq_bytes,fastq_md5,"
+		       "library_strategy,library_source,library_selection,library_layout,library_name,"
+		       "instrument_model,instrument_platform,"
+		       "read_count,base_count,"
+		       "sample_alias,sample_title,scientific_name,tax_id,"
+		       "collection_date,country,lat,lon,depth";
+	}
+	if (result_type == "sample") {
+		return "sample_accession,secondary_sample_accession,sample_alias,sample_title,"
+		       "description,scientific_name,tax_id,tax_lineage,"
+		       "collection_date,country,lat,lon,depth,"
+		       "environment_biome,environment_feature,environment_material,"
+		       "host,isolation_source";
+	}
+	if (result_type == "study") {
+		return "study_accession,secondary_study_accession,study_title,study_description,"
+		       "center_name,first_public,last_updated,scientific_name,tax_id";
+	}
+	return "";
+}
+
+} // namespace miint

--- a/src/include/duckdb_seq_stream.hpp
+++ b/src/include/duckdb_seq_stream.hpp
@@ -45,3 +45,12 @@ using DuckDBSeqStreamIn = klibpp::KStreamIn<DuckDBSeqStream *, int (*)(DuckDBSeq
 #endif // MIINT_STATIC_BUILD
 
 } // namespace miint
+
+#ifdef MIINT_STATIC_BUILD
+namespace duckdb {
+// Create a DuckDBSeqStream for reading a remote (or local) file through DuckDB's FileSystem.
+// Handles gzip detection and decompression initialization.
+// Caller takes ownership of the returned pointer (kseq++ close callback deletes it).
+miint::DuckDBSeqStream *CreateDuckDBSeqStream(FileSystem &fs, const std::string &path);
+} // namespace duckdb
+#endif

--- a/src/include/ena_client.hpp
+++ b/src/include/ena_client.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "ena_parser.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/main/database.hpp"
+#include <chrono>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace miint {
+
+// HTTP client for EBI/ENA APIs.
+// For parsing utilities, use ENAParser directly (ena_parser.hpp).
+//
+// Rate Limiting: ~3 requests/second (no API key required)
+// Retry: HTTP 429, 500, 502, 503 with exponential backoff
+class ENAClient {
+public:
+	static constexpr double RATE_LIMIT = 3.0;
+	static constexpr int MAX_RETRIES = 3;
+	static constexpr int INITIAL_RETRY_DELAY_MS = 1000;
+
+	ENAClient(duckdb::DatabaseInstance &db);
+
+	// HTTP methods — build URL via ENAParser, then fetch
+	std::string Search(const std::string &accession, const std::string &result_type, const std::string &fields);
+	std::string FetchXML(const std::vector<std::string> &accessions);
+
+private:
+	duckdb::DatabaseInstance &db;
+	std::chrono::steady_clock::time_point last_request_time;
+	mutable std::mutex rate_limit_mutex;
+
+	std::string MakeRequest(const std::string &url);
+	static bool IsRetryableStatus(int status);
+	void RespectRateLimit();
+};
+
+} // namespace miint

--- a/src/include/ena_parser.hpp
+++ b/src/include/ena_parser.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace miint {
+
+enum class ENAAccessionType { STUDY, SAMPLE, RUN, EXPERIMENT, UNKNOWN };
+
+struct SampleAttribute {
+	std::string sample_accession;
+	std::string tag;
+	std::string value;
+};
+
+struct ENATSVResult {
+	std::vector<std::string> column_names;
+	std::vector<std::vector<std::string>> rows;
+};
+
+// Pure parsing and URL construction utilities for ENA APIs.
+// No network dependencies — safe for unit tests.
+class ENAParser {
+public:
+	static ENAAccessionType DetectAccessionType(const std::string &accession);
+	static std::string QueryParamForAccessionType(ENAAccessionType type);
+
+	// Validate that accession contains only safe characters (alphanumeric, underscore, hyphen, dot)
+	static void ValidateAccession(const std::string &accession);
+	// Validate that fields contain only safe characters (alphanumeric, underscore, comma)
+	static void ValidateFields(const std::string &fields);
+
+	// URL construction
+	static std::string BuildSearchURL(const std::string &accession, const std::string &result_type,
+	                                  const std::string &fields);
+	static std::string BuildXMLURL(const std::vector<std::string> &accessions);
+
+	// Parsing
+	static ENATSVResult ParseTSV(const std::string &tsv);
+	static std::vector<SampleAttribute> ParseSampleAttributesXML(const std::string &xml);
+
+	// Helpers
+	static std::vector<std::string> FTPtoHTTPS(const std::string &ftp_field);
+	static std::string DefaultFields(const std::string &result_type);
+
+	// Base URLs
+	static constexpr const char *PORTAL_BASE = "https://www.ebi.ac.uk/ena/portal/api";
+	static constexpr const char *BROWSER_BASE = "https://www.ebi.ac.uk/ena/browser/api";
+};
+
+} // namespace miint

--- a/src/include/read_ena.hpp
+++ b/src/include/read_ena.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "ena_client.hpp"
+#include "ena_parser.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <mutex>
+#include <vector>
+
+namespace duckdb {
+
+class ReadENATableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::vector<std::string> accessions;
+		std::string result_type;
+		std::string fields;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data(std::vector<std::string> accessions, const std::string &result_type, const std::string &fields);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		mutex lock;
+		unique_ptr<miint::ENAClient> client;
+		// Rows reordered to match the schema column order
+		std::vector<std::vector<std::string>> rows;
+		size_t next_accession_idx;
+		size_t row_offset;
+
+		GlobalState(DatabaseInstance &db, const std::vector<std::string> &accessions, const std::string &result_type,
+		            const std::string &fields, const std::vector<std::string> &schema_names);
+
+		bool FetchNextAccession();
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+
+	private:
+		std::vector<std::string> accessions;
+		std::string result_type;
+		std::string fields;
+		std::vector<std::string> schema_names; // Column order from user's fields param
+	};
+
+	struct LocalState : public LocalTableFunctionState {};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/read_ena_attributes.hpp
+++ b/src/include/read_ena_attributes.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "ena_client.hpp"
+#include "ena_parser.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <mutex>
+#include <vector>
+
+namespace duckdb {
+
+class ReadENAAttributesTableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::vector<std::string> accessions;
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data(std::vector<std::string> accessions);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		mutex lock;
+		unique_ptr<miint::ENAClient> client;
+		std::vector<miint::SampleAttribute> attributes;
+		size_t row_offset;
+		bool fetched;
+
+		GlobalState(DatabaseInstance &db);
+
+		void FetchAttributes(const std::vector<std::string> &accessions);
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+
+	private:
+		std::vector<std::string> ResolveSampleAccessions(const std::vector<std::string> &accessions);
+	};
+
+	struct LocalState : public LocalTableFunctionState {};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/read_ena_fastq.hpp
+++ b/src/include/read_ena_fastq.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "SequenceReader.hpp"
+#include "duckdb_seq_stream.hpp"
+#include "ena_client.hpp"
+#include "ena_parser.hpp"
+#include "remote_file_helper.hpp"
+#include "table_function_common.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <atomic>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace duckdb {
+
+class ReadENAFastqTableFunction {
+public:
+	struct RunInfo {
+		std::string run_accession;
+		std::string sample_accession;
+		std::string experiment_accession;
+		std::vector<std::string> fastq_urls; // 1 for single-end, 2 for paired-end
+		bool is_paired;
+	};
+
+	struct Data : public TableFunctionData {
+		std::vector<RunInfo> runs;
+		bool include_filepath;
+		uint8_t qual_offset;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data(std::vector<RunInfo> runs, bool include_fp, uint8_t offset);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		mutex lock;
+		std::vector<std::unique_ptr<miint::SequenceReader>> readers;
+		std::vector<RunInfo> runs;
+		size_t next_run_idx;
+		std::vector<uint64_t> run_sequence_counters;
+
+		idx_t MaxThreads() const override {
+			return std::min<idx_t>(readers.size(), 8);
+		}
+
+		GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs);
+	};
+
+	struct LocalState : public LocalTableFunctionState {
+		size_t current_run_idx;
+		bool has_run;
+
+		LocalState() : current_run_idx(0), has_run(false) {
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/read_fastx.hpp
+++ b/src/include/read_fastx.hpp
@@ -80,10 +80,10 @@ public:
 
 				if (r1_remote || r2_remote) {
 					// Stream via DuckDB FileHandle for remote paths
-					auto *s1 = CreateDuckDBStream(fs, sequence1_paths[i]);
+					auto *s1 = CreateDuckDBSeqStream(fs, sequence1_paths[i]);
 					miint::DuckDBSeqStream *s2 = nullptr;
 					if (sequence2_paths.has_value()) {
-						s2 = CreateDuckDBStream(fs, sequence2_paths.value()[i]);
+						s2 = CreateDuckDBSeqStream(fs, sequence2_paths.value()[i]);
 					}
 					readers.push_back(std::make_unique<miint::SequenceReader>(s1, s2));
 				} else if (sequence2_paths.has_value()) {
@@ -94,22 +94,6 @@ public:
 				}
 				file_sequence_counters.emplace_back(1);
 			}
-		}
-
-	private:
-		static miint::DuckDBSeqStream *CreateDuckDBStream(FileSystem &fs, const std::string &path) {
-			auto *stream = new miint::DuckDBSeqStream();
-			auto handle = fs.OpenFile(path, FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ));
-			stream->handle = std::shared_ptr<FileHandle>(handle.release());
-			stream->is_gzipped = IsGzipped(path);
-			if (stream->is_gzipped) {
-				if (inflateInit2(&stream->zs, 16 + MAX_WBITS) != Z_OK) {
-					delete stream;
-					throw IOException("Failed to initialize zlib for: " + path);
-				}
-				stream->zs_initialized = true;
-			}
-			return stream;
 		}
 	};
 

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -25,6 +25,9 @@
 #include <read_ncbi_fasta.hpp>
 #include <read_ncbi.hpp>
 #include <read_ncbi_annotation.hpp>
+#include <read_ena.hpp>
+#include <read_ena_attributes.hpp>
+#include <read_ena_fastq.hpp>
 #include <miint_macros.hpp>
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/database.hpp"
@@ -187,6 +190,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ReadNCBIFastaTableFunction::Register(loader);
 	ReadNCBITableFunction::Register(loader);
 	ReadNCBIAnnotationTableFunction::Register(loader);
+	ReadENATableFunction::Register(loader);
+	ReadENAAttributesTableFunction::Register(loader);
+	ReadENAFastqTableFunction::Register(loader);
 
 	AlignmentFlagFunctions::Register(loader);
 	AlignmentSeqIdentityFunction::Register(loader);

--- a/src/read_ena.cpp
+++ b/src/read_ena.cpp
@@ -1,0 +1,279 @@
+#include "read_ena.hpp"
+#include "duckdb/common/vector_size.hpp"
+#include <algorithm>
+
+namespace duckdb {
+
+// ---- Helpers ----
+
+static std::string TrimWhitespace(const std::string &s) {
+	auto start = s.find_first_not_of(" \t\n\r");
+	if (start == std::string::npos) {
+		return "";
+	}
+	auto end = s.find_last_not_of(" \t\n\r");
+	return s.substr(start, end - start + 1);
+}
+
+// Find a column value by name in a parsed TSV result.
+static std::string FindColumnValue(const miint::ENATSVResult &parsed, const std::string &column_name) {
+	for (size_t i = 0; i < parsed.column_names.size(); i++) {
+		if (parsed.column_names[i] == column_name && !parsed.rows.empty() && i < parsed.rows[0].size()) {
+			return parsed.rows[0][i];
+		}
+	}
+	return "";
+}
+
+// Resolve an accession to the correct query accession for a given result type.
+static std::string ResolveAccession(miint::ENAClient &client, const std::string &accession,
+                                    const std::string &result_type) {
+	auto acc_type = miint::ENAParser::DetectAccessionType(accession);
+
+	if (result_type == "read_run") {
+		return accession;
+	}
+
+	if (result_type == "sample") {
+		if (acc_type == miint::ENAAccessionType::SAMPLE || acc_type == miint::ENAAccessionType::STUDY) {
+			return accession;
+		}
+		auto tsv = client.Search(accession, "read_run", "sample_accession");
+		auto parsed = miint::ENAParser::ParseTSV(tsv);
+		auto resolved = FindColumnValue(parsed, "sample_accession");
+		if (!resolved.empty()) {
+			return resolved;
+		}
+		throw IOException("read_ena: could not resolve '%s' to a sample accession", accession);
+	}
+
+	if (result_type == "study") {
+		if (acc_type == miint::ENAAccessionType::STUDY) {
+			return accession;
+		}
+		auto tsv = client.Search(accession, "read_run", "study_accession");
+		auto parsed = miint::ENAParser::ParseTSV(tsv);
+		auto resolved = FindColumnValue(parsed, "study_accession");
+		if (!resolved.empty()) {
+			return resolved;
+		}
+		throw IOException("read_ena: could not resolve '%s' to a study accession", accession);
+	}
+
+	return accession;
+}
+
+// Reorder a TSV row to match the schema column order.
+// ENA returns columns in its own order; we need them in the user-requested order.
+static std::vector<std::string> ReorderRow(const std::vector<std::string> &row,
+                                           const std::vector<std::string> &tsv_column_names,
+                                           const std::vector<int> &column_map) {
+	std::vector<std::string> reordered(column_map.size());
+	for (size_t i = 0; i < column_map.size(); i++) {
+		int src_idx = column_map[i];
+		if (src_idx >= 0 && src_idx < static_cast<int>(row.size())) {
+			reordered[i] = row[src_idx];
+		}
+	}
+	return reordered;
+}
+
+// Build a mapping from schema column positions to TSV column positions.
+static std::vector<int> BuildColumnMap(const std::vector<std::string> &schema_names,
+                                       const std::vector<std::string> &tsv_column_names) {
+	std::vector<int> map;
+	for (const auto &name : schema_names) {
+		int found = -1;
+		for (size_t i = 0; i < tsv_column_names.size(); i++) {
+			if (tsv_column_names[i] == name) {
+				found = static_cast<int>(i);
+				break;
+			}
+		}
+		map.push_back(found);
+	}
+	return map;
+}
+
+// ---- Data ----
+
+ReadENATableFunction::Data::Data(std::vector<std::string> accessions, const std::string &result_type,
+                                 const std::string &fields)
+    : accessions(std::move(accessions)), result_type(result_type), fields(fields) {
+	// Column names from the user-specified fields string (comma-separated)
+	std::istringstream stream(fields);
+	std::string field;
+	while (std::getline(stream, field, ',')) {
+		names.push_back(field);
+		types.push_back(LogicalType::VARCHAR);
+	}
+}
+
+// ---- GlobalState ----
+
+ReadENATableFunction::GlobalState::GlobalState(DatabaseInstance &db, const std::vector<std::string> &accessions,
+                                               const std::string &result_type, const std::string &fields,
+                                               const std::vector<std::string> &schema_names)
+    : client(make_uniq<miint::ENAClient>(db)), next_accession_idx(0), row_offset(0), accessions(accessions),
+      result_type(result_type), fields(fields), schema_names(schema_names) {
+}
+
+bool ReadENATableFunction::GlobalState::FetchNextAccession() {
+	if (next_accession_idx >= accessions.size()) {
+		return false;
+	}
+
+	const auto &accession = accessions[next_accession_idx];
+	next_accession_idx++;
+
+	auto resolved = ResolveAccession(*client, accession, result_type);
+	auto tsv_body = client->Search(resolved, result_type, fields);
+	auto parsed = miint::ENAParser::ParseTSV(tsv_body);
+
+	// Clear previously consumed rows to avoid unbounded memory growth
+	rows.clear();
+	row_offset = 0;
+
+	// Reorder each row to match the schema column order
+	auto column_map = BuildColumnMap(schema_names, parsed.column_names);
+	for (auto &row : parsed.rows) {
+		rows.push_back(ReorderRow(row, parsed.column_names, column_map));
+	}
+
+	return true;
+}
+
+// ---- Bind ----
+
+unique_ptr<FunctionData> ReadENATableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<std::string> &names) {
+	std::vector<std::string> accessions;
+	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
+		accessions.push_back(input.inputs[0].ToString());
+	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
+		auto &list_children = ListValue::GetChildren(input.inputs[0]);
+		for (const auto &child : list_children) {
+			accessions.push_back(child.ToString());
+		}
+	} else {
+		throw InvalidInputException("read_ena: first argument must be VARCHAR or VARCHAR[]");
+	}
+
+	if (accessions.empty()) {
+		throw InvalidInputException("read_ena: at least one accession must be provided");
+	}
+	for (auto &acc : accessions) {
+		acc = TrimWhitespace(acc);
+		if (acc.empty()) {
+			throw InvalidInputException("read_ena: accession cannot be empty");
+		}
+	}
+
+	// Parse result type (default: read_run)
+	std::string result_type = "read_run";
+	auto result_param = input.named_parameters.find("result");
+	if (result_param != input.named_parameters.end() && !result_param->second.IsNull()) {
+		result_type = result_param->second.ToString();
+		if (result_type != "read_run" && result_type != "sample" && result_type != "study") {
+			throw InvalidInputException("read_ena: result must be one of: read_run, sample, study");
+		}
+	}
+
+	// Parse fields (default: from ENAParser::DefaultFields)
+	std::string fields;
+	auto fields_param = input.named_parameters.find("fields");
+	if (fields_param != input.named_parameters.end() && !fields_param->second.IsNull()) {
+		fields = fields_param->second.ToString();
+	} else {
+		fields = miint::ENAParser::DefaultFields(result_type);
+	}
+
+	if (fields.empty()) {
+		throw InvalidInputException("read_ena: fields parameter cannot be empty");
+	}
+
+	auto data = make_uniq<Data>(std::move(accessions), result_type, fields);
+
+	for (auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+// ---- InitGlobal / InitLocal ----
+
+unique_ptr<GlobalTableFunctionState> ReadENATableFunction::InitGlobal(ClientContext &context,
+                                                                      TableFunctionInitInput &input) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto &db = DatabaseInstance::GetDatabase(context);
+	return make_uniq<GlobalState>(db, data.accessions, data.result_type, data.fields, data.names);
+}
+
+unique_ptr<LocalTableFunctionState> ReadENATableFunction::InitLocal(ExecutionContext &context,
+                                                                    TableFunctionInitInput &input,
+                                                                    GlobalTableFunctionState *global_state) {
+	return make_uniq<LocalState>();
+}
+
+// ---- Execute ----
+
+void ReadENATableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &global_state = data_p.global_state->Cast<GlobalState>();
+
+	lock_guard<mutex> guard(global_state.lock);
+
+	while (global_state.row_offset >= global_state.rows.size()) {
+		if (!global_state.FetchNextAccession()) {
+			output.SetCardinality(0);
+			return;
+		}
+	}
+
+	idx_t remaining = global_state.rows.size() - global_state.row_offset;
+	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+
+	auto &rows = global_state.rows;
+	size_t offset = global_state.row_offset;
+	idx_t num_cols = bind_data.names.size();
+
+	for (idx_t col = 0; col < num_cols; col++) {
+		auto col_data = FlatVector::GetData<string_t>(output.data[col]);
+		auto &validity = FlatVector::Validity(output.data[col]);
+		for (idx_t i = 0; i < count; i++) {
+			auto &row = rows[offset + i];
+			if (col < row.size()) {
+				const auto &val = row[col];
+				if (val.empty()) {
+					validity.SetInvalid(i);
+				} else {
+					col_data[i] = StringVector::AddString(output.data[col], val);
+				}
+			} else {
+				validity.SetInvalid(i);
+			}
+		}
+	}
+
+	global_state.row_offset += count;
+	output.SetCardinality(count);
+}
+
+// ---- Registration ----
+
+TableFunction ReadENATableFunction::GetFunction() {
+	auto tf = TableFunction("read_ena", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
+	tf.named_parameters["result"] = LogicalType::VARCHAR;
+	tf.named_parameters["fields"] = LogicalType::VARCHAR;
+	return tf;
+}
+
+void ReadENATableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/read_ena_attributes.cpp
+++ b/src/read_ena_attributes.cpp
@@ -1,0 +1,212 @@
+#include "read_ena_attributes.hpp"
+#include "duckdb/common/vector_size.hpp"
+
+namespace duckdb {
+
+// ---- Data ----
+
+ReadENAAttributesTableFunction::Data::Data(std::vector<std::string> accessions)
+    : accessions(std::move(accessions)), names({"sample_accession", "tag", "value"}),
+      types({LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}) {
+}
+
+// ---- GlobalState ----
+
+ReadENAAttributesTableFunction::GlobalState::GlobalState(DatabaseInstance &db)
+    : client(make_uniq<miint::ENAClient>(db)), row_offset(0), fetched(false) {
+}
+
+std::vector<std::string>
+ReadENAAttributesTableFunction::GlobalState::ResolveSampleAccessions(const std::vector<std::string> &accessions) {
+	std::vector<std::string> sample_accs;
+
+	for (const auto &acc : accessions) {
+		auto acc_type = miint::ENAParser::DetectAccessionType(acc);
+
+		if (acc_type == miint::ENAAccessionType::SAMPLE) {
+			sample_accs.push_back(acc);
+		} else if (acc_type == miint::ENAAccessionType::STUDY) {
+			// Get all sample accessions for the study
+			auto tsv = client->Search(acc, "sample", "sample_accession");
+			auto parsed = miint::ENAParser::ParseTSV(tsv);
+			for (size_t i = 0; i < parsed.column_names.size(); i++) {
+				if (parsed.column_names[i] == "sample_accession") {
+					for (const auto &row : parsed.rows) {
+						if (i < row.size() && !row[i].empty()) {
+							sample_accs.push_back(row[i]);
+						}
+					}
+					break;
+				}
+			}
+		} else {
+			// Run or experiment: resolve to sample_accession via read_run
+			auto tsv = client->Search(acc, "read_run", "sample_accession");
+			auto parsed = miint::ENAParser::ParseTSV(tsv);
+			for (size_t i = 0; i < parsed.column_names.size(); i++) {
+				if (parsed.column_names[i] == "sample_accession") {
+					for (const auto &row : parsed.rows) {
+						if (i < row.size() && !row[i].empty()) {
+							sample_accs.push_back(row[i]);
+						}
+					}
+					break;
+				}
+			}
+		}
+	}
+
+	return sample_accs;
+}
+
+void ReadENAAttributesTableFunction::GlobalState::FetchAttributes(const std::vector<std::string> &accessions) {
+	// Mark as fetched immediately to avoid infinite retry loops on network errors
+	fetched = true;
+
+	auto sample_accs = ResolveSampleAccessions(accessions);
+
+	if (sample_accs.empty()) {
+		return;
+	}
+
+	// NOTE: This materializes all attributes before returning any rows.
+	// For large studies (thousands of samples), this may use significant memory
+	// and block until all XML batches are fetched. A streaming approach would
+	// be better for very large studies.
+	static constexpr size_t BATCH_SIZE = 50;
+	for (size_t start = 0; start < sample_accs.size(); start += BATCH_SIZE) {
+		size_t end = std::min(start + BATCH_SIZE, sample_accs.size());
+		std::vector<std::string> batch(sample_accs.begin() + start, sample_accs.begin() + end);
+
+		auto xml = client->FetchXML(batch);
+		auto batch_attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
+
+		for (auto &attr : batch_attrs) {
+			attributes.push_back(std::move(attr));
+		}
+	}
+}
+
+// ---- Bind ----
+
+unique_ptr<FunctionData> ReadENAAttributesTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                              vector<LogicalType> &return_types,
+                                                              vector<std::string> &names) {
+	std::vector<std::string> accessions;
+	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
+		accessions.push_back(input.inputs[0].ToString());
+	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
+		auto &list_children = ListValue::GetChildren(input.inputs[0]);
+		for (const auto &child : list_children) {
+			accessions.push_back(child.ToString());
+		}
+	} else {
+		throw InvalidInputException("read_ena_attributes: first argument must be VARCHAR or VARCHAR[]");
+	}
+
+	if (accessions.empty()) {
+		throw InvalidInputException("read_ena_attributes: at least one accession must be provided");
+	}
+	for (auto &acc : accessions) {
+		// Trim whitespace
+		auto start = acc.find_first_not_of(" \t\n\r");
+		if (start == std::string::npos) {
+			acc.clear();
+		} else {
+			acc = acc.substr(start, acc.find_last_not_of(" \t\n\r") - start + 1);
+		}
+		if (acc.empty()) {
+			throw InvalidInputException("read_ena_attributes: accession cannot be empty");
+		}
+	}
+
+	auto data = make_uniq<Data>(std::move(accessions));
+
+	for (auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+// ---- InitGlobal / InitLocal ----
+
+unique_ptr<GlobalTableFunctionState> ReadENAAttributesTableFunction::InitGlobal(ClientContext &context,
+                                                                                TableFunctionInitInput &input) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	return make_uniq<GlobalState>(db);
+}
+
+unique_ptr<LocalTableFunctionState> ReadENAAttributesTableFunction::InitLocal(ExecutionContext &context,
+                                                                              TableFunctionInitInput &input,
+                                                                              GlobalTableFunctionState *global_state) {
+	return make_uniq<LocalState>();
+}
+
+// ---- Execute ----
+
+void ReadENAAttributesTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &global_state = data_p.global_state->Cast<GlobalState>();
+
+	lock_guard<mutex> guard(global_state.lock);
+
+	// Fetch all attributes on first call
+	if (!global_state.fetched) {
+		global_state.FetchAttributes(bind_data.accessions);
+	}
+
+	if (global_state.row_offset >= global_state.attributes.size()) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	idx_t remaining = global_state.attributes.size() - global_state.row_offset;
+	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+
+	auto &attrs = global_state.attributes;
+	size_t offset = global_state.row_offset;
+
+	// sample_accession (column 0)
+	auto acc_data = FlatVector::GetData<string_t>(output.data[0]);
+	for (idx_t i = 0; i < count; i++) {
+		acc_data[i] = StringVector::AddString(output.data[0], attrs[offset + i].sample_accession);
+	}
+
+	// tag (column 1)
+	auto tag_data = FlatVector::GetData<string_t>(output.data[1]);
+	for (idx_t i = 0; i < count; i++) {
+		tag_data[i] = StringVector::AddString(output.data[1], attrs[offset + i].tag);
+	}
+
+	// value (column 2)
+	auto val_data = FlatVector::GetData<string_t>(output.data[2]);
+	auto &val_validity = FlatVector::Validity(output.data[2]);
+	for (idx_t i = 0; i < count; i++) {
+		const auto &val = attrs[offset + i].value;
+		if (val.empty()) {
+			val_validity.SetInvalid(i);
+		} else {
+			val_data[i] = StringVector::AddString(output.data[2], val);
+		}
+	}
+
+	global_state.row_offset += count;
+	output.SetCardinality(count);
+}
+
+// ---- Registration ----
+
+TableFunction ReadENAAttributesTableFunction::GetFunction() {
+	auto tf = TableFunction("read_ena_attributes", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
+	return tf;
+}
+
+void ReadENAAttributesTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/read_ena_fastq.cpp
+++ b/src/read_ena_fastq.cpp
@@ -1,0 +1,272 @@
+#include "read_ena_fastq.hpp"
+#include "SequenceRecord.hpp"
+#include "duckdb/common/vector_size.hpp"
+
+namespace duckdb {
+
+// ---- Data ----
+
+ReadENAFastqTableFunction::Data::Data(std::vector<RunInfo> runs, bool include_fp, uint8_t offset)
+    : runs(std::move(runs)), include_filepath(include_fp), qual_offset(offset),
+      names({"sequence_index", "read_id", "comment", "sequence1", "sequence2", "qual1", "qual2", "run_accession",
+             "sample_accession", "experiment_accession"}),
+      types({LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
+             LogicalType::VARCHAR, LogicalType::LIST(LogicalType::UTINYINT), LogicalType::LIST(LogicalType::UTINYINT),
+             LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR}) {
+	if (include_filepath) {
+		names.emplace_back("filepath");
+		types.emplace_back(LogicalType::VARCHAR);
+	}
+}
+
+// ---- GlobalState ----
+
+ReadENAFastqTableFunction::GlobalState::GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs)
+    : runs(runs), next_run_idx(0) {
+	for (const auto &run : runs) {
+		if (run.fastq_urls.empty()) {
+			throw IOException("read_ena_fastq: no FASTQ URLs available for run '%s'", run.run_accession);
+		}
+
+		auto *s1 = CreateDuckDBSeqStream(fs, run.fastq_urls[0]);
+		miint::DuckDBSeqStream *s2 = nullptr;
+		if (run.is_paired && run.fastq_urls.size() >= 2) {
+			s2 = CreateDuckDBSeqStream(fs, run.fastq_urls[1]);
+		}
+		readers.push_back(std::make_unique<miint::SequenceReader>(s1, s2));
+		run_sequence_counters.emplace_back(1);
+	}
+}
+
+// ---- Bind ----
+
+// Resolve accessions to run info via ENA Portal API
+static std::vector<ReadENAFastqTableFunction::RunInfo> ResolveRuns(miint::ENAClient &client,
+                                                                   const std::vector<std::string> &accessions) {
+	std::vector<ReadENAFastqTableFunction::RunInfo> runs;
+
+	for (const auto &acc : accessions) {
+		auto tsv = client.Search(acc, "read_run",
+		                         "run_accession,sample_accession,experiment_accession,fastq_ftp,library_layout");
+		auto parsed = miint::ENAParser::ParseTSV(tsv);
+
+		// Find column indices by name
+		int run_col = -1, sample_col = -1, exp_col = -1, ftp_col = -1, layout_col = -1;
+		for (size_t i = 0; i < parsed.column_names.size(); i++) {
+			if (parsed.column_names[i] == "run_accession")
+				run_col = static_cast<int>(i);
+			else if (parsed.column_names[i] == "sample_accession")
+				sample_col = static_cast<int>(i);
+			else if (parsed.column_names[i] == "experiment_accession")
+				exp_col = static_cast<int>(i);
+			else if (parsed.column_names[i] == "fastq_ftp")
+				ftp_col = static_cast<int>(i);
+			else if (parsed.column_names[i] == "library_layout")
+				layout_col = static_cast<int>(i);
+		}
+
+		for (const auto &row : parsed.rows) {
+			ReadENAFastqTableFunction::RunInfo info;
+			info.run_accession = (run_col >= 0 && run_col < (int)row.size()) ? row[run_col] : "";
+			info.sample_accession = (sample_col >= 0 && sample_col < (int)row.size()) ? row[sample_col] : "";
+			info.experiment_accession = (exp_col >= 0 && exp_col < (int)row.size()) ? row[exp_col] : "";
+
+			std::string ftp_field = (ftp_col >= 0 && ftp_col < (int)row.size()) ? row[ftp_col] : "";
+			info.fastq_urls = miint::ENAParser::FTPtoHTTPS(ftp_field);
+
+			std::string layout = (layout_col >= 0 && layout_col < (int)row.size()) ? row[layout_col] : "";
+			info.is_paired = (layout == "PAIRED");
+
+			if (!info.fastq_urls.empty()) {
+				runs.push_back(std::move(info));
+			}
+		}
+	}
+
+	return runs;
+}
+
+unique_ptr<FunctionData> ReadENAFastqTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                         vector<LogicalType> &return_types,
+                                                         vector<std::string> &names) {
+	std::vector<std::string> accessions;
+	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
+		accessions.push_back(input.inputs[0].ToString());
+	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
+		auto &list_children = ListValue::GetChildren(input.inputs[0]);
+		for (const auto &child : list_children) {
+			accessions.push_back(child.ToString());
+		}
+	} else {
+		throw InvalidInputException("read_ena_fastq: first argument must be VARCHAR or VARCHAR[]");
+	}
+
+	if (accessions.empty()) {
+		throw InvalidInputException("read_ena_fastq: at least one accession must be provided");
+	}
+	for (auto &acc : accessions) {
+		// Trim whitespace
+		auto start = acc.find_first_not_of(" \t\n\r");
+		if (start == std::string::npos) {
+			acc.clear();
+		} else {
+			acc = acc.substr(start, acc.find_last_not_of(" \t\n\r") - start + 1);
+		}
+		if (acc.empty()) {
+			throw InvalidInputException("read_ena_fastq: accession cannot be empty");
+		}
+	}
+
+	bool include_filepath = false;
+	auto fp_param = input.named_parameters.find("include_filepath");
+	if (fp_param != input.named_parameters.end() && !fp_param->second.IsNull()) {
+		include_filepath = fp_param->second.GetValue<bool>();
+	}
+
+	uint8_t qual_offset = 33;
+	auto qo_param = input.named_parameters.find("qual_offset");
+	if (qo_param != input.named_parameters.end() && !qo_param->second.IsNull()) {
+		qual_offset = static_cast<uint8_t>(qo_param->second.GetValue<int64_t>());
+	}
+
+	// Resolve accessions to run info via ENA Portal API
+	auto &db = DatabaseInstance::GetDatabase(context);
+	miint::ENAClient client(db);
+	auto runs = ResolveRuns(client, accessions);
+
+	if (runs.empty()) {
+		throw IOException("read_ena_fastq: no FASTQ data found for the provided accession(s)");
+	}
+
+	auto data = make_uniq<Data>(std::move(runs), include_filepath, qual_offset);
+
+	for (auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+// ---- InitGlobal / InitLocal ----
+
+unique_ptr<GlobalTableFunctionState> ReadENAFastqTableFunction::InitGlobal(ClientContext &context,
+                                                                           TableFunctionInitInput &input) {
+	auto &data = input.bind_data->Cast<Data>();
+	FileSystem &fs = FileSystem::GetFileSystem(context);
+	return make_uniq<GlobalState>(fs, data.runs);
+}
+
+unique_ptr<LocalTableFunctionState> ReadENAFastqTableFunction::InitLocal(ExecutionContext &context,
+                                                                         TableFunctionInitInput &input,
+                                                                         GlobalTableFunctionState *global_state) {
+	return make_uniq<LocalState>();
+}
+
+// ---- Execute ----
+
+void ReadENAFastqTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &global_state = data_p.global_state->Cast<GlobalState>();
+	auto &local_state = data_p.local_state->Cast<LocalState>();
+
+	miint::SequenceRecordBatch batch;
+	size_t current_run_idx;
+
+	// Claim-read-release loop (same pattern as read_fastx)
+	while (true) {
+		if (!local_state.has_run) {
+			lock_guard<mutex> read_lock(global_state.lock);
+			if (global_state.next_run_idx >= global_state.readers.size()) {
+				output.SetCardinality(0);
+				return;
+			}
+			local_state.current_run_idx = global_state.next_run_idx;
+			global_state.next_run_idx++;
+			local_state.has_run = true;
+		}
+
+		current_run_idx = local_state.current_run_idx;
+		batch = global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
+
+		if (batch.empty()) {
+			local_state.has_run = false;
+			continue;
+		}
+		break;
+	}
+
+	idx_t count = batch.size();
+	idx_t field_idx = 0;
+	const auto &run = global_state.runs[current_run_idx];
+	auto &seq_counter = global_state.run_sequence_counters[current_run_idx];
+
+	// sequence_index (column 0)
+	auto seq_idx_data = FlatVector::GetData<int64_t>(output.data[field_idx++]);
+	for (idx_t i = 0; i < count; i++) {
+		seq_idx_data[i] = static_cast<int64_t>(seq_counter++);
+	}
+
+	// read_id (column 1)
+	SetResultVectorString(output.data[field_idx++], batch.read_ids);
+
+	// comment (column 2)
+	SetResultVectorStringNullable(output.data[field_idx++], batch.comments);
+
+	// sequence1 (column 3)
+	SetResultVectorString(output.data[field_idx++], batch.sequences1);
+
+	// sequence2 (column 4)
+	if (batch.is_paired) {
+		SetResultVectorString(output.data[field_idx++], batch.sequences2);
+	} else {
+		SetResultVectorNull(output.data[field_idx++]);
+	}
+
+	// qual1 (column 5)
+	SetResultVectorListUInt8(output.data[field_idx++], batch.quals1, bind_data.qual_offset);
+
+	// qual2 (column 6)
+	if (batch.is_paired) {
+		SetResultVectorListUInt8(output.data[field_idx++], batch.quals2, bind_data.qual_offset);
+	} else {
+		SetResultVectorNull(output.data[field_idx++]);
+	}
+
+	// run_accession (column 7) - constant for all rows in this chunk
+	SetResultVectorFilepath(output.data[field_idx++], run.run_accession);
+
+	// sample_accession (column 8) - constant
+	SetResultVectorFilepath(output.data[field_idx++], run.sample_accession);
+
+	// experiment_accession (column 9) - constant
+	SetResultVectorFilepath(output.data[field_idx++], run.experiment_accession);
+
+	// filepath (column 10) - optional, semicolon-separated for paired-end
+	if (bind_data.include_filepath) {
+		std::string filepath = run.fastq_urls[0];
+		for (size_t u = 1; u < run.fastq_urls.size(); u++) {
+			filepath += ";" + run.fastq_urls[u];
+		}
+		SetResultVectorFilepath(output.data[field_idx++], filepath);
+	}
+
+	output.SetCardinality(count);
+}
+
+// ---- Registration ----
+
+TableFunction ReadENAFastqTableFunction::GetFunction() {
+	auto tf = TableFunction("read_ena_fastq", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
+	tf.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
+	tf.named_parameters["qual_offset"] = LogicalType::BIGINT;
+	return tf;
+}
+
+void ReadENAFastqTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/test/cpp/test_ENAClient.cpp
+++ b/test/cpp/test_ENAClient.cpp
@@ -1,0 +1,339 @@
+#include <catch2/catch_test_macros.hpp>
+#include "ena_parser.hpp"
+
+// ---- Step 1.1: Accession type detection ----
+
+TEST_CASE("ENAClient accession type detection", "[ena]") {
+	SECTION("Study accessions") {
+		CHECK(miint::ENAParser::DetectAccessionType("PRJNA555783") == miint::ENAAccessionType::STUDY);
+		CHECK(miint::ENAParser::DetectAccessionType("PRJEB5291") == miint::ENAAccessionType::STUDY);
+		CHECK(miint::ENAParser::DetectAccessionType("PRJDB1234") == miint::ENAAccessionType::STUDY);
+		CHECK(miint::ENAParser::DetectAccessionType("ERP005989") == miint::ENAAccessionType::STUDY);
+		CHECK(miint::ENAParser::DetectAccessionType("SRP228341") == miint::ENAAccessionType::STUDY);
+		CHECK(miint::ENAParser::DetectAccessionType("DRP000001") == miint::ENAAccessionType::STUDY);
+	}
+
+	SECTION("Sample accessions") {
+		CHECK(miint::ENAParser::DetectAccessionType("SAMN12329471") == miint::ENAAccessionType::SAMPLE);
+		CHECK(miint::ENAParser::DetectAccessionType("SAMEA3271045") == miint::ENAAccessionType::SAMPLE);
+		CHECK(miint::ENAParser::DetectAccessionType("SAMD00000001") == miint::ENAAccessionType::SAMPLE);
+	}
+
+	SECTION("Run accessions") {
+		CHECK(miint::ENAParser::DetectAccessionType("ERR1074767") == miint::ENAAccessionType::RUN);
+		CHECK(miint::ENAParser::DetectAccessionType("SRR19396253") == miint::ENAAccessionType::RUN);
+		CHECK(miint::ENAParser::DetectAccessionType("DRR000001") == miint::ENAAccessionType::RUN);
+	}
+
+	SECTION("Experiment accessions") {
+		CHECK(miint::ENAParser::DetectAccessionType("ERX1106717") == miint::ENAAccessionType::EXPERIMENT);
+		CHECK(miint::ENAParser::DetectAccessionType("SRX7123456") == miint::ENAAccessionType::EXPERIMENT);
+		CHECK(miint::ENAParser::DetectAccessionType("DRX000001") == miint::ENAAccessionType::EXPERIMENT);
+	}
+
+	SECTION("Unknown accessions") {
+		CHECK(miint::ENAParser::DetectAccessionType("") == miint::ENAAccessionType::UNKNOWN);
+		CHECK(miint::ENAParser::DetectAccessionType("garbage") == miint::ENAAccessionType::UNKNOWN);
+		CHECK(miint::ENAParser::DetectAccessionType("NC_001416.1") == miint::ENAAccessionType::UNKNOWN);
+		CHECK(miint::ENAParser::DetectAccessionType("GCF_000005845.2") == miint::ENAAccessionType::UNKNOWN);
+	}
+}
+
+// ---- Step 1.2: URL construction ----
+
+TEST_CASE("ENAClient URL construction", "[ena]") {
+	SECTION("Study accession uses study_accession query param") {
+		auto url = miint::ENAParser::BuildSearchURL("PRJEB5291", "read_run", "run_accession,fastq_ftp");
+		CHECK(url == "https://www.ebi.ac.uk/ena/portal/api/search?"
+		             "result=read_run"
+		             "&query=study_accession%3D%22PRJEB5291%22"
+		             "&fields=run_accession,fastq_ftp"
+		             "&limit=0&format=tsv");
+	}
+
+	SECTION("Run accession uses run_accession query param") {
+		auto url = miint::ENAParser::BuildSearchURL("ERR1074767", "read_run", "run_accession,fastq_ftp");
+		CHECK(url.find("run_accession%3D%22ERR1074767%22") != std::string::npos);
+	}
+
+	SECTION("Sample accession uses sample_accession query param") {
+		auto url = miint::ENAParser::BuildSearchURL("SAMEA3271045", "read_run", "run_accession");
+		CHECK(url.find("sample_accession%3D%22SAMEA3271045%22") != std::string::npos);
+	}
+
+	SECTION("Experiment accession uses experiment_accession query param") {
+		auto url = miint::ENAParser::BuildSearchURL("ERX1106717", "read_run", "run_accession");
+		CHECK(url.find("experiment_accession%3D%22ERX1106717%22") != std::string::npos);
+	}
+
+	SECTION("SRP study accession") {
+		auto url = miint::ENAParser::BuildSearchURL("SRP228341", "read_run", "run_accession");
+		CHECK(url.find("study_accession%3D%22SRP228341%22") != std::string::npos);
+	}
+
+	SECTION("Different result types are embedded") {
+		auto url = miint::ENAParser::BuildSearchURL("ERR1074767", "sample", "sample_accession");
+		CHECK(url.find("result=sample") != std::string::npos);
+	}
+}
+
+// ---- Step 1.3: TSV parsing ----
+
+TEST_CASE("ENAClient TSV parsing", "[ena]") {
+	SECTION("Basic TSV with headers and one row") {
+		std::string tsv = "run_accession\tsample_accession\tfastq_ftp\n"
+		                  "ERR1074767\tSAMEA3271045\tftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/"
+		                  "ERR1074767.fastq.gz\n";
+
+		auto result = miint::ENAParser::ParseTSV(tsv);
+
+		REQUIRE(result.column_names.size() == 3);
+		CHECK(result.column_names[0] == "run_accession");
+		CHECK(result.column_names[1] == "sample_accession");
+		CHECK(result.column_names[2] == "fastq_ftp");
+
+		REQUIRE(result.rows.size() == 1);
+		CHECK(result.rows[0][0] == "ERR1074767");
+		CHECK(result.rows[0][1] == "SAMEA3271045");
+	}
+
+	SECTION("Empty TSV (headers only, no data rows)") {
+		std::string tsv = "run_accession\tsample_accession\n";
+		auto result = miint::ENAParser::ParseTSV(tsv);
+		CHECK(result.column_names.size() == 2);
+		CHECK(result.rows.empty());
+	}
+
+	SECTION("Multiple rows") {
+		std::string tsv = "col1\tcol2\n"
+		                  "a\tb\n"
+		                  "c\td\n";
+		auto result = miint::ENAParser::ParseTSV(tsv);
+		REQUIRE(result.rows.size() == 2);
+		CHECK(result.rows[0][0] == "a");
+		CHECK(result.rows[0][1] == "b");
+		CHECK(result.rows[1][0] == "c");
+		CHECK(result.rows[1][1] == "d");
+	}
+
+	SECTION("Empty fields between tabs") {
+		std::string tsv = "col1\tcol2\tcol3\n"
+		                  "a\t\tc\n";
+		auto result = miint::ENAParser::ParseTSV(tsv);
+		REQUIRE(result.rows.size() == 1);
+		CHECK(result.rows[0][0] == "a");
+		CHECK(result.rows[0][1] == "");
+		CHECK(result.rows[0][2] == "c");
+	}
+
+	SECTION("No trailing newline") {
+		std::string tsv = "col1\n"
+		                  "val1";
+		auto result = miint::ENAParser::ParseTSV(tsv);
+		REQUIRE(result.rows.size() == 1);
+		CHECK(result.rows[0][0] == "val1");
+	}
+
+	SECTION("Empty body") {
+		std::string tsv = "";
+		auto result = miint::ENAParser::ParseTSV(tsv);
+		CHECK(result.column_names.empty());
+		CHECK(result.rows.empty());
+	}
+}
+
+// ---- Step 1.4: XML sample attribute parsing ----
+
+TEST_CASE("ENAClient XML sample attribute parsing", "[ena]") {
+	SECTION("Basic sample attributes") {
+		std::string xml =
+		    R"(<?xml version="1.0" encoding="UTF-8"?>
+<ROOT>
+  <SAMPLE accession="SAMEA3271045" alias="test">
+    <SAMPLE_ATTRIBUTES>
+      <SAMPLE_ATTRIBUTE>
+        <TAG>collection date</TAG>
+        <VALUE>2013</VALUE>
+      </SAMPLE_ATTRIBUTE>
+      <SAMPLE_ATTRIBUTE>
+        <TAG>geographic location (country and/or sea)</TAG>
+        <VALUE>United Kingdom</VALUE>
+      </SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES>
+  </SAMPLE>
+</ROOT>)";
+
+		auto attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
+
+		REQUIRE(attrs.size() == 2);
+		CHECK(attrs[0].sample_accession == "SAMEA3271045");
+		CHECK(attrs[0].tag == "collection date");
+		CHECK(attrs[0].value == "2013");
+		CHECK(attrs[1].sample_accession == "SAMEA3271045");
+		CHECK(attrs[1].tag == "geographic location (country and/or sea)");
+		CHECK(attrs[1].value == "United Kingdom");
+	}
+
+	SECTION("Multiple samples in one XML") {
+		std::string xml =
+		    R"(<?xml version="1.0" encoding="UTF-8"?>
+<ROOT>
+  <SAMPLE accession="SAMEA001">
+    <SAMPLE_ATTRIBUTES>
+      <SAMPLE_ATTRIBUTE><TAG>depth</TAG><VALUE>10m</VALUE></SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES>
+  </SAMPLE>
+  <SAMPLE accession="SAMEA002">
+    <SAMPLE_ATTRIBUTES>
+      <SAMPLE_ATTRIBUTE><TAG>depth</TAG><VALUE>20m</VALUE></SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES>
+  </SAMPLE>
+</ROOT>)";
+
+		auto attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
+		REQUIRE(attrs.size() == 2);
+		CHECK(attrs[0].sample_accession == "SAMEA001");
+		CHECK(attrs[0].value == "10m");
+		CHECK(attrs[1].sample_accession == "SAMEA002");
+		CHECK(attrs[1].value == "20m");
+	}
+
+	SECTION("Empty attributes section") {
+		std::string xml =
+		    R"(<ROOT><SAMPLE accession="SAMEA001"><SAMPLE_ATTRIBUTES></SAMPLE_ATTRIBUTES></SAMPLE></ROOT>)";
+		auto attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
+		CHECK(attrs.empty());
+	}
+
+	SECTION("Attribute with empty value") {
+		std::string xml =
+		    R"(<ROOT><SAMPLE accession="SAMEA001"><SAMPLE_ATTRIBUTES>
+        <SAMPLE_ATTRIBUTE><TAG>host</TAG><VALUE></VALUE></SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES></SAMPLE></ROOT>)";
+		auto attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
+		REQUIRE(attrs.size() == 1);
+		CHECK(attrs[0].tag == "host");
+		CHECK(attrs[0].value == "");
+	}
+
+	SECTION("Attribute with no VALUE element") {
+		std::string xml =
+		    R"(<ROOT><SAMPLE accession="SAMEA001"><SAMPLE_ATTRIBUTES>
+        <SAMPLE_ATTRIBUTE><TAG>orphan_tag</TAG></SAMPLE_ATTRIBUTE>
+    </SAMPLE_ATTRIBUTES></SAMPLE></ROOT>)";
+		auto attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
+		REQUIRE(attrs.size() == 1);
+		CHECK(attrs[0].tag == "orphan_tag");
+		CHECK(attrs[0].value == "");
+	}
+}
+
+// ---- Step 1.5: FTP-to-HTTPS URL conversion ----
+
+TEST_CASE("ENAClient FTP to HTTPS conversion", "[ena]") {
+	SECTION("Single-end FTP path") {
+		auto urls =
+		    miint::ENAParser::FTPtoHTTPS("ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767.fastq.gz");
+		REQUIRE(urls.size() == 1);
+		CHECK(urls[0] == "https://ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767.fastq.gz");
+	}
+
+	SECTION("Paired-end FTP paths (semicolon-separated)") {
+		auto urls =
+		    miint::ENAParser::FTPtoHTTPS("ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767_1.fastq.gz;"
+		                                 "ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767_2.fastq.gz");
+		REQUIRE(urls.size() == 2);
+		CHECK(urls[0] == "https://ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767_1.fastq.gz");
+		CHECK(urls[1] == "https://ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767_2.fastq.gz");
+	}
+
+	SECTION("Empty FTP field") {
+		auto urls = miint::ENAParser::FTPtoHTTPS("");
+		CHECK(urls.empty());
+	}
+}
+
+// ---- Step 1.6: Default fields ----
+
+TEST_CASE("ENAClient default fields", "[ena]") {
+	SECTION("Default read_run fields include key columns") {
+		auto fields = miint::ENAParser::DefaultFields("read_run");
+		CHECK(fields.find("run_accession") != std::string::npos);
+		CHECK(fields.find("sample_accession") != std::string::npos);
+		CHECK(fields.find("experiment_accession") != std::string::npos);
+		CHECK(fields.find("study_accession") != std::string::npos);
+		CHECK(fields.find("fastq_ftp") != std::string::npos);
+		CHECK(fields.find("fastq_bytes") != std::string::npos);
+		CHECK(fields.find("fastq_md5") != std::string::npos);
+		CHECK(fields.find("library_layout") != std::string::npos);
+		CHECK(fields.find("library_strategy") != std::string::npos);
+		CHECK(fields.find("instrument_model") != std::string::npos);
+		CHECK(fields.find("read_count") != std::string::npos);
+		CHECK(fields.find("base_count") != std::string::npos);
+	}
+
+	SECTION("Default sample fields include key columns") {
+		auto fields = miint::ENAParser::DefaultFields("sample");
+		CHECK(fields.find("sample_accession") != std::string::npos);
+		CHECK(fields.find("scientific_name") != std::string::npos);
+		CHECK(fields.find("tax_id") != std::string::npos);
+	}
+
+	SECTION("Default study fields include key columns") {
+		auto fields = miint::ENAParser::DefaultFields("study");
+		CHECK(fields.find("study_accession") != std::string::npos);
+		CHECK(fields.find("study_title") != std::string::npos);
+	}
+
+	SECTION("Unknown result type returns empty string") {
+		auto fields = miint::ENAParser::DefaultFields("nonsense");
+		CHECK(fields.empty());
+	}
+}
+
+// ---- Step 1.7: XML URL construction ----
+
+TEST_CASE("ENAClient XML URL construction", "[ena]") {
+	SECTION("Single accession") {
+		auto url = miint::ENAParser::BuildXMLURL({"SAMEA001"});
+		CHECK(url == "https://www.ebi.ac.uk/ena/browser/api/xml/SAMEA001");
+	}
+
+	SECTION("Multiple accessions batched") {
+		auto url = miint::ENAParser::BuildXMLURL({"SAMEA001", "SAMEA002", "SAMEA003"});
+		CHECK(url == "https://www.ebi.ac.uk/ena/browser/api/xml/SAMEA001,SAMEA002,SAMEA003");
+	}
+}
+
+// ---- Step 1.8: Input validation ----
+
+TEST_CASE("ENAParser input validation", "[ena]") {
+	SECTION("Valid accessions pass validation") {
+		CHECK_NOTHROW(miint::ENAParser::ValidateAccession("ERR1074767"));
+		CHECK_NOTHROW(miint::ENAParser::ValidateAccession("PRJNA555783"));
+		CHECK_NOTHROW(miint::ENAParser::ValidateAccession("GCF_000005845.2"));
+	}
+
+	SECTION("Accessions with special characters are rejected") {
+		CHECK_THROWS(miint::ENAParser::ValidateAccession("ERR107&limit=1"));
+		CHECK_THROWS(miint::ENAParser::ValidateAccession("ERR107 extra"));
+		CHECK_THROWS(miint::ENAParser::ValidateAccession("ERR107%22"));
+		CHECK_THROWS(miint::ENAParser::ValidateAccession("ERR107=bad"));
+	}
+
+	SECTION("Valid fields pass validation") {
+		CHECK_NOTHROW(miint::ENAParser::ValidateFields("run_accession,fastq_ftp"));
+		CHECK_NOTHROW(miint::ENAParser::ValidateFields("sample_accession"));
+	}
+
+	SECTION("Fields with special characters are rejected") {
+		CHECK_THROWS(miint::ENAParser::ValidateFields("run_accession&limit=1"));
+		CHECK_THROWS(miint::ENAParser::ValidateFields("field with spaces"));
+	}
+
+	SECTION("FTPtoHTTPS strips ftp:// prefix") {
+		auto urls = miint::ENAParser::FTPtoHTTPS("ftp://ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/file.gz");
+		REQUIRE(urls.size() == 1);
+		CHECK(urls[0] == "https://ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/file.gz");
+	}
+}

--- a/test/sql/read_ena.test
+++ b/test/sql/read_ena.test
@@ -1,0 +1,87 @@
+# name: test/sql/read_ena.test
+# description: Test read_ena table function
+# group: [sql]
+
+# NOTE: This test requires network access to EBI/ENA servers.
+# Tests are structured to minimize ENA requests by fetching data once into temp tables.
+
+require httpfs
+
+require miint
+
+# ---- Error handling (no network needed) ----
+
+statement error
+SELECT * FROM read_ena('');
+----
+read_ena: accession cannot be empty
+
+statement error
+SELECT * FROM read_ena([]);
+----
+read_ena: at least one accession must be provided
+
+statement error
+SELECT * FROM read_ena('ERR1074767', result='invalid_type');
+----
+read_ena: result must be one of: read_run, sample, study
+
+# ---- Single run accession with custom fields ----
+
+statement ok
+CREATE TEMP TABLE ena_run AS
+SELECT * FROM read_ena('ERR1074767', fields='run_accession,sample_accession,experiment_accession,library_layout');
+
+query I
+SELECT run_accession FROM ena_run;
+----
+ERR1074767
+
+query I
+SELECT sample_accession IS NOT NULL AS has_sample FROM ena_run;
+----
+true
+
+query I
+SELECT experiment_accession IS NOT NULL AS has_experiment FROM ena_run;
+----
+true
+
+query I
+SELECT library_layout FROM ena_run;
+----
+SINGLE
+
+# ---- Custom fields determine schema ----
+
+query II nosort
+SELECT column_name, column_type
+FROM (DESCRIBE SELECT * FROM read_ena('ERR1074767', fields='run_accession,library_layout'));
+----
+run_accession	VARCHAR
+library_layout	VARCHAR
+
+# ---- Sample result type (resolves run -> sample accession) ----
+
+query I
+SELECT sample_accession IS NOT NULL AS has_sample
+FROM read_ena('ERR1074767', result='sample', fields='sample_accession,scientific_name')
+LIMIT 1;
+----
+true
+
+# ---- Study result type (resolves run -> study accession) ----
+
+query I
+SELECT study_accession IS NOT NULL AS has_study
+FROM read_ena('ERR1074767', result='study', fields='study_accession,study_title')
+LIMIT 1;
+----
+true
+
+# ---- Array of accessions ----
+
+query I
+SELECT run_accession FROM read_ena(['ERR1074767'], fields='run_accession');
+----
+ERR1074767

--- a/test/sql/read_ena_attributes.test
+++ b/test/sql/read_ena_attributes.test
@@ -1,0 +1,58 @@
+# name: test/sql/read_ena_attributes.test
+# description: Test read_ena_attributes table function
+# group: [sql]
+
+# NOTE: This test requires network access to EBI/ENA servers.
+
+require httpfs
+
+require miint
+
+# ---- Error handling ----
+
+statement error
+SELECT * FROM read_ena_attributes('');
+----
+read_ena_attributes: accession cannot be empty
+
+# ---- Schema ----
+
+query IIIIII
+DESCRIBE SELECT * FROM read_ena_attributes('ERR1074767');
+----
+sample_accession	VARCHAR	YES	NULL	NULL	NULL
+tag	VARCHAR	YES	NULL	NULL	NULL
+value	VARCHAR	YES	NULL	NULL	NULL
+
+# ---- Single run accession ----
+
+statement ok
+CREATE TEMP TABLE run_attrs AS SELECT * FROM read_ena_attributes('ERR1074767');
+
+# Should have at least one attribute
+query I
+SELECT COUNT(*) > 0 AS has_attrs FROM run_attrs;
+----
+true
+
+# All rows should have sample_accession populated
+query I
+SELECT COUNT(*) = 0 AS no_nulls FROM run_attrs WHERE sample_accession IS NULL;
+----
+true
+
+# ---- Sample accession direct ----
+
+statement ok
+CREATE TEMP TABLE sample_attrs AS SELECT * FROM read_ena_attributes('SAMEA3610311');
+
+query I
+SELECT COUNT(*) > 0 AS has_attrs FROM sample_attrs;
+----
+true
+
+# Should only contain this sample
+query I
+SELECT COUNT(DISTINCT sample_accession) FROM sample_attrs;
+----
+1

--- a/test/sql/read_ena_fastq.test
+++ b/test/sql/read_ena_fastq.test
@@ -1,0 +1,103 @@
+# name: test/sql/read_ena_fastq.test
+# description: Test read_ena_fastq table function
+# group: [sql]
+
+# NOTE: This test requires network access to EBI/ENA servers.
+# ERR1074767 is a SINGLE-end run from the American Gut Project.
+
+require httpfs
+
+require miint
+
+# ---- Error handling ----
+
+statement error
+SELECT * FROM read_ena_fastq('');
+----
+read_ena_fastq: accession cannot be empty
+
+# ---- Schema (no filepath by default) ----
+
+query IIIIII
+DESCRIBE SELECT * FROM read_ena_fastq('ERR1074767');
+----
+sequence_index	BIGINT	YES	NULL	NULL	NULL
+read_id	VARCHAR	YES	NULL	NULL	NULL
+comment	VARCHAR	YES	NULL	NULL	NULL
+sequence1	VARCHAR	YES	NULL	NULL	NULL
+sequence2	VARCHAR	YES	NULL	NULL	NULL
+qual1	UTINYINT[]	YES	NULL	NULL	NULL
+qual2	UTINYINT[]	YES	NULL	NULL	NULL
+run_accession	VARCHAR	YES	NULL	NULL	NULL
+sample_accession	VARCHAR	YES	NULL	NULL	NULL
+experiment_accession	VARCHAR	YES	NULL	NULL	NULL
+
+# ---- Stream reads from a single run ----
+
+statement ok
+CREATE TEMP TABLE ena_reads AS SELECT * FROM read_ena_fastq('ERR1074767') LIMIT 10;
+
+query I
+SELECT COUNT(*) FROM ena_reads;
+----
+10
+
+# run_accession populated for all rows
+query I
+SELECT DISTINCT run_accession FROM ena_reads;
+----
+ERR1074767
+
+# sequence1 should be non-empty
+query I
+SELECT LENGTH(sequence1) > 0 AS has_seq FROM ena_reads LIMIT 1;
+----
+true
+
+# qual1 should be populated (FASTQ has quality)
+query I
+SELECT qual1 IS NOT NULL AS has_qual FROM ena_reads LIMIT 1;
+----
+true
+
+# ERR1074767 is SINGLE-end: sequence2 and qual2 should be NULL
+query I
+SELECT COUNT(*) = 0 AS all_null FROM ena_reads WHERE sequence2 IS NOT NULL;
+----
+true
+
+# Sequences should contain only valid nucleotide characters
+query I
+SELECT COUNT(*) = 0 AS valid_chars FROM ena_reads WHERE NOT regexp_matches(sequence1, '^[ACGTN]+$');
+----
+true
+
+# Quality scores should be in valid Phred+33 range (0-41 typical)
+query I
+SELECT COUNT(*) = 0 AS valid_qual FROM ena_reads
+WHERE list_any_value(list_transform(qual1, x -> x > 60));
+----
+true
+
+# ---- Schema with include_filepath ----
+
+query IIIIII
+DESCRIBE SELECT * FROM read_ena_fastq('ERR1074767', include_filepath=true);
+----
+sequence_index	BIGINT	YES	NULL	NULL	NULL
+read_id	VARCHAR	YES	NULL	NULL	NULL
+comment	VARCHAR	YES	NULL	NULL	NULL
+sequence1	VARCHAR	YES	NULL	NULL	NULL
+sequence2	VARCHAR	YES	NULL	NULL	NULL
+qual1	UTINYINT[]	YES	NULL	NULL	NULL
+qual2	UTINYINT[]	YES	NULL	NULL	NULL
+run_accession	VARCHAR	YES	NULL	NULL	NULL
+sample_accession	VARCHAR	YES	NULL	NULL	NULL
+experiment_accession	VARCHAR	YES	NULL	NULL	NULL
+filepath	VARCHAR	YES	NULL	NULL	NULL
+
+# filepath should contain ebi.ac.uk
+query I
+SELECT filepath LIKE '%ebi.ac.uk%' AS has_ebi FROM read_ena_fastq('ERR1074767', include_filepath=true) LIMIT 1;
+----
+true


### PR DESCRIPTION
Add three table functions for programmatic access to EBI/ENA BioProject data:

- read_ena: Query metadata from ENA Portal API (runs, samples, studies). Supports cross-type accession resolution (e.g., run -> study). All columns returned as VARCHAR with user-configurable field selection.

- read_ena_attributes: Fetch custom sample attributes via ENA Browser XML API. Returns key-value pairs including submitter-defined attributes not available through the Portal API's fixed schema. Batches XML requests in groups of 50.

- read_ena_fastq: Stream FASTQ data from ENA with run_accession, sample_accession, and experiment_accession columns. Reuses existing SequenceReader/DuckDBSeqStream infrastructure. Automatic paired-end detection from library_layout field.

Also extracts CreateDuckDBSeqStream into a shared utility (was duplicated between read_fastx and read_ena_fastq), adds input validation for URL construction to prevent injection, and adds RAII guard for expat XML parser.