### PR TITLE
Convert eager file opening to lazy for read_fastx, read_alignments, r…

### DIFF
--- a/src/include/read_alignments.hpp
+++ b/src/include/read_alignments.hpp
@@ -83,45 +83,59 @@ public:
 
 	struct GlobalState : public GlobalTableFunctionState {
 		mutex lock;
+		// Readers are created lazily when a thread claims a file, not all upfront.
+		// This avoids opening many HTTP connections simultaneously for remote file arrays.
 		std::vector<std::unique_ptr<miint::SAMReader>> readers;
 		std::vector<std::string> filepaths; // Original paths (for include_filepath)
 		size_t next_file_idx;
+		FileSystem &fs;
+		std::optional<std::unordered_map<std::string, uint64_t>> ref_lengths;
+		bool include_seq_qual;
 
 		idx_t MaxThreads() const override {
 			auto hw = std::thread::hardware_concurrency();
 			if (hw == 0) {
 				hw = 1;
 			}
-			return std::min<idx_t>(readers.size(), hw);
+			return std::min<idx_t>(filepaths.size(), hw);
 		}
 
 		GlobalState(const std::vector<std::string> &paths, FileSystem &fs,
 		            std::optional<std::unordered_map<std::string, uint64_t>> ref_lengths, bool include_seq_qual)
-		    : filepaths(paths), next_file_idx(0) {
-			for (const auto &path : paths) {
-				try {
-					if (miint::RemoteFileHelper::IsRemotePath(path)) {
-						hFILE *hf = miint::hfile_duckdb_open(fs, path);
-						if (!hf) {
-							throw IOException("Failed to open remote file: " + path);
-						}
-						if (ref_lengths.has_value()) {
-							readers.push_back(
-							    std::make_unique<miint::SAMReader>(hf, path, ref_lengths.value(), include_seq_qual));
-						} else {
-							readers.push_back(std::make_unique<miint::SAMReader>(hf, path, include_seq_qual));
-						}
-					} else {
-						if (ref_lengths.has_value()) {
-							readers.push_back(
-							    std::make_unique<miint::SAMReader>(path, ref_lengths.value(), include_seq_qual));
-						} else {
-							readers.push_back(std::make_unique<miint::SAMReader>(path, include_seq_qual));
-						}
+		    : filepaths(paths), next_file_idx(0), fs(fs), ref_lengths(std::move(ref_lengths)),
+		      include_seq_qual(include_seq_qual) {
+			// Pre-allocate slots but don't open connections yet
+			readers.resize(paths.size());
+		}
+
+		// Open reader for a specific file index. Called under lock when a thread claims the file.
+		void OpenReader(size_t file_idx) {
+			if (readers[file_idx]) {
+				return; // Already opened
+			}
+			const auto &path = filepaths[file_idx];
+			try {
+				if (miint::RemoteFileHelper::IsRemotePath(path)) {
+					hFILE *hf = miint::hfile_duckdb_open(fs, path);
+					if (!hf) {
+						throw IOException("Failed to open remote file: " + path);
 					}
-				} catch (std::exception &e) {
-					throw IOException("Error opening '%s': %s", path, e.what());
+					if (ref_lengths.has_value()) {
+						readers[file_idx] =
+						    std::make_unique<miint::SAMReader>(hf, path, ref_lengths.value(), include_seq_qual);
+					} else {
+						readers[file_idx] = std::make_unique<miint::SAMReader>(hf, path, include_seq_qual);
+					}
+				} else {
+					if (ref_lengths.has_value()) {
+						readers[file_idx] =
+						    std::make_unique<miint::SAMReader>(path, ref_lengths.value(), include_seq_qual);
+					} else {
+						readers[file_idx] = std::make_unique<miint::SAMReader>(path, include_seq_qual);
+					}
 				}
+			} catch (std::exception &e) {
+				throw IOException("Error opening '%s': %s", path, e.what());
 			}
 		}
 	};

--- a/src/include/read_ena_fastq.hpp
+++ b/src/include/read_ena_fastq.hpp
@@ -42,16 +42,22 @@ public:
 
 	struct GlobalState : public GlobalTableFunctionState {
 		mutex lock;
+		// Readers are created lazily when a thread claims a run, not all upfront.
+		// This avoids opening hundreds of HTTP connections simultaneously for large projects.
 		std::vector<std::unique_ptr<miint::SequenceReader>> readers;
 		std::vector<RunInfo> runs;
 		size_t next_run_idx;
 		std::vector<uint64_t> run_sequence_counters;
+		FileSystem &fs;
 
 		idx_t MaxThreads() const override {
-			return std::min<idx_t>(readers.size(), 8);
+			return std::min<idx_t>(runs.size(), 8);
 		}
 
 		GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs);
+
+		// Open reader for a specific run index. Called under lock.
+		void OpenReader(size_t run_idx);
 	};
 
 	struct LocalState : public LocalTableFunctionState {

--- a/src/include/read_fastx.hpp
+++ b/src/include/read_fastx.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "SequenceReader.hpp"
 #include "duckdb_seq_stream.hpp"
 #include "remote_file_helper.hpp"
@@ -47,6 +48,8 @@ public:
 
 	struct GlobalState : public GlobalTableFunctionState {
 		mutex lock;
+		// Readers are created lazily when a thread claims a file, not all upfront.
+		// This avoids opening many HTTP connections simultaneously for remote file arrays.
 		std::vector<std::unique_ptr<miint::SequenceReader>> readers;
 		std::vector<std::string> sequence1_filepaths;
 		std::vector<std::string> sequence2_filepaths;
@@ -54,6 +57,7 @@ public:
 		bool uses_stdin;
 		std::vector<uint64_t>
 		    file_sequence_counters; // Per-file sequence counters (no atomic needed - file access is exclusive)
+		FileSystem &fs;
 
 		// stdin cannot be read in parallel (no seeking/rewinding).
 		// This forces sequential execution, which may be slower than
@@ -62,37 +66,43 @@ public:
 			if (uses_stdin) {
 				return 1;
 			}
-			return std::min<idx_t>(readers.size(), std::thread::hardware_concurrency());
+			return std::min<idx_t>(sequence1_filepaths.size(), std::thread::hardware_concurrency());
 		};
 
 		GlobalState(FileSystem &fs, const std::vector<std::string> &sequence1_paths,
 		            const std::optional<std::vector<std::string>> &sequence2_paths, bool stdin_used)
-		    : next_file_idx(0), uses_stdin(stdin_used) {
+		    : next_file_idx(0), uses_stdin(stdin_used), fs(fs) {
 			sequence1_filepaths = sequence1_paths;
 			if (sequence2_paths.has_value()) {
 				sequence2_filepaths = sequence2_paths.value();
 			}
 
-			for (size_t i = 0; i < sequence1_paths.size(); i++) {
-				bool r1_remote = miint::RemoteFileHelper::IsRemotePath(sequence1_paths[i]);
-				bool r2_remote =
-				    sequence2_paths.has_value() && miint::RemoteFileHelper::IsRemotePath(sequence2_paths.value()[i]);
+			// Pre-allocate slots but don't open connections yet
+			readers.resize(sequence1_paths.size());
+			file_sequence_counters.resize(sequence1_paths.size(), 1);
+		}
 
-				if (r1_remote || r2_remote) {
-					// Stream via DuckDB FileHandle for remote paths
-					auto *s1 = CreateDuckDBSeqStream(fs, sequence1_paths[i]);
-					miint::DuckDBSeqStream *s2 = nullptr;
-					if (sequence2_paths.has_value()) {
-						s2 = CreateDuckDBSeqStream(fs, sequence2_paths.value()[i]);
-					}
-					readers.push_back(std::make_unique<miint::SequenceReader>(s1, s2));
-				} else if (sequence2_paths.has_value()) {
-					readers.push_back(
-					    std::make_unique<miint::SequenceReader>(sequence1_paths[i], sequence2_paths.value()[i]));
-				} else {
-					readers.push_back(std::make_unique<miint::SequenceReader>(sequence1_paths[i]));
+		// Open reader for a specific file index. Called under lock when a thread claims the file.
+		void OpenReader(size_t file_idx) {
+			if (readers[file_idx]) {
+				return; // Already opened
+			}
+			bool r1_remote = miint::RemoteFileHelper::IsRemotePath(sequence1_filepaths[file_idx]);
+			bool r2_remote =
+			    !sequence2_filepaths.empty() && miint::RemoteFileHelper::IsRemotePath(sequence2_filepaths[file_idx]);
+
+			if (r1_remote || r2_remote) {
+				auto *s1 = CreateDuckDBSeqStream(fs, sequence1_filepaths[file_idx]);
+				miint::DuckDBSeqStream *s2 = nullptr;
+				if (!sequence2_filepaths.empty()) {
+					s2 = CreateDuckDBSeqStream(fs, sequence2_filepaths[file_idx]);
 				}
-				file_sequence_counters.emplace_back(1);
+				readers[file_idx] = std::make_unique<miint::SequenceReader>(s1, s2);
+			} else if (!sequence2_filepaths.empty()) {
+				readers[file_idx] = std::make_unique<miint::SequenceReader>(sequence1_filepaths[file_idx],
+				                                                            sequence2_filepaths[file_idx]);
+			} else {
+				readers[file_idx] = std::make_unique<miint::SequenceReader>(sequence1_filepaths[file_idx]);
 			}
 		}
 	};

--- a/src/read_alignments.cpp
+++ b/src/read_alignments.cpp
@@ -184,18 +184,24 @@ void ReadAlignmentsTableFunction::Execute(ClientContext &context, TableFunctionI
 	while (true) {
 		// If this thread doesn't have a file, claim one
 		if (!local_state.has_file) {
-			lock_guard<mutex> lock(global_state.lock);
+			{
+				lock_guard<mutex> lock(global_state.lock);
 
-			// Check if all files exhausted
-			if (global_state.next_file_idx >= global_state.readers.size()) {
-				output.SetCardinality(0);
-				return;
-			}
+				// Check if all files exhausted
+				if (global_state.next_file_idx >= global_state.filepaths.size()) {
+					output.SetCardinality(0);
+					return;
+				}
 
-			// Claim next available file
-			local_state.current_file_idx = global_state.next_file_idx;
-			global_state.next_file_idx++;
-			local_state.has_file = true;
+				// Claim next available file index
+				local_state.current_file_idx = global_state.next_file_idx;
+				global_state.next_file_idx++;
+				local_state.has_file = true;
+			} // Lock released before I/O
+
+			// Open reader without holding the lock — safe because this thread
+			// has exclusive ownership of the claimed file index
+			global_state.OpenReader(local_state.current_file_idx);
 		}
 
 		// Read from claimed file (no lock needed - exclusive access)

--- a/src/read_ena_fastq.cpp
+++ b/src/read_ena_fastq.cpp
@@ -22,20 +22,29 @@ ReadENAFastqTableFunction::Data::Data(std::vector<RunInfo> runs, bool include_fp
 // ---- GlobalState ----
 
 ReadENAFastqTableFunction::GlobalState::GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs)
-    : runs(runs), next_run_idx(0) {
-	for (const auto &run : runs) {
-		if (run.fastq_urls.empty()) {
-			throw IOException("read_ena_fastq: no FASTQ URLs available for run '%s'", run.run_accession);
-		}
+    : runs(runs), next_run_idx(0), fs(fs) {
+	// Pre-allocate slots but don't open any connections yet.
+	// Readers are created lazily in OpenReader() to avoid opening hundreds of
+	// HTTP connections simultaneously for large projects.
+	readers.resize(runs.size());
+	run_sequence_counters.resize(runs.size(), 1);
+}
 
-		auto *s1 = CreateDuckDBSeqStream(fs, run.fastq_urls[0]);
-		miint::DuckDBSeqStream *s2 = nullptr;
-		if (run.is_paired && run.fastq_urls.size() >= 2) {
-			s2 = CreateDuckDBSeqStream(fs, run.fastq_urls[1]);
-		}
-		readers.push_back(std::make_unique<miint::SequenceReader>(s1, s2));
-		run_sequence_counters.emplace_back(1);
+void ReadENAFastqTableFunction::GlobalState::OpenReader(size_t run_idx) {
+	if (readers[run_idx]) {
+		return; // Already opened
 	}
+	const auto &run = runs[run_idx];
+	if (run.fastq_urls.empty()) {
+		throw IOException("read_ena_fastq: no FASTQ URLs available for run '%s'", run.run_accession);
+	}
+
+	auto *s1 = CreateDuckDBSeqStream(fs, run.fastq_urls[0]);
+	miint::DuckDBSeqStream *s2 = nullptr;
+	if (run.is_paired && run.fastq_urls.size() >= 2) {
+		s2 = CreateDuckDBSeqStream(fs, run.fastq_urls[1]);
+	}
+	readers[run_idx] = std::make_unique<miint::SequenceReader>(s1, s2);
 }
 
 // ---- Bind ----
@@ -178,14 +187,20 @@ void ReadENAFastqTableFunction::Execute(ClientContext &context, TableFunctionInp
 	// Claim-read-release loop (same pattern as read_fastx)
 	while (true) {
 		if (!local_state.has_run) {
-			lock_guard<mutex> read_lock(global_state.lock);
-			if (global_state.next_run_idx >= global_state.readers.size()) {
-				output.SetCardinality(0);
-				return;
-			}
-			local_state.current_run_idx = global_state.next_run_idx;
-			global_state.next_run_idx++;
-			local_state.has_run = true;
+			{
+				lock_guard<mutex> read_lock(global_state.lock);
+				if (global_state.next_run_idx >= global_state.runs.size()) {
+					output.SetCardinality(0);
+					return;
+				}
+				local_state.current_run_idx = global_state.next_run_idx;
+				global_state.next_run_idx++;
+				local_state.has_run = true;
+			} // Lock released before I/O
+
+			// Open reader without holding the lock — safe because this thread
+			// has exclusive ownership of the claimed run index
+			global_state.OpenReader(local_state.current_run_idx);
 		}
 
 		current_run_idx = local_state.current_run_idx;

--- a/src/read_fastx.cpp
+++ b/src/read_fastx.cpp
@@ -180,21 +180,25 @@ void ReadFastxTableFunction::Execute(ClientContext &context, TableFunctionInput 
 	while (true) {
 		// If this thread doesn't have a file, claim one
 		if (!local_state.has_file) {
-			lock_guard<mutex> read_lock(global_state.lock);
+			{
+				lock_guard<mutex> read_lock(global_state.lock);
 
-			// Check if all files exhausted
-			if (global_state.next_file_idx >= global_state.readers.size()) {
-				output.SetCardinality(0);
-				return;
-			}
+				// Check if all files exhausted
+				if (global_state.next_file_idx >= global_state.sequence1_filepaths.size()) {
+					output.SetCardinality(0);
+					return;
+				}
 
-			// Claim next available file
-			local_state.current_file_idx = global_state.next_file_idx;
-			global_state.next_file_idx++;
-			local_state.has_file = true;
+				// Claim next available file index
+				local_state.current_file_idx = global_state.next_file_idx;
+				global_state.next_file_idx++;
+				local_state.has_file = true;
+			} // Lock released before I/O
+
+			// Open reader without holding the lock — safe because this thread
+			// has exclusive ownership of the claimed file index
+			global_state.OpenReader(local_state.current_file_idx);
 		}
-		// Lock released - now do I/O without blocking other threads
-		// This thread has exclusive access to its claimed file
 
 		// Read from claimed file (no lock needed)
 		batch = global_state.readers[local_state.current_file_idx]->read(STANDARD_VECTOR_SIZE);


### PR DESCRIPTION
…ead_ena_fastq

All three table functions previously opened every file/reader in the GlobalState constructor. For large arrays of remote URLs, this caused hundreds of simultaneous HTTP connections, overwhelming servers like EBI.

Now readers are created lazily when a thread claims a file index. The OpenReader call happens outside the mutex lock so multiple threads can open their claimed files in parallel (up to MaxThreads concurrency).

Also adds #pragma once to read_fastx.hpp (was missing).