### PR TITLE
Fix read_ena_fastq HTTP HEAD failures on large projects

### DIFF
--- a/src/include/read_ena_fastq.hpp
+++ b/src/include/read_ena_fastq.hpp
@@ -42,8 +42,7 @@ public:
 
 	struct GlobalState : public GlobalTableFunctionState {
 		mutex lock;
-		// Readers are created lazily when a thread claims a run, not all upfront.
-		// This avoids opening hundreds of HTTP connections simultaneously for large projects.
+		mutex open_mutex; // Serializes file opens to avoid overwhelming remote servers
 		std::vector<std::unique_ptr<miint::SequenceReader>> readers;
 		std::vector<RunInfo> runs;
 		size_t next_run_idx;
@@ -56,7 +55,8 @@ public:
 
 		GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs);
 
-		// Open reader for a specific run index. Called under lock.
+		// Open reader for a specific run index.
+		// Called outside the lock — each thread owns its run_idx exclusively.
 		void OpenReader(size_t run_idx);
 	};
 

--- a/src/read_ena_fastq.cpp
+++ b/src/read_ena_fastq.cpp
@@ -32,12 +32,17 @@ ReadENAFastqTableFunction::GlobalState::GlobalState(FileSystem &fs, const std::v
 
 void ReadENAFastqTableFunction::GlobalState::OpenReader(size_t run_idx) {
 	if (readers[run_idx]) {
-		return; // Already opened
+		return;
 	}
 	const auto &run = runs[run_idx];
 	if (run.fastq_urls.empty()) {
 		throw IOException("read_ena_fastq: no FASTQ URLs available for run '%s'", run.run_accession);
 	}
+
+	// Serialize file opens to avoid overwhelming remote servers with
+	// simultaneous HTTP HEAD requests (e.g., EBI rejects concurrent connections).
+	// Reading from opened files is still fully parallel — only the open is serialized.
+	lock_guard<mutex> open_guard(open_mutex);
 
 	auto *s1 = CreateDuckDBSeqStream(fs, run.fastq_urls[0]);
 	miint::DuckDBSeqStream *s2 = nullptr;
@@ -207,6 +212,8 @@ void ReadENAFastqTableFunction::Execute(ClientContext &context, TableFunctionInp
 		batch = global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
 
 		if (batch.empty()) {
+			// Release the reader to free the HTTP connection for subsequent runs
+			global_state.readers[current_run_idx].reset();
 			local_state.has_run = false;
 			continue;
 		}


### PR DESCRIPTION
Root cause: with MaxThreads=8, all 8 threads called OpenReader simultaneously, causing 16 concurrent HTTP HEAD requests (R1+R2 for paired-end) to EBI servers. EBI rejects connections under this load.

Fix: serialize file opens with a dedicated open_mutex. Reading from opened files remains fully parallel — only the open is serialized. Also release readers (reset) when a run is exhausted to free HTTP connections for subsequent runs.