### PR TITLE
Parallel Aspera downloads with per-run ascp processes

### DIFF
--- a/src/aspera_stream.cpp
+++ b/src/aspera_stream.cpp
@@ -42,8 +42,8 @@ AsperaProcess::AsperaProcess(const AsperaConfig &config, const std::vector<std::
 	};
 
 	push_arg(config.ascp_path);
-	push_arg("-T"); // Disable encryption
-	push_arg("-l"); // Max transfer rate
+	push_arg("-QT"); // Adaptive rate + disable encryption
+	push_arg("-l");  // Max transfer rate
 	push_arg(config.max_rate);
 	push_arg("-P"); // SSH port
 	push_arg(std::to_string(config.port));
@@ -61,12 +61,14 @@ AsperaProcess::AsperaProcess(const AsperaConfig &config, const std::vector<std::
 
 	if (total_path_chars > 100000) {
 		// Write paths to temp file
-		char tmpl[] = "/tmp/miint_aspera_XXXXXX";
-		int fd = mkstemp(tmpl);
+		std::string tmpl_str = miint::GetTempDir() + "/miint_aspera_XXXXXX";
+		std::vector<char> tmpl_buf(tmpl_str.begin(), tmpl_str.end());
+		tmpl_buf.push_back('\0');
+		int fd = mkstemp(tmpl_buf.data());
 		if (fd == -1) {
 			throw duckdb::IOException("AsperaProcess: failed to create temp file for --file-list");
 		}
-		file_list_path_ = tmpl;
+		file_list_path_ = std::string(tmpl_buf.data());
 		for (const auto &p : remote_paths) {
 			auto line = p + "\n";
 			auto written = write(fd, line.data(), line.size());
@@ -88,6 +90,9 @@ AsperaProcess::AsperaProcess(const AsperaConfig &config, const std::vector<std::
 	// Create pipe for stdout
 	int stdout_pipe[2];
 	if (pipe(stdout_pipe) == -1) {
+		if (!file_list_path_.empty()) {
+			unlink(file_list_path_.c_str());
+		}
 		throw duckdb::IOException("AsperaProcess: failed to create pipe: %s", strerror(errno));
 	}
 
@@ -95,6 +100,9 @@ AsperaProcess::AsperaProcess(const AsperaConfig &config, const std::vector<std::
 	if (child_pid_ == -1) {
 		close(stdout_pipe[0]);
 		close(stdout_pipe[1]);
+		if (!file_list_path_.empty()) {
+			unlink(file_list_path_.c_str());
+		}
 		throw duckdb::IOException("AsperaProcess: failed to fork: %s", strerror(errno));
 	}
 
@@ -134,8 +142,20 @@ AsperaProcess::~AsperaProcess() {
 	}
 	if (child_pid_ > 0) {
 		kill(child_pid_, SIGTERM);
+		// Give ascp a moment to exit cleanly, then force-kill.
+		// ascp catches SIGTERM and may block during network cleanup.
 		int status;
+		for (int i = 0; i < 10; i++) {
+			pid_t ret = waitpid(child_pid_, &status, WNOHANG);
+			if (ret > 0) {
+				goto reaped;
+			}
+			usleep(100000); // 100ms
+		}
+		// Still alive after 1s — force kill
+		kill(child_pid_, SIGKILL);
 		waitpid(child_pid_, &status, 0);
+	reaped:
 		child_pid_ = -1;
 	}
 	if (!file_list_path_.empty()) {

--- a/src/aspera_utils.cpp
+++ b/src/aspera_utils.cpp
@@ -1,5 +1,17 @@
 #include "aspera_utils.hpp"
 
+namespace miint {
+
+std::string GetTempDir() {
+	const char *tmpdir = getenv("TMPDIR");
+	if (tmpdir && tmpdir[0] != '\0') {
+		return std::string(tmpdir);
+	}
+	return "/tmp";
+}
+
+} // namespace miint
+
 #if MIINT_ASPERA_SUPPORTED
 
 #include "duckdb/common/exception.hpp"

--- a/src/include/aspera_utils.hpp
+++ b/src/include/aspera_utils.hpp
@@ -12,6 +12,9 @@
 
 namespace miint {
 
+// Return the temp directory: $TMPDIR if set and non-empty, otherwise /tmp.
+std::string GetTempDir();
+
 struct AsperaPath {
 	std::string host;
 	std::string remote_path;

--- a/src/include/read_ena_fastx.hpp
+++ b/src/include/read_ena_fastx.hpp
@@ -57,15 +57,17 @@ public:
 		FileSystem &fs;
 		bool use_aspera;
 
+		// Progress tracking
+		std::atomic<idx_t> runs_completed;
+		idx_t total_runs;
+
 #if MIINT_ASPERA_SUPPORTED
-		std::unique_ptr<miint::AsperaProcess> aspera_process;
-		std::string temp_file_path; // For paired-end R1 buffering
+		std::vector<std::unique_ptr<miint::AsperaProcess>> aspera_processes;
+		std::vector<std::string> temp_file_paths;
+		miint::AsperaConfig aspera_config;
 #endif
 
 		idx_t MaxThreads() const override {
-			if (use_aspera) {
-				return 1; // Pipe is sequential
-			}
 			return std::min<idx_t>(runs.size(), 8);
 		}
 
@@ -96,6 +98,8 @@ public:
 	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                     GlobalTableFunctionState *global_state);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static double Progress(ClientContext &context, const FunctionData *bind_data,
+	                       const GlobalTableFunctionState *global_state);
 	static TableFunction GetFunction();
 	static void Register(ExtensionLoader &loader);
 };

--- a/src/include/read_ena_fastx.hpp
+++ b/src/include/read_ena_fastx.hpp
@@ -61,6 +61,10 @@ public:
 		std::atomic<idx_t> runs_completed;
 		idx_t total_runs;
 
+		// Skipped runs (transient failures after retry)
+		mutex skipped_lock;
+		std::vector<std::string> skipped_runs;
+
 #if MIINT_ASPERA_SUPPORTED
 		std::vector<std::unique_ptr<miint::AsperaProcess>> aspera_processes;
 		std::vector<std::string> temp_file_paths;

--- a/src/read_ena_fastx.cpp
+++ b/src/read_ena_fastx.cpp
@@ -1,6 +1,7 @@
 #include "read_ena_fastx.hpp"
 #include "SequenceRecord.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include <cerrno>
 #include <fstream>
 
 namespace duckdb {
@@ -23,19 +24,24 @@ ReadENAFastxTableFunction::Data::Data(std::vector<RunInfo> runs, bool include_fp
 // ---- GlobalState ----
 
 ReadENAFastxTableFunction::GlobalState::GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs, bool use_aspera)
-    : runs(runs), next_run_idx(0), fs(fs), use_aspera(use_aspera) {
+    : runs(runs), next_run_idx(0), fs(fs), use_aspera(use_aspera), runs_completed(0), total_runs(runs.size()) {
 	readers.resize(runs.size());
 	run_sequence_counters.resize(runs.size(), 1);
+#if MIINT_ASPERA_SUPPORTED
+	aspera_processes.resize(runs.size());
+	temp_file_paths.resize(runs.size());
+#endif
 }
 
 ReadENAFastxTableFunction::GlobalState::~GlobalState() {
 #if MIINT_ASPERA_SUPPORTED
-	// Clean up temp file if one exists
-	if (!temp_file_path.empty()) {
-		std::remove(temp_file_path.c_str());
-		temp_file_path.clear();
+	for (auto &path : temp_file_paths) {
+		if (!path.empty()) {
+			std::remove(path.c_str());
+			path.clear();
+		}
 	}
-	// AsperaProcess destructor handles killing child + closing pipe
+	// AsperaProcess destructors handle killing children + closing pipes
 #endif
 }
 
@@ -78,24 +84,34 @@ void ReadENAFastxTableFunction::GlobalState::OpenReader(size_t run_idx) {
 
 #if MIINT_ASPERA_SUPPORTED
 
-static std::string GetTempDir() {
-	const char *tmpdir = getenv("TMPDIR");
-	if (tmpdir && tmpdir[0] != '\0') {
-		return std::string(tmpdir);
-	}
-	return "/tmp";
-}
-
 void ReadENAFastxTableFunction::GlobalState::OpenReaderAspera(size_t run_idx) {
 	if (readers[run_idx]) {
 		return;
 	}
 	const auto &run = runs[run_idx];
 
+	// Collect remote paths for this run only
+	std::vector<std::string> remote_paths;
+	for (const auto &ap : run.aspera_paths) {
+		remote_paths.push_back(ap.remote_path);
+	}
+
+	auto config = aspera_config;
+	if (!run.aspera_paths.empty()) {
+		config.host = run.aspera_paths[0].host;
+	}
+
+	// Serialize ascp launches (fork/exec) — pipe reads happen on each thread's own pipe
+	{
+		lock_guard<mutex> open_guard(open_mutex);
+		aspera_processes[run_idx] = std::make_unique<miint::AsperaProcess>(config, remote_paths);
+	}
+	auto *proc = aspera_processes[run_idx].get();
+
 	std::string filename;
 	size_t file_size;
 
-	if (!aspera_process->NextFile(filename, file_size)) {
+	if (!proc->NextFile(filename, file_size)) {
 		throw IOException("read_ena_fastx: Aspera stream ended unexpectedly (expected files for run '%s')",
 		                  run.run_accession);
 	}
@@ -108,37 +124,54 @@ void ReadENAFastxTableFunction::GlobalState::OpenReaderAspera(size_t run_idx) {
 	bool is_gz = IsGzipped(gz_hint);
 
 	if (!run.is_paired) {
-		auto *s1 = miint::CreateAsperaSeqStream(aspera_process.get(), is_gz);
-		readers[run_idx] =
-		    std::make_unique<miint::SequenceReader>(s1, static_cast<miint::AsperaSeqStream *>(nullptr), true);
+		auto *s1 = miint::CreateAsperaSeqStream(proc, is_gz);
+		try {
+			readers[run_idx] =
+			    std::make_unique<miint::SequenceReader>(s1, static_cast<miint::AsperaSeqStream *>(nullptr), true);
+		} catch (...) {
+			delete s1;
+			throw;
+		}
 	} else {
 		// Paired-end: stream R1 from pipe to temp file in chunks, then stream R2 live
 		static constexpr size_t COPY_BUF_SIZE = 1024 * 1024; // 1 MB
 
-		std::string tmpl = GetTempDir() + "/miint_aspera_r1_XXXXXX";
+		std::string tmpl = miint::GetTempDir() + "/miint_aspera_r1_XXXXXX";
 		std::vector<char> tmpl_buf(tmpl.begin(), tmpl.end());
 		tmpl_buf.push_back('\0');
 		int fd = mkstemp(tmpl_buf.data());
 		if (fd == -1) {
 			throw IOException("read_ena_fastx: failed to create temp file for paired-end Aspera buffering");
 		}
-		temp_file_path = std::string(tmpl_buf.data());
+		temp_file_paths[run_idx] = std::string(tmpl_buf.data());
 
 		// Stream-copy R1 from pipe to temp file in 1MB chunks (no full-file buffering)
 		std::vector<char> copy_buf(COPY_BUF_SIZE);
 		while (true) {
-			int n = aspera_process->ReadBounded(copy_buf.data(), COPY_BUF_SIZE);
-			if (n <= 0) {
+			int n = proc->ReadBounded(copy_buf.data(), COPY_BUF_SIZE);
+			if (n == 0) {
 				break;
+			}
+			if (n < 0) {
+				close(fd);
+				std::remove(temp_file_paths[run_idx].c_str());
+				temp_file_paths[run_idx].clear();
+				throw IOException("read_ena_fastx: pipe read error while buffering R1 for run '%s'", run.run_accession);
 			}
 			size_t written = 0;
 			while (written < static_cast<size_t>(n)) {
 				ssize_t w = write(fd, copy_buf.data() + written, static_cast<size_t>(n) - written);
-				if (w <= 0) {
+				if (w < 0) {
+					if (errno == EINTR) {
+						continue;
+					}
+					int err = errno;
 					close(fd);
-					std::remove(temp_file_path.c_str());
-					temp_file_path.clear();
-					throw IOException("read_ena_fastx: failed to write temp file for paired-end Aspera buffering");
+					std::remove(temp_file_paths[run_idx].c_str());
+					temp_file_paths[run_idx].clear();
+					throw IOException("read_ena_fastx: failed to write temp file for paired-end Aspera buffering "
+					                  "(run '%s', errno=%d: %s)",
+					                  run.run_accession, err, strerror(err));
 				}
 				written += static_cast<size_t>(w);
 			}
@@ -148,9 +181,9 @@ void ReadENAFastxTableFunction::GlobalState::OpenReaderAspera(size_t run_idx) {
 		// Advance tar stream to R2
 		std::string filename2;
 		size_t file_size2;
-		if (!aspera_process->NextFile(filename2, file_size2)) {
-			std::remove(temp_file_path.c_str());
-			temp_file_path.clear();
+		if (!proc->NextFile(filename2, file_size2)) {
+			std::remove(temp_file_paths[run_idx].c_str());
+			temp_file_paths[run_idx].clear();
 			throw IOException("read_ena_fastx: Aspera stream ended unexpectedly (expected R2 for run '%s')",
 			                  run.run_accession);
 		}
@@ -161,9 +194,16 @@ void ReadENAFastxTableFunction::GlobalState::OpenReaderAspera(size_t run_idx) {
 		}
 		bool is_gz2 = IsGzipped(gz_hint2);
 
-		auto *s1 = CreateDuckDBSeqStream(fs, temp_file_path, is_gz);
-		auto *s2 = miint::CreateAsperaSeqStream(aspera_process.get(), is_gz2);
-		readers[run_idx] = std::make_unique<miint::SequenceReader>(s1, s2, true);
+		auto *s1 = CreateDuckDBSeqStream(fs, temp_file_paths[run_idx], is_gz);
+		miint::AsperaSeqStream *s2 = nullptr;
+		try {
+			s2 = miint::CreateAsperaSeqStream(proc, is_gz2);
+			readers[run_idx] = std::make_unique<miint::SequenceReader>(s1, s2, true);
+		} catch (...) {
+			delete s2;
+			delete s1;
+			throw;
+		}
 	}
 }
 #endif // MIINT_ASPERA_SUPPORTED
@@ -212,6 +252,34 @@ static std::vector<ReadENAFastxTableFunction::RunInfo> ResolveRuns(miint::ENACli
 
 			std::string layout = (layout_col >= 0 && layout_col < (int)row.size()) ? row[layout_col] : "";
 			info.is_paired = (layout == "PAIRED");
+
+			// ENA sometimes returns 3 files for paired-end runs: unsplit + _1 + _2.
+			// Filter to only _1/_2 for paired-end so we don't accidentally use
+			// the unsplit file as R1.
+			if (info.is_paired && info.fastq_urls.size() > 2) {
+				std::vector<std::string> filtered;
+				for (const auto &url : info.fastq_urls) {
+					// Match _1.fastq or _2.fastq (with optional .gz)
+					if (url.find("_1.fast") != std::string::npos || url.find("_2.fast") != std::string::npos) {
+						filtered.push_back(url);
+					}
+				}
+				if (filtered.size() == 2) {
+					info.fastq_urls = std::move(filtered);
+				}
+			}
+			if (info.is_paired && info.aspera_paths.size() > 2) {
+				std::vector<miint::AsperaPath> filtered;
+				for (const auto &ap : info.aspera_paths) {
+					if (ap.remote_path.find("_1.fast") != std::string::npos ||
+					    ap.remote_path.find("_2.fast") != std::string::npos) {
+						filtered.push_back(ap);
+					}
+				}
+				if (filtered.size() == 2) {
+					info.aspera_paths = std::move(filtered);
+				}
+			}
 
 			if (!info.fastq_urls.empty()) {
 				runs.push_back(std::move(info));
@@ -343,23 +411,7 @@ unique_ptr<GlobalTableFunctionState> ReadENAFastxTableFunction::InitGlobal(Clien
 
 #if MIINT_ASPERA_SUPPORTED
 	if (data.use_aspera) {
-		// Collect all remote paths across all runs (ordered: for each run, R1 then R2)
-		std::vector<std::string> remote_paths;
-		std::string host;
-		for (const auto &run : data.runs) {
-			for (const auto &ap : run.aspera_paths) {
-				if (host.empty()) {
-					host = ap.host;
-				}
-				remote_paths.push_back(ap.remote_path);
-			}
-		}
-
-		auto config = data.aspera_config;
-		if (!host.empty()) {
-			config.host = host;
-		}
-		state->aspera_process = std::make_unique<miint::AsperaProcess>(config, remote_paths);
+		state->aspera_config = data.aspera_config;
 	}
 #endif
 
@@ -388,16 +440,6 @@ void ReadENAFastxTableFunction::Execute(ClientContext &context, TableFunctionInp
 			{
 				lock_guard<mutex> read_lock(global_state.lock);
 				if (global_state.next_run_idx >= global_state.runs.size()) {
-#if MIINT_ASPERA_SUPPORTED
-					// All runs consumed — check ascp exit code
-					if (global_state.aspera_process) {
-						int exit_code = global_state.aspera_process->WaitForExit();
-						global_state.aspera_process.reset();
-						if (exit_code != 0 && exit_code != -1) {
-							throw IOException("read_ena_fastx: ascp exited with code %d", exit_code);
-						}
-					}
-#endif
 					output.SetCardinality(0);
 					return;
 				}
@@ -426,12 +468,20 @@ void ReadENAFastxTableFunction::Execute(ClientContext &context, TableFunctionInp
 			// Release the reader to free the HTTP connection (or Aspera pipe slot)
 			global_state.readers[current_run_idx].reset();
 #if MIINT_ASPERA_SUPPORTED
-			// Clean up temp file for paired-end Aspera
-			if (!global_state.temp_file_path.empty()) {
-				std::remove(global_state.temp_file_path.c_str());
-				global_state.temp_file_path.clear();
+			if (global_state.use_aspera && global_state.aspera_processes[current_run_idx]) {
+				int exit_code = global_state.aspera_processes[current_run_idx]->WaitForExit();
+				global_state.aspera_processes[current_run_idx].reset();
+				if (exit_code != 0 && exit_code != -1) {
+					throw IOException("read_ena_fastx: ascp exited with code %d for run '%s'", exit_code,
+					                  global_state.runs[current_run_idx].run_accession);
+				}
+			}
+			if (!global_state.temp_file_paths[current_run_idx].empty()) {
+				std::remove(global_state.temp_file_paths[current_run_idx].c_str());
+				global_state.temp_file_paths[current_run_idx].clear();
 			}
 #endif
+			global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
 			local_state.has_run = false;
 			continue;
 		}
@@ -504,6 +554,27 @@ void ReadENAFastxTableFunction::Execute(ClientContext &context, TableFunctionInp
 	output.SetCardinality(count);
 }
 
+// ---- Progress ----
+
+double ReadENAFastxTableFunction::Progress(ClientContext &context, const FunctionData *bind_data,
+                                           const GlobalTableFunctionState *global_state) {
+	if (!global_state) {
+		return -1.0;
+	}
+	auto &state = global_state->Cast<GlobalState>();
+	if (state.total_runs == 0) {
+		return 100.0;
+	}
+	idx_t completed = state.runs_completed.load(std::memory_order_relaxed);
+	if (completed == 0) {
+		// Work is in progress (downloading) but no run has completed yet.
+		// Return a small positive value so the shell progress bar's time
+		// remaining estimator does not divide by zero progress rate.
+		return 0.5;
+	}
+	return std::min(100.0, static_cast<double>(completed) / static_cast<double>(state.total_runs) * 100.0);
+}
+
 // ---- Registration ----
 
 TableFunction ReadENAFastxTableFunction::GetFunction() {
@@ -511,6 +582,8 @@ TableFunction ReadENAFastxTableFunction::GetFunction() {
 	tf.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
 	tf.named_parameters["qual_offset"] = LogicalType::BIGINT;
 	tf.named_parameters["download_method"] = LogicalType::VARCHAR;
+	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
+	tf.table_scan_progress = Progress;
 	return tf;
 }
 

--- a/src/read_ena_fastx.cpp
+++ b/src/read_ena_fastx.cpp
@@ -1,5 +1,6 @@
 #include "read_ena_fastx.hpp"
 #include "SequenceRecord.hpp"
+#include "duckdb/common/printer.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include <cerrno>
 #include <fstream>
@@ -434,12 +435,52 @@ void ReadENAFastxTableFunction::Execute(ClientContext &context, TableFunctionInp
 	miint::SequenceRecordBatch batch;
 	size_t current_run_idx;
 
+	// Helper: tear down a failed run's reader and process
+	auto cleanup_run = [&](size_t idx) {
+		global_state.readers[idx].reset();
+#if MIINT_ASPERA_SUPPORTED
+		if (global_state.use_aspera && global_state.aspera_processes[idx]) {
+			global_state.aspera_processes[idx].reset();
+		}
+		if (!global_state.temp_file_paths[idx].empty()) {
+			std::remove(global_state.temp_file_paths[idx].c_str());
+			global_state.temp_file_paths[idx].clear();
+		}
+#endif
+	};
+
+	// Helper: open reader for the current run
+	auto open_run = [&](size_t idx) {
+#if MIINT_ASPERA_SUPPORTED
+		if (global_state.use_aspera) {
+			global_state.OpenReaderAspera(idx);
+		} else {
+			global_state.OpenReader(idx);
+		}
+#else
+		global_state.OpenReader(idx);
+#endif
+	};
+
 	// Claim-read-release loop (same pattern as read_fastx)
 	while (true) {
 		if (!local_state.has_run) {
 			{
 				lock_guard<mutex> read_lock(global_state.lock);
 				if (global_state.next_run_idx >= global_state.runs.size()) {
+					// Report skipped runs as a warning so the user knows
+					if (!global_state.skipped_runs.empty()) {
+						lock_guard<mutex> skip_guard(global_state.skipped_lock);
+						if (!global_state.skipped_runs.empty()) {
+							std::string msg =
+							    "read_ena_fastx: WARNING: " + std::to_string(global_state.skipped_runs.size()) +
+							    " run(s) skipped due to download errors:";
+							for (const auto &acc : global_state.skipped_runs) {
+								msg += " " + acc;
+							}
+							Printer::Print(msg);
+						}
+					}
 					output.SetCardinality(0);
 					return;
 				}
@@ -448,24 +489,62 @@ void ReadENAFastxTableFunction::Execute(ClientContext &context, TableFunctionInp
 				local_state.has_run = true;
 			} // Lock released before I/O
 
-			// Open reader without holding the lock — safe because this thread
-			// has exclusive ownership of the claimed run index
-#if MIINT_ASPERA_SUPPORTED
-			if (global_state.use_aspera) {
-				global_state.OpenReaderAspera(local_state.current_run_idx);
-			} else {
-				global_state.OpenReader(local_state.current_run_idx);
+			// Open reader — retry once on failure before skipping
+			try {
+				open_run(local_state.current_run_idx);
+			} catch (const std::exception &e) {
+				auto &run = global_state.runs[local_state.current_run_idx];
+				Printer::PrintF("read_ena_fastx: warning: run '%s' failed to open (%s), retrying...", run.run_accession,
+				                e.what());
+				cleanup_run(local_state.current_run_idx);
+				global_state.run_sequence_counters[local_state.current_run_idx] = 1;
+				try {
+					open_run(local_state.current_run_idx);
+				} catch (const std::exception &e2) {
+					Printer::PrintF("read_ena_fastx: warning: run '%s' failed on retry (%s), skipping",
+					                run.run_accession, e2.what());
+					cleanup_run(local_state.current_run_idx);
+					{
+						lock_guard<mutex> skip_guard(global_state.skipped_lock);
+						global_state.skipped_runs.push_back(run.run_accession);
+					}
+					global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
+					local_state.has_run = false;
+					continue;
+				}
 			}
-#else
-			global_state.OpenReader(local_state.current_run_idx);
-#endif
 		}
 
 		current_run_idx = local_state.current_run_idx;
-		batch = global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
+		try {
+			batch = global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
+		} catch (const std::exception &e) {
+			// Mid-stream read failure (e.g., truncated stream, mismatched R1/R2).
+			// Tear down and retry the entire run from scratch.
+			auto &run = global_state.runs[current_run_idx];
+			Printer::PrintF("read_ena_fastx: warning: run '%s' failed mid-stream (%s), retrying...", run.run_accession,
+			                e.what());
+			cleanup_run(current_run_idx);
+			global_state.run_sequence_counters[current_run_idx] = 1;
+			try {
+				open_run(current_run_idx);
+				batch = global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
+			} catch (const std::exception &e2) {
+				Printer::PrintF("read_ena_fastx: warning: run '%s' failed on retry (%s), skipping", run.run_accession,
+				                e2.what());
+				cleanup_run(current_run_idx);
+				{
+					lock_guard<mutex> skip_guard(global_state.skipped_lock);
+					global_state.skipped_runs.push_back(run.run_accession);
+				}
+				global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
+				local_state.has_run = false;
+				continue;
+			}
+		}
 
 		if (batch.empty()) {
-			// Release the reader to free the HTTP connection (or Aspera pipe slot)
+			// Run completed successfully — release resources
 			global_state.readers[current_run_idx].reset();
 #if MIINT_ASPERA_SUPPORTED
 			if (global_state.use_aspera && global_state.aspera_processes[current_run_idx]) {

--- a/test/cpp/test_AsperaUtils.cpp
+++ b/test/cpp/test_AsperaUtils.cpp
@@ -41,6 +41,7 @@ TEST_CASE("AsperaUtils path parsing", "[aspera]") {
 	}
 }
 
+#if !defined(_WIN32)
 TEST_CASE("GetTempDir respects TMPDIR", "[aspera]") {
 	SECTION("returns /tmp when TMPDIR unset") {
 		unsetenv("TMPDIR");
@@ -57,6 +58,7 @@ TEST_CASE("GetTempDir respects TMPDIR", "[aspera]") {
 		unsetenv("TMPDIR");
 	}
 }
+#endif
 
 TEST_CASE("AsperaUtils config building", "[aspera]") {
 	auto config = miint::AsperaUtils::BuildConfig("/usr/bin/ascp", "/home/user/.aspera/key.openssh");

--- a/test/cpp/test_AsperaUtils.cpp
+++ b/test/cpp/test_AsperaUtils.cpp
@@ -41,6 +41,23 @@ TEST_CASE("AsperaUtils path parsing", "[aspera]") {
 	}
 }
 
+TEST_CASE("GetTempDir respects TMPDIR", "[aspera]") {
+	SECTION("returns /tmp when TMPDIR unset") {
+		unsetenv("TMPDIR");
+		REQUIRE(miint::GetTempDir() == "/tmp");
+	}
+	SECTION("returns TMPDIR value when set") {
+		setenv("TMPDIR", "/my/custom/tmp", 1);
+		REQUIRE(miint::GetTempDir() == "/my/custom/tmp");
+		unsetenv("TMPDIR");
+	}
+	SECTION("returns /tmp when TMPDIR is empty") {
+		setenv("TMPDIR", "", 1);
+		REQUIRE(miint::GetTempDir() == "/tmp");
+		unsetenv("TMPDIR");
+	}
+}
+
 TEST_CASE("AsperaUtils config building", "[aspera]") {
 	auto config = miint::AsperaUtils::BuildConfig("/usr/bin/ascp", "/home/user/.aspera/key.openssh");
 	CHECK(config.ascp_path == "/usr/bin/ascp");


### PR DESCRIPTION
Restructure read_ena_fastx to launch one AsperaProcess per run instead of a single shared process for all runs. This enables parallel Aspera downloads matching the existing HTTP parallelism (up to 8 threads).

Key changes:
- Per-run aspera_processes/temp_file_paths vectors in GlobalState
- OpenReaderAspera creates per-run AsperaProcess under open_mutex
- Per-run exit code checking and temp file cleanup in Execute
- NO_ORDER for parallel CTAS pipelines
- Extract GetTempDir() to miint namespace, honor $TMPDIR everywhere
- Fix 3-file paired-end ENA layout (unsplit+_1+_2 → keep only _1/_2)
- Fix destructor hang: WNOHANG poll + SIGKILL fallback after 1s
- Fix ReadBounded -1 error vs EOF distinction in R1 buffering
- Fix file-list temp file leak on pipe/fork failure
- Fix raw pointer leak in PE stream creation on exception
- Add EINTR handling in R1 temp file write loop
- Switch ascp from -T to -QT (adaptive rate + no encryption)
- Add progress bar via table_scan_progress callback