### PR TITLE
Bound read_fastx memory and fix FASTA/FASTQ COPY performance on large…

### DIFF
--- a/src/SequenceReader.cpp
+++ b/src/SequenceReader.cpp
@@ -167,107 +167,202 @@ SequenceReader::SequenceReader(DuckDBSeqStream *stream1, AsperaSeqStream *stream
 #endif // MIINT_ASPERA_SUPPORTED
 #endif // MIINT_STATIC_BUILD
 
-SequenceRecordBatch SequenceReader::read_se(const int n) {
+// Records polled per stream call. Larger values amortize per-call overhead (vector
+// allocation) across more records; smaller values cap the transient memory overshoot
+// when a single poll pulls in records that together exceed max_bytes. 16 is a
+// compromise: for short-read FASTQ a 2048-record chunk needs ~128 polls instead of
+// 2048 (cuts ~94% of per-record allocation overhead), while for bacterial genomes
+// (~5 MB/record) the worst-case overshoot is 16 * 5 MB = 80 MB -- negligible next to
+// a 512 MB default budget. Any tail records beyond the stop point are pushed back
+// into buffered_read1_ / buffered_read2_ for the next call, so nothing is dropped.
+static constexpr int POLL_CHUNK_SIZE = 16;
+
+// Bytes contributed by a single record. Counted against the per-chunk budget so that
+// FASTQ quality (and paired mates) are accounted for alongside the sequence itself.
+static size_t record_bytes(const klibpp::KSeq &rec) {
+	return rec.name.size() + rec.comment.size() + rec.seq.size() + rec.qual.size();
+}
+
+// Append a KSeq into an SE batch, stripping sequence whitespace in place.
+static void append_se(SequenceRecordBatch &batch, klibpp::KSeq &rec) {
+	rec.seq.erase(std::remove_if(rec.seq.begin(), rec.seq.end(), [](unsigned char c) { return std::isspace(c); }),
+	              rec.seq.end());
+	batch.read_ids.emplace_back(base_read_id(rec.name));
+	batch.comments.emplace_back(rec.comment);
+	batch.sequences1.emplace_back(std::move(rec.seq));
+	batch.quals1.emplace_back(rec.qual);
+}
+
+SequenceRecordBatch SequenceReader::read_se(const int n, const size_t max_bytes) {
 	SequenceRecordBatch batch(false);
 	batch.reserve(n);
 
-	std::vector<klibpp::KSeq> reads;
+	size_t cumulative_bytes = 0;
 
-	// On first read, return buffered records first
+	// Drain a polled chunk into `batch`, pushing any unused tail into buffered_read1_ when
+	// a stop condition (budget hit or batch full) fires mid-chunk. Returns true when the
+	// whole chunk was consumed and caller should poll again, false otherwise.
+	auto drain_chunk = [&](std::vector<klibpp::KSeq> &chunk) -> bool {
+		for (size_t i = 0; i < chunk.size(); i++) {
+			auto &rec = chunk[i];
+			const size_t rec_bytes = record_bytes(rec);
+			// Starvation guard: if batch is still empty, accept at least one record even
+			// when it alone exceeds max_bytes -- otherwise the pipeline stalls.
+			if (!batch.empty() && cumulative_bytes + rec_bytes > max_bytes) {
+				buffered_read1_.clear();
+				buffered_read1_.reserve(chunk.size() - i);
+				for (size_t j = i; j < chunk.size(); j++) {
+					buffered_read1_.push_back(std::move(chunk[j]));
+				}
+				first_read_ = true;
+				return false;
+			}
+			append_se(batch, rec);
+			cumulative_bytes += rec_bytes;
+			const bool done = (int)batch.size() >= n || cumulative_bytes >= max_bytes;
+			if (done) {
+				if (i + 1 < chunk.size()) {
+					buffered_read1_.clear();
+					buffered_read1_.reserve(chunk.size() - (i + 1));
+					for (size_t j = i + 1; j < chunk.size(); j++) {
+						buffered_read1_.push_back(std::move(chunk[j]));
+					}
+					first_read_ = true;
+				}
+				return false;
+			}
+		}
+		return true;
+	};
+
+	// Replay pre-buffered records first (peeked at construction, or tail from a prior call).
 	if (first_read_) {
 		first_read_ = false;
-		reads = std::move(buffered_read1_);
-
-		// If we got fewer than n records from buffer, read more
-		int remaining = n - (int)reads.size();
-		if (remaining > 0) {
-			auto more = read_stream(sequence1_reader_, remaining);
-			reads.insert(reads.end(), more.begin(), more.end());
+		auto buffered = std::move(buffered_read1_);
+		buffered_read1_.clear();
+		if (!drain_chunk(buffered)) {
+			return batch;
 		}
-	} else {
-		reads = read_stream(sequence1_reader_, n);
 	}
 
-	// Populate batch directly from KSeq records
-	for (auto &rec : reads) {
-		// Strip whitespace from sequence (FASTA files may contain spaces/newlines in sequences)
-		rec.seq.erase(std::remove_if(rec.seq.begin(), rec.seq.end(), [](unsigned char c) { return std::isspace(c); }),
-		              rec.seq.end());
-
-		batch.read_ids.emplace_back(base_read_id(rec.name));
-		batch.comments.emplace_back(rec.comment);
-		batch.sequences1.emplace_back(std::move(rec.seq));
-		batch.quals1.emplace_back(rec.qual);
+	// Poll the stream in chunks so the budget can short-circuit before the next I/O round.
+	while ((int)batch.size() < n && cumulative_bytes < max_bytes) {
+		const int remaining = n - (int)batch.size();
+		const int poll_n = remaining < POLL_CHUNK_SIZE ? remaining : POLL_CHUNK_SIZE;
+		auto more = read_stream(sequence1_reader_, poll_n);
+		if (more.empty()) {
+			break;
+		}
+		if (!drain_chunk(more)) {
+			break;
+		}
 	}
 
 	return batch;
 }
 
-SequenceRecordBatch SequenceReader::read_pe(const int n) {
+// Append a paired KSeq into a PE batch, stripping sequence whitespace on both mates.
+static void append_pe(SequenceRecordBatch &batch, klibpp::KSeq &rec1, klibpp::KSeq &rec2) {
+	rec1.seq.erase(std::remove_if(rec1.seq.begin(), rec1.seq.end(), [](unsigned char c) { return std::isspace(c); }),
+	               rec1.seq.end());
+	rec2.seq.erase(std::remove_if(rec2.seq.begin(), rec2.seq.end(), [](unsigned char c) { return std::isspace(c); }),
+	               rec2.seq.end());
+
+	batch.read_ids.emplace_back(base_read_id(rec1.name));
+	batch.comments.emplace_back(rec1.comment);
+	batch.sequences1.emplace_back(std::move(rec1.seq));
+	batch.sequences2.emplace_back(std::move(rec2.seq));
+	batch.quals1.emplace_back(rec1.qual);
+	batch.quals2.emplace_back(rec2.qual);
+}
+
+SequenceRecordBatch SequenceReader::read_pe(const int n, const size_t max_bytes) {
 	SequenceRecordBatch batch(true);
 	batch.reserve(n);
 
-	// Read sequence1 and sequence2 sequentially
-	// DuckDB's parallel execution (MaxThreads) provides better parallelism
-	// than internal threading with small batch sizes
-	std::vector<klibpp::KSeq> read1s, read2s;
+	size_t cumulative_bytes = 0;
 
-	// On first read, start with buffered records
+	// Push [i..end) of both chunks into buffered_read1_ / buffered_read2_ so the next call
+	// replays them. Kept in a helper to keep mate buffers in lockstep.
+	auto push_back_tail = [&](std::vector<klibpp::KSeq> &c1, std::vector<klibpp::KSeq> &c2, size_t i) {
+		buffered_read1_.clear();
+		buffered_read2_.clear();
+		const size_t tail = c1.size() - i;
+		buffered_read1_.reserve(tail);
+		buffered_read2_.reserve(tail);
+		for (size_t j = i; j < c1.size(); j++) {
+			buffered_read1_.push_back(std::move(c1[j]));
+			buffered_read2_.push_back(std::move(c2[j]));
+		}
+		first_read_ = true;
+	};
+
+	// Drain paired chunks into `batch`, validating mate-id parity and enforcing the budget.
+	auto drain_chunks = [&](std::vector<klibpp::KSeq> &c1, std::vector<klibpp::KSeq> &c2) -> bool {
+		if (c1.size() != c2.size()) {
+			const std::string &id = !c1.empty() ? c1.back().name : c2.back().name;
+			throw std::runtime_error("Mismatched number of records: missing mate for " + id);
+		}
+		for (size_t i = 0; i < c1.size(); i++) {
+			auto &rec1 = c1[i];
+			auto &rec2 = c2[i];
+			check_ids(rec1.name, rec2.name);
+			const size_t pair_bytes = record_bytes(rec1) + record_bytes(rec2);
+			if (!batch.empty() && cumulative_bytes + pair_bytes > max_bytes) {
+				push_back_tail(c1, c2, i);
+				return false;
+			}
+			append_pe(batch, rec1, rec2);
+			cumulative_bytes += pair_bytes;
+			const bool done = (int)batch.size() >= n || cumulative_bytes >= max_bytes;
+			if (done) {
+				if (i + 1 < c1.size()) {
+					push_back_tail(c1, c2, i + 1);
+				}
+				return false;
+			}
+		}
+		return true;
+	};
+
 	if (first_read_) {
 		first_read_ = false;
-		read1s = std::move(buffered_read1_);
-		read2s = std::move(buffered_read2_);
+		auto buf1 = std::move(buffered_read1_);
+		auto buf2 = std::move(buffered_read2_);
+		buffered_read1_.clear();
+		buffered_read2_.clear();
 
-		// If we got fewer than n records from buffer, read more
-		int remaining = n - (int)read1s.size();
-		if (remaining > 0) {
-			auto more1 = read_stream(sequence1_reader_, remaining);
-			auto more2 = read_stream(sequence2_reader_.value(), remaining);
-			read1s.insert(read1s.end(), more1.begin(), more1.end());
-			read2s.insert(read2s.end(), more2.begin(), more2.end());
+		if (buf1.size() != buf2.size()) {
+			// Should not happen -- peek-at-construction and push_back_tail keep them in sync.
+			throw std::runtime_error("Buffered paired records out of sync (internal error)");
 		}
-	} else {
-		read1s = read_stream(sequence1_reader_, n);
-		read2s = read_stream(sequence2_reader_.value(), n);
+		if (!drain_chunks(buf1, buf2)) {
+			return batch;
+		}
 	}
 
-	if (read1s.size() != read2s.size()) {
-		auto id1 = read1s.back().name;
-		throw std::runtime_error("Mismatched number of records: missing mate for " + id1);
-	}
+	while ((int)batch.size() < n && cumulative_bytes < max_bytes) {
+		const int remaining = n - (int)batch.size();
+		const int poll_n = remaining < POLL_CHUNK_SIZE ? remaining : POLL_CHUNK_SIZE;
+		auto more1 = read_stream(sequence1_reader_, poll_n);
+		auto more2 = read_stream(sequence2_reader_.value(), poll_n);
 
-	// Populate batch directly from KSeq records
-	for (size_t i = 0; i < read1s.size(); i++) {
-		auto &rec1 = read1s[i];
-		auto &rec2 = read2s[i];
-
-		// Validate that read IDs match
-		check_ids(rec1.name, rec2.name);
-
-		// Strip whitespace from sequences (FASTA files may contain spaces/newlines in sequences)
-		rec1.seq.erase(
-		    std::remove_if(rec1.seq.begin(), rec1.seq.end(), [](unsigned char c) { return std::isspace(c); }),
-		    rec1.seq.end());
-		rec2.seq.erase(
-		    std::remove_if(rec2.seq.begin(), rec2.seq.end(), [](unsigned char c) { return std::isspace(c); }),
-		    rec2.seq.end());
-
-		batch.read_ids.emplace_back(base_read_id(rec1.name));
-		batch.comments.emplace_back(rec1.comment);
-		batch.sequences1.emplace_back(std::move(rec1.seq));
-		batch.sequences2.emplace_back(std::move(rec2.seq));
-		batch.quals1.emplace_back(rec1.qual);
-		batch.quals2.emplace_back(rec2.qual);
+		if (more1.empty() && more2.empty()) {
+			break;
+		}
+		if (!drain_chunks(more1, more2)) {
+			break;
+		}
 	}
 
 	return batch;
 }
 
-SequenceRecordBatch SequenceReader::read(const int n) {
+SequenceRecordBatch SequenceReader::read(const int n, const size_t max_bytes) {
 	if (paired_) {
-		return read_pe(n);
+		return read_pe(n, max_bytes);
 	} else {
-		return read_se(n);
+		return read_se(n, max_bytes);
 	}
 }
 }; // namespace miint

--- a/src/copy_fasta.cpp
+++ b/src/copy_fasta.cpp
@@ -116,28 +116,22 @@ static unique_ptr<LocalFunctionData> FastaCopyInitializeLocal(ExecutionContext &
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
-static void WriteFastaRecordToBuffer(MemoryStream &stream, const string &id, const string &seq, const string &comment) {
-	// Pre-calculate total size to avoid reallocations
-	idx_t size = 1 + id.size() + 1 + seq.size() + 1; // > + id + \n + seq + \n
-	if (!comment.empty()) {
-		size += 1 + comment.size(); // space + comment
+// Write a FASTA record directly to the stream without building an intermediate string.
+// Avoids O(seq.size()) extra copies per record -- the previous implementation copied the
+// sequence bytes twice (into an intermediate `record` string, then into the stream). For
+// a FASTA of bacterial genomes (~5 MB/record) that's ~10 MB of extra memory bandwidth per
+// record; direct writes let the sequence flow kseq->MemoryStream with a single memcpy.
+static void WriteFastaRecordToBuffer(MemoryStream &stream, const char *id, idx_t id_size, const char *seq,
+                                     idx_t seq_size, const char *comment, idx_t comment_size) {
+	stream.WriteData(const_data_ptr_cast(">"), 1);
+	stream.WriteData(const_data_ptr_cast(id), id_size);
+	if (comment_size > 0) {
+		stream.WriteData(const_data_ptr_cast(" "), 1);
+		stream.WriteData(const_data_ptr_cast(comment), comment_size);
 	}
-
-	// Build record string with pre-reserved capacity
-	string record;
-	record.reserve(size);
-	record += '>';
-	record += id;
-	if (!comment.empty()) {
-		record += ' ';
-		record += comment;
-	}
-	record += '\n';
-	record += seq;
-	record += '\n';
-
-	// Write to stream
-	stream.WriteData(const_data_ptr_cast(record.c_str()), record.size());
+	stream.WriteData(const_data_ptr_cast("\n"), 1);
+	stream.WriteData(const_data_ptr_cast(seq), seq_size);
+	stream.WriteData(const_data_ptr_cast("\n"), 1);
 }
 
 static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate_p,
@@ -179,7 +173,11 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		stream_r2 = lstate.writer_state_r2->stream.get();
 	}
 
-	// Build all records into local buffer(s) - NO LOCK
+	// Build all records into local buffer(s) - NO LOCK.
+	// Hot-path rule: never call string_t::GetString() on the sequence -- it makes a heap
+	// copy of the (potentially multi-MB) sequence per record. Use GetData()/GetSize() so
+	// the sequence bytes flow directly from the DuckDB string heap into the MemoryStream.
+	string id_buf; // only used when id_as_sequence_index is true
 	for (idx_t row = 0; row < input.size(); row++) {
 		auto row_idx = read_id_data.sel->get_index(row);
 
@@ -189,22 +187,28 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		}
 
 		// Get ID
-		string id;
+		const char *id_ptr;
+		idx_t id_size;
 		if (fdata.id_as_sequence_index) {
 			auto seq_idx_data = UnifiedVectorFormat::GetData<int64_t>(sequence_index_data);
 			auto seq_idx_row = sequence_index_data.sel->get_index(row);
-			id = to_string(seq_idx_data[seq_idx_row]);
+			id_buf = to_string(seq_idx_data[seq_idx_row]);
+			id_ptr = id_buf.data();
+			id_size = id_buf.size();
 		} else {
-			id = read_ids[row_idx].GetString();
+			id_ptr = read_ids[row_idx].GetData();
+			id_size = read_ids[row_idx].GetSize();
 		}
 
-		// Get comment
-		string comment;
+		// Get comment (may be absent or NULL)
+		const char *comment_ptr = nullptr;
+		idx_t comment_size = 0;
 		if (fdata.include_comment && indices.comment_idx != DConstants::INVALID_INDEX) {
 			auto comment_strings = UnifiedVectorFormat::GetData<string_t>(comment_data);
 			auto comment_row = comment_data.sel->get_index(row);
 			if (comment_data.validity.RowIsValid(comment_row)) {
-				comment = comment_strings[comment_row].GetString();
+				comment_ptr = comment_strings[comment_row].GetData();
+				comment_size = comment_strings[comment_row].GetSize();
 			}
 		}
 
@@ -213,10 +217,11 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		if (!seq1_data.validity.RowIsValid(seq1_row)) {
 			throw InvalidInputException("NULL value in sequence1 column (row %llu)", row);
 		}
-		string seq1 = seq1_strings[seq1_row].GetString();
+		const char *seq1_ptr = seq1_strings[seq1_row].GetData();
+		idx_t seq1_size = seq1_strings[seq1_row].GetSize();
 
 		// Write R1 record to local buffer
-		WriteFastaRecordToBuffer(stream_r1, id, seq1, comment);
+		WriteFastaRecordToBuffer(stream_r1, id_ptr, id_size, seq1_ptr, seq1_size, comment_ptr, comment_size);
 		lstate.writer_state_r1->written_anything = true;
 
 		// Handle R2 for paired-end
@@ -226,26 +231,29 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 			if (!seq2_data.validity.RowIsValid(seq2_row)) {
 				throw InvalidInputException("NULL value in sequence2 column (row %llu)", row);
 			}
-			string seq2 = seq2_strings[seq2_row].GetString();
+			const char *seq2_ptr = seq2_strings[seq2_row].GetData();
+			idx_t seq2_size = seq2_strings[seq2_row].GetSize();
 
 			if (fdata.interleave) {
 				// Write R2 to same buffer
-				WriteFastaRecordToBuffer(stream_r1, id, seq2, comment);
+				WriteFastaRecordToBuffer(stream_r1, id_ptr, id_size, seq2_ptr, seq2_size, comment_ptr, comment_size);
 			} else {
 				// Write R2 to separate buffer
-				WriteFastaRecordToBuffer(*stream_r2, id, seq2, comment);
+				WriteFastaRecordToBuffer(*stream_r2, id_ptr, id_size, seq2_ptr, seq2_size, comment_ptr, comment_size);
 				lstate.writer_state_r2->written_anything = true;
 			}
 		}
-	}
 
-	// Check if we need to flush (buffer exceeded threshold)
-	if (lstate.writer_state_r1->stream->GetPosition() >= lstate.writer_state_r1->flush_size) {
-		FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
-	}
-
-	if (stream_r2 && lstate.writer_state_r2->stream->GetPosition() >= lstate.writer_state_r2->flush_size) {
-		FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+		// Flush per-record once the threshold is crossed, not per-chunk. Large records
+		// (bacterial genomes, plant chromosomes) can each be multiple MB; batching them
+		// until the end of a DataChunk would let the buffer grow to many GB before the
+		// first flush, which blows past gzip's 4 GiB write limit and chews memory.
+		if (lstate.writer_state_r1->stream->GetPosition() >= lstate.writer_state_r1->flush_size) {
+			FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
+		}
+		if (stream_r2 && lstate.writer_state_r2->stream->GetPosition() >= lstate.writer_state_r2->flush_size) {
+			FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+		}
 	}
 }
 

--- a/src/copy_fastq.cpp
+++ b/src/copy_fastq.cpp
@@ -215,8 +215,8 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 	// makes a heap copy per record. Use GetData()/GetSize() and write directly to the
 	// MemoryStream. The quality-encoding buffer is reused across rows so ASCII-offset
 	// encoding doesn't allocate per record either.
-	string id_buf;            // reused when id_as_sequence_index is true
-	string qual_encoded_buf;  // reused across all rows and both mates
+	string id_buf;           // reused when id_as_sequence_index is true
+	string qual_encoded_buf; // reused across all rows and both mates
 	for (idx_t row = 0; row < input.size(); row++) {
 		auto row_idx = read_id_data.sel->get_index(row);
 

--- a/src/copy_fastq.cpp
+++ b/src/copy_fastq.cpp
@@ -42,13 +42,6 @@ struct FastqCopyBindData : public SequenceCopyBindData {
 };
 
 //===--------------------------------------------------------------------===//
-// Helper Functions
-//===--------------------------------------------------------------------===//
-static string EncodeQuality(const uint8_t *qual_data, idx_t length, uint8_t offset) {
-	return miint::encode_quality_ascii(qual_data, static_cast<size_t>(length), offset);
-}
-
-//===--------------------------------------------------------------------===//
 // Bind
 //===--------------------------------------------------------------------===//
 static unique_ptr<FunctionData> FastqCopyBind(ClientContext &context, CopyFunctionBindInput &input,
@@ -143,32 +136,36 @@ static unique_ptr<LocalFunctionData> FastqCopyInitializeLocal(ExecutionContext &
 //===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
-static void WriteFastqRecordToBuffer(MemoryStream &stream, const string &id, const string &seq,
-                                     const uint8_t *qual_data, idx_t qual_length, uint8_t qual_offset,
-                                     const string &comment) {
-	// Pre-calculate total size to avoid reallocations
-	idx_t size = 1 + id.size() + 1 + seq.size() + 3 + qual_length + 1; // @ + id + \n + seq + \n+\n + qual + \n
-	if (!comment.empty()) {
-		size += 1 + comment.size(); // space + comment
+// Write a FASTQ record directly to the stream without a per-record intermediate string.
+// `qual_encoded_buf` is a caller-owned scratch buffer reused across records -- we resize
+// it to qual_length and fill in place, amortizing quality-encoding allocation across the
+// DataChunk instead of allocating fresh per row. Saves several large copies per record
+// on long-read FASTQ (sequence + quality can each be multi-kB).
+static void WriteFastqRecordToBuffer(MemoryStream &stream, const char *id, idx_t id_size, const char *seq,
+                                     idx_t seq_size, const uint8_t *qual_data, idx_t qual_length, uint8_t qual_offset,
+                                     const char *comment, idx_t comment_size, string &qual_encoded_buf) {
+	qual_encoded_buf.resize(qual_length);
+	for (idx_t k = 0; k < qual_length; k++) {
+		int encoded = static_cast<int>(qual_data[k]) + qual_offset;
+		if (encoded > 126) {
+			throw InvalidInputException("Quality score overflow: " + std::to_string(qual_data[k]) + " + " +
+			                            std::to_string(qual_offset) + " = " + std::to_string(encoded) +
+			                            " exceeds valid ASCII range (max 126)");
+		}
+		qual_encoded_buf[k] = static_cast<char>(encoded);
 	}
 
-	// Build record string with pre-reserved capacity
-	string record;
-	record.reserve(size);
-	record += '@';
-	record += id;
-	if (!comment.empty()) {
-		record += ' ';
-		record += comment;
+	stream.WriteData(const_data_ptr_cast("@"), 1);
+	stream.WriteData(const_data_ptr_cast(id), id_size);
+	if (comment_size > 0) {
+		stream.WriteData(const_data_ptr_cast(" "), 1);
+		stream.WriteData(const_data_ptr_cast(comment), comment_size);
 	}
-	record += '\n';
-	record += seq;
-	record += "\n+\n";
-	record += EncodeQuality(qual_data, qual_length, qual_offset);
-	record += '\n';
-
-	// Write to stream
-	stream.WriteData(const_data_ptr_cast(record.c_str()), record.size());
+	stream.WriteData(const_data_ptr_cast("\n"), 1);
+	stream.WriteData(const_data_ptr_cast(seq), seq_size);
+	stream.WriteData(const_data_ptr_cast("\n+\n"), 3);
+	stream.WriteData(const_data_ptr_cast(qual_encoded_buf.data()), qual_length);
+	stream.WriteData(const_data_ptr_cast("\n"), 1);
 }
 
 static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate_p,
@@ -213,7 +210,13 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		stream_r2 = lstate.writer_state_r2->stream.get();
 	}
 
-	// Build all records into local buffer(s) - NO LOCK
+	// Build all records into local buffer(s) - NO LOCK.
+	// Hot-path rule: never call string_t::GetString() on sequence/quality fields -- it
+	// makes a heap copy per record. Use GetData()/GetSize() and write directly to the
+	// MemoryStream. The quality-encoding buffer is reused across rows so ASCII-offset
+	// encoding doesn't allocate per record either.
+	string id_buf;            // reused when id_as_sequence_index is true
+	string qual_encoded_buf;  // reused across all rows and both mates
 	for (idx_t row = 0; row < input.size(); row++) {
 		auto row_idx = read_id_data.sel->get_index(row);
 
@@ -223,22 +226,28 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		}
 
 		// Get ID
-		string id;
+		const char *id_ptr;
+		idx_t id_size;
 		if (fdata.id_as_sequence_index) {
 			auto seq_idx_data = UnifiedVectorFormat::GetData<int64_t>(sequence_index_data);
 			auto seq_idx_row = sequence_index_data.sel->get_index(row);
-			id = to_string(seq_idx_data[seq_idx_row]);
+			id_buf = to_string(seq_idx_data[seq_idx_row]);
+			id_ptr = id_buf.data();
+			id_size = id_buf.size();
 		} else {
-			id = read_ids[row_idx].GetString();
+			id_ptr = read_ids[row_idx].GetData();
+			id_size = read_ids[row_idx].GetSize();
 		}
 
-		// Get comment
-		string comment;
+		// Get comment (may be absent or NULL)
+		const char *comment_ptr = nullptr;
+		idx_t comment_size = 0;
 		if (fdata.include_comment && indices.comment_idx != DConstants::INVALID_INDEX) {
 			auto comment_strings = UnifiedVectorFormat::GetData<string_t>(comment_data);
 			auto comment_row = comment_data.sel->get_index(row);
 			if (comment_data.validity.RowIsValid(comment_row)) {
-				comment = comment_strings[comment_row].GetString();
+				comment_ptr = comment_strings[comment_row].GetData();
+				comment_size = comment_strings[comment_row].GetSize();
 			}
 		}
 
@@ -247,7 +256,8 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		if (!seq1_data.validity.RowIsValid(seq1_row)) {
 			throw InvalidInputException("NULL value in sequence1 column (row %llu)", row);
 		}
-		string seq1 = seq1_strings[seq1_row].GetString();
+		const char *seq1_ptr = seq1_strings[seq1_row].GetData();
+		idx_t seq1_size = seq1_strings[seq1_row].GetSize();
 
 		auto qual1_row = qual1_data.sel->get_index(row);
 		if (!qual1_data.validity.RowIsValid(qual1_row)) {
@@ -260,14 +270,15 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		const uint8_t *qual1_ptr = qual1_list_data + qual1_entries[qual1_row].offset;
 
 		// Validate quality score length matches sequence length
-		if (qual1_length != seq1.size()) {
+		if (qual1_length != seq1_size) {
 			throw InvalidInputException(
 			    "Quality score length (%llu) does not match sequence length (%llu) for row %llu", qual1_length,
-			    seq1.size(), row);
+			    seq1_size, row);
 		}
 
 		// Write R1 record to local buffer
-		WriteFastqRecordToBuffer(stream_r1, id, seq1, qual1_ptr, qual1_length, fdata.qual_offset, comment);
+		WriteFastqRecordToBuffer(stream_r1, id_ptr, id_size, seq1_ptr, seq1_size, qual1_ptr, qual1_length,
+		                         fdata.qual_offset, comment_ptr, comment_size, qual_encoded_buf);
 		lstate.writer_state_r1->written_anything = true;
 
 		// Handle R2 for paired-end
@@ -277,7 +288,8 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 			if (!seq2_data.validity.RowIsValid(seq2_row)) {
 				throw InvalidInputException("NULL value in sequence2 column (row %llu)", row);
 			}
-			string seq2 = seq2_strings[seq2_row].GetString();
+			const char *seq2_ptr = seq2_strings[seq2_row].GetData();
+			idx_t seq2_size = seq2_strings[seq2_row].GetSize();
 
 			auto qual2_row = qual2_data.sel->get_index(row);
 			if (!qual2_data.validity.RowIsValid(qual2_row)) {
@@ -290,30 +302,33 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 			const uint8_t *qual2_ptr = qual2_list_data + qual2_entries[qual2_row].offset;
 
 			// Validate quality score length matches sequence length
-			if (qual2_length != seq2.size()) {
+			if (qual2_length != seq2_size) {
 				throw InvalidInputException(
 				    "Quality score length (%llu) does not match sequence length (%llu) for row %llu (R2)", qual2_length,
-				    seq2.size(), row);
+				    seq2_size, row);
 			}
 
 			if (fdata.interleave) {
 				// Write R2 to same buffer
-				WriteFastqRecordToBuffer(stream_r1, id, seq2, qual2_ptr, qual2_length, fdata.qual_offset, comment);
+				WriteFastqRecordToBuffer(stream_r1, id_ptr, id_size, seq2_ptr, seq2_size, qual2_ptr, qual2_length,
+				                         fdata.qual_offset, comment_ptr, comment_size, qual_encoded_buf);
 			} else {
 				// Write R2 to separate buffer
-				WriteFastqRecordToBuffer(*stream_r2, id, seq2, qual2_ptr, qual2_length, fdata.qual_offset, comment);
+				WriteFastqRecordToBuffer(*stream_r2, id_ptr, id_size, seq2_ptr, seq2_size, qual2_ptr, qual2_length,
+				                         fdata.qual_offset, comment_ptr, comment_size, qual_encoded_buf);
 				lstate.writer_state_r2->written_anything = true;
 			}
 		}
-	}
 
-	// Check if we need to flush (buffer exceeded threshold)
-	if (lstate.writer_state_r1->stream->GetPosition() >= lstate.writer_state_r1->flush_size) {
-		FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
-	}
-
-	if (stream_r2 && lstate.writer_state_r2->stream->GetPosition() >= lstate.writer_state_r2->flush_size) {
-		FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+		// Flush per-record once the threshold is crossed, not per-chunk. Keeps the local
+		// buffer bounded even when individual records are very large (e.g. long-read
+		// FASTQ), so we never hand gzip more than flush_size + one_record at a time.
+		if (lstate.writer_state_r1->stream->GetPosition() >= lstate.writer_state_r1->flush_size) {
+			FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
+		}
+		if (stream_r2 && lstate.writer_state_r2->stream->GetPosition() >= lstate.writer_state_r2->flush_size) {
+			FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+		}
 	}
 }
 

--- a/src/copy_format_common.cpp
+++ b/src/copy_format_common.cpp
@@ -31,8 +31,21 @@ void FlushFormatBuffer(FormatWriterState &local_state, CopyFileHandle &file, mut
 
 	lock_guard<mutex> glock(lock);
 
-	// Write accumulated buffer to file
-	file.Write(local_state.stream->GetData(), local_state.stream->GetPosition());
+	// Write accumulated buffer to file in <= 1 GiB slices. DuckDB's MiniZStreamWrapper
+	// (the gzip path) casts the write size to unsigned int internally, so a single write
+	// larger than 4 GiB throws "Information loss on integer cast". Chunking keeps every
+	// underlying compressor call within 32-bit bounds regardless of how much the local
+	// MemoryStream accumulated.
+	constexpr idx_t MAX_WRITE_CHUNK = 1ULL * 1024 * 1024 * 1024; // 1 GiB
+	const_data_ptr_t data = local_state.stream->GetData();
+	idx_t remaining = local_state.stream->GetPosition();
+	idx_t offset = 0;
+	while (remaining > 0) {
+		idx_t to_write = remaining < MAX_WRITE_CHUNK ? remaining : MAX_WRITE_CHUNK;
+		file.Write(data + offset, to_write);
+		offset += to_write;
+		remaining -= to_write;
+	}
 
 	// Reset local buffer
 	local_state.Reset();

--- a/src/include/SequenceReader.hpp
+++ b/src/include/SequenceReader.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <climits>
+#include <cstddef>
 #include <optional>
 #include <variant>
 #include <vector>
@@ -33,7 +35,12 @@ public:
 #endif // MIINT_ASPERA_SUPPORTED
 #endif // MIINT_STATIC_BUILD
 
-	SequenceRecordBatch read(const int n);
+	// Read up to `n` records or until cumulative bytes across the accumulated batch exceed
+	// `max_bytes`, whichever comes first. Byte accounting sums `name + comment + seq + qual`
+	// across both mates in paired-end mode. At least one record is always returned if the
+	// stream has data, even when a single record alone exceeds `max_bytes` (starvation guard).
+	// Defaults to SIZE_MAX, preserving the row-only behavior for existing callers.
+	SequenceRecordBatch read(const int n, const size_t max_bytes = SIZE_MAX);
 
 private:
 	using SeqStreamIn = klibpp::SeqStreamIn;
@@ -57,7 +64,7 @@ private:
 	std::vector<klibpp::KSeq> buffered_read1_;
 	std::vector<klibpp::KSeq> buffered_read2_;
 
-	SequenceRecordBatch read_se(const int n);
-	SequenceRecordBatch read_pe(const int n);
+	SequenceRecordBatch read_se(const int n, const size_t max_bytes);
+	SequenceRecordBatch read_pe(const int n, const size_t max_bytes);
 };
 }; // namespace miint

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -190,7 +190,7 @@ const std::string READ_JPLACE = // NOLINT
     "    filepath "
     "FROM ( "
     "    SELECT unnest(placements) AS placement, filename AS filepath "
-    "    FROM read_json(path, filename := true) "
+    "    FROM read_json(path, filename := true, maximum_object_size=1000000000) "
     "); ";
 
 // mz_within(observed, target, tolerance_da)

--- a/src/include/read_fastx.hpp
+++ b/src/include/read_fastx.hpp
@@ -27,14 +27,15 @@ public:
 		bool include_filepath;
 		bool uses_stdin;
 		uint8_t qual_offset;
+		uint64_t max_batch_bytes;
 
 		std::vector<std::string> names; // field names
 		std::vector<LogicalType> types; // field types
 
 		Data(const std::vector<std::string> &r1_paths, const std::optional<std::vector<std::string>> &r2_paths,
-		     bool include_fp, bool stdin_used, uint8_t offset)
+		     bool include_fp, bool stdin_used, uint8_t offset, uint64_t max_bytes)
 		    : sequence1_paths(r1_paths), sequence2_paths(r2_paths), include_filepath(include_fp),
-		      uses_stdin(stdin_used), qual_offset(offset),
+		      uses_stdin(stdin_used), qual_offset(offset), max_batch_bytes(max_bytes),
 		      names({"sequence_index", "read_id", "comment", "sequence1", "sequence2", "qual1", "qual2"}),
 		      types({LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 		             LogicalType::VARCHAR, LogicalType::LIST(LogicalType::UTINYINT),

--- a/src/read_fastx.cpp
+++ b/src/read_fastx.cpp
@@ -2,9 +2,12 @@
 #include "SequenceRecord.hpp"
 #include "remote_file_helper.hpp"
 #include "table_function_common.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/storage/statistics/node_statistics.hpp"
+#include <filesystem>
 #include <read_fastx.hpp>
 
 namespace duckdb {
@@ -144,7 +147,27 @@ unique_ptr<FunctionData> ReadFastxTableFunction::Bind(ClientContext &context, Ta
 		qual_offset = static_cast<uint8_t>(offset_value);
 	}
 
-	auto data = duckdb::make_uniq<Data>(sequence1_paths, sequence2_paths, include_filepath, uses_stdin, qual_offset);
+	// Default byte budget: 512 MiB. Large enough that typical short-read workflows
+	// always fill STANDARD_VECTOR_SIZE (~600 KB per chunk) without being capped, but
+	// small enough to prevent multi-GB chunks when reading large sequences
+	// (e.g. bacterial genomes at ~5 MB/record would otherwise blow past RAM at 2048x).
+	uint64_t max_batch_bytes = 512ULL * 1024 * 1024;
+	auto mbb_param = input.named_parameters.find("max_batch_bytes");
+	if (mbb_param != input.named_parameters.end() && !mbb_param->second.IsNull()) {
+		std::string raw = mbb_param->second.ToString();
+		idx_t parsed = 0;
+		std::string err = StringUtil::TryParseFormattedBytes(raw, parsed);
+		if (!err.empty()) {
+			throw InvalidInputException("max_batch_bytes: %s", err);
+		}
+		if (parsed == 0) {
+			throw InvalidInputException("max_batch_bytes must be greater than 0");
+		}
+		max_batch_bytes = static_cast<uint64_t>(parsed);
+	}
+
+	auto data = duckdb::make_uniq<Data>(sequence1_paths, sequence2_paths, include_filepath, uses_stdin, qual_offset,
+	                                    max_batch_bytes);
 	for (auto &name : data->names) {
 		names.emplace_back(name);
 	}
@@ -201,7 +224,8 @@ void ReadFastxTableFunction::Execute(ClientContext &context, TableFunctionInput 
 		}
 
 		// Read from claimed file (no lock needed)
-		batch = global_state.readers[local_state.current_file_idx]->read(STANDARD_VECTOR_SIZE);
+		batch = global_state.readers[local_state.current_file_idx]->read(STANDARD_VECTOR_SIZE,
+		                                                                  bind_data.max_batch_bytes);
 		current_filepath = global_state.sequence1_filepaths[local_state.current_file_idx];
 
 		// If this file is exhausted, release it and try to claim another
@@ -260,11 +284,77 @@ void ReadFastxTableFunction::Execute(ClientContext &context, TableFunctionInput 
 	output.SetCardinality(batch.size());
 }
 
+// Cardinality estimate so the query optimizer knows roughly how big the scan is. Without
+// this, DuckDB defaults unknown table-function scans to a tiny cardinality, which causes
+// joins to pick read_fastx as the BUILD side -- catastrophic when the file is multi-GB of
+// genomic sequence (e.g. bacterial genome catalogs): DuckDB ends up hashing ~50 GB of
+// sequence into memory instead of streaming.
+//
+// We deliberately err on the side of OVER-estimating record count:
+//   - if the estimate is too high, the optimizer treats the scan as "large" and probes it
+//     -- always the safe choice for a streaming file source.
+//   - if it's too low (the status quo), the optimizer builds a hash table on it -> OOM.
+//
+// Heuristic: bytes-on-disk / AVG_RECORD_BYTES. 50 bytes/record is intentionally small so
+// that bacterial-genome FASTA (~5 MB/record) and short-read FASTQ (~300 B/record) both
+// resolve to "big" when the file is big. Gzipped files use a 4x expansion factor.
+// Remote files and stdin fall back to a large constant (exact record count is unknown but
+// streaming is always the right plan).
+static unique_ptr<NodeStatistics> ReadFastxCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+	constexpr idx_t AVG_BYTES_PER_RECORD = 50;
+	constexpr idx_t GZIP_EXPANSION_FACTOR = 4;
+	constexpr idx_t REMOTE_OR_STDIN_ESTIMATE = 10'000'000; // err large
+
+	auto &bind_data = bind_data_p->Cast<ReadFastxTableFunction::Data>();
+
+	if (bind_data.uses_stdin) {
+		return make_uniq<NodeStatistics>(REMOTE_OR_STDIN_ESTIMATE);
+	}
+
+	idx_t total_bytes = 0;
+	auto accumulate = [&](const std::string &path) -> bool {
+		if (miint::RemoteFileHelper::IsRemotePath(path)) {
+			return false; // signal "unknown, fall back"
+		}
+		std::error_code ec;
+		auto sz = std::filesystem::file_size(path, ec);
+		if (ec) {
+			return false;
+		}
+		if (IsGzipped(path)) {
+			sz *= GZIP_EXPANSION_FACTOR;
+		}
+		total_bytes += sz;
+		return true;
+	};
+
+	for (const auto &path : bind_data.sequence1_paths) {
+		if (!accumulate(path)) {
+			return make_uniq<NodeStatistics>(REMOTE_OR_STDIN_ESTIMATE);
+		}
+	}
+	if (bind_data.sequence2_paths.has_value()) {
+		for (const auto &path : bind_data.sequence2_paths.value()) {
+			if (!accumulate(path)) {
+				return make_uniq<NodeStatistics>(REMOTE_OR_STDIN_ESTIMATE);
+			}
+		}
+	}
+
+	idx_t estimated = total_bytes / AVG_BYTES_PER_RECORD;
+	if (estimated < 1) {
+		estimated = 1;
+	}
+	return make_uniq<NodeStatistics>(estimated);
+}
+
 TableFunction ReadFastxTableFunction::GetFunction() {
 	auto tf = TableFunction("read_fastx", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
 	tf.named_parameters["sequence2"] = LogicalType::ANY;
 	tf.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
 	tf.named_parameters["qual_offset"] = LogicalType::BIGINT;
+	tf.named_parameters["max_batch_bytes"] = LogicalType::VARCHAR;
+	tf.cardinality = ReadFastxCardinality;
 	return tf;
 }
 

--- a/src/read_fastx.cpp
+++ b/src/read_fastx.cpp
@@ -224,8 +224,8 @@ void ReadFastxTableFunction::Execute(ClientContext &context, TableFunctionInput 
 		}
 
 		// Read from claimed file (no lock needed)
-		batch = global_state.readers[local_state.current_file_idx]->read(STANDARD_VECTOR_SIZE,
-		                                                                  bind_data.max_batch_bytes);
+		batch =
+		    global_state.readers[local_state.current_file_idx]->read(STANDARD_VECTOR_SIZE, bind_data.max_batch_bytes);
 		current_filepath = global_state.sequence1_filepaths[local_state.current_file_idx];
 
 		// If this file is exhausted, release it and try to claim another

--- a/test/cpp/test_SequenceReader.cpp
+++ b/test/cpp/test_SequenceReader.cpp
@@ -333,3 +333,133 @@ TEST_CASE("SequenceReader paired-end mismatched count with context", "[SequenceR
 	miint::SequenceReader reader(r1, r2);
 	REQUIRE_THROWS_WITH(reader.read(5), Catch::Matchers::ContainsSubstring("missing mate"));
 }
+
+TEST_CASE("SequenceReader byte budget SE: generous budget returns all records", "[SequenceReader][byte_budget]") {
+	TempFileFixture fixture;
+	auto path = "budget_generous.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 10; i++) {
+		records.push_back(fixture.simple_read("r" + std::to_string(i), "ACGTACGT", "IIIIIIII"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+	auto batch = reader.read(100, 1024 * 1024); // 1 MiB -- way more than needed
+
+	REQUIRE((batch.size() == 10));
+}
+
+TEST_CASE("SequenceReader byte budget SE: tight budget caps records per chunk", "[SequenceReader][byte_budget]") {
+	TempFileFixture fixture;
+	auto path = "budget_tight.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 10; i++) {
+		// Each record: name=~3 chars, comment=0, seq=8, qual=8 -> ~19 bytes/record
+		records.push_back(fixture.simple_read("r" + std::to_string(i), "ACGTACGT", "IIIIIIII"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+
+	// Budget ~25 bytes -> first record (~19 B) fits, adding a second (~38 B total) exceeds.
+	// Expect 1 record per call.
+	size_t total = 0;
+	for (int call = 0; call < 20; call++) {
+		auto batch = reader.read(100, 25);
+		if (batch.empty()) {
+			break;
+		}
+		REQUIRE((batch.size() == 1));
+		total += batch.size();
+	}
+	REQUIRE((total == 10));
+}
+
+TEST_CASE("SequenceReader byte budget SE: starvation guard returns at least one record",
+          "[SequenceReader][byte_budget]") {
+	TempFileFixture fixture;
+	auto path = "budget_starve.fq";
+	fixture.write_temp_fastq(path, {fixture.simple_read("big", std::string(1000, 'A'), std::string(1000, 'I'))});
+
+	miint::SequenceReader reader(path);
+	auto batch = reader.read(100, 1); // budget absurdly small; single record massively over
+
+	// Starvation guard: always return at least one record when stream has data.
+	REQUIRE((batch.size() == 1));
+	REQUIRE((batch.read_ids[0] == "big"));
+}
+
+TEST_CASE("SequenceReader byte budget SE: budget preserves full content across calls",
+          "[SequenceReader][byte_budget]") {
+	TempFileFixture fixture;
+	auto path = "budget_preserve.fq";
+	std::vector<std::string> expected_ids;
+	std::vector<std::string> records;
+	for (int i = 0; i < 7; i++) {
+		std::string id = "rec" + std::to_string(i);
+		expected_ids.push_back(id);
+		records.push_back(fixture.simple_read(id, "ACGT", "IIII"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+
+	std::vector<std::string> seen;
+	for (int call = 0; call < 20; call++) {
+		auto batch = reader.read(100, 20); // tight budget; ~1 record per call
+		if (batch.empty()) {
+			break;
+		}
+		for (auto &id : batch.read_ids) {
+			seen.push_back(id);
+		}
+	}
+
+	REQUIRE((seen == expected_ids));
+}
+
+TEST_CASE("SequenceReader byte budget PE: budget counts both mates", "[SequenceReader][byte_budget]") {
+	TempFileFixture fixture;
+	auto r1 = "pe_budget_r1.fq";
+	auto r2 = "pe_budget_r2.fq";
+
+	std::vector<std::string> recs1, recs2;
+	for (int i = 0; i < 5; i++) {
+		std::string id = "pair" + std::to_string(i);
+		recs1.push_back(fixture.simple_read(id, "ACGT", "IIII"));
+		recs2.push_back(fixture.simple_read(id, "TGCA", "HHHH"));
+	}
+	fixture.write_temp_fastq(r1, recs1);
+	fixture.write_temp_fastq(r2, recs2);
+
+	miint::SequenceReader reader(r1, r2);
+
+	// Each mate is ~5 (name) + 4 (seq) + 4 (qual) = 13 bytes; pair ~26 bytes.
+	// Budget 40 bytes -> pair 1 fits, adding pair 2 (>52 bytes) exceeds -> 1 pair per call.
+	size_t total = 0;
+	for (int call = 0; call < 20; call++) {
+		auto batch = reader.read(100, 40);
+		if (batch.empty()) {
+			break;
+		}
+		REQUIRE((batch.size() == 1));
+		REQUIRE((batch.is_paired));
+		total += batch.size();
+	}
+	REQUIRE((total == 5));
+}
+
+TEST_CASE("SequenceReader byte budget default (SIZE_MAX) unchanged behavior", "[SequenceReader][byte_budget]") {
+	// Regression: callers that don't pass a budget see the same rows-only behavior.
+	TempFileFixture fixture;
+	auto path = "budget_default.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 50; i++) {
+		records.push_back(fixture.simple_read("r" + std::to_string(i), "ACGT", "IIII"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+	auto batch = reader.read(100); // no budget argument -> default SIZE_MAX
+	REQUIRE((batch.size() == 50));
+}

--- a/test/sql/read_fastx_max_batch_bytes.test
+++ b/test/sql/read_fastx_max_batch_bytes.test
@@ -1,0 +1,97 @@
+# name: test/sql/read_fastx_max_batch_bytes.test
+# description: Test max_batch_bytes parameter in read_fastx
+# group: [sql]
+
+require miint
+
+# Default (no parameter) - sanity check baseline row count
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq');
+----
+2
+
+# Human-readable sizes are accepted (1GB)
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='1GB');
+----
+2
+
+# MB suffix
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='32MB');
+----
+2
+
+# KB suffix
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='256KB');
+----
+2
+
+# Binary (IEC) suffix
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='1MiB');
+----
+2
+
+# Bytes suffix
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='1048576B');
+----
+2
+
+# Tight budget: correctness unchanged (row count equals unbounded read),
+# even though chunks become smaller.
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='32B');
+----
+2
+
+# Starvation guard: budget of 1 byte still returns every record (at least one per chunk)
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='1B');
+----
+2
+
+# Paired-end still works with max_batch_bytes
+query I
+SELECT count(*) FROM read_fastx('data/fastq/small_a_r1.fq', sequence2='data/fastq/small_a_r2.fq', max_batch_bytes='1MB');
+----
+1
+
+# Invalid: empty string rejected
+statement error
+SELECT * FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='');
+----
+max_batch_bytes
+
+# Invalid: non-numeric rejected
+statement error
+SELECT * FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='not_a_size');
+----
+max_batch_bytes
+
+# Invalid: unit-less numeric rejected (DuckDB parser requires a unit)
+statement error
+SELECT * FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='1048576');
+----
+max_batch_bytes
+
+# Invalid: zero with byte unit rejected
+statement error
+SELECT * FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='0B');
+----
+max_batch_bytes must be greater than 0
+
+# Invalid: zero with MB unit rejected
+statement error
+SELECT * FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='0MB');
+----
+max_batch_bytes must be greater than 0
+
+# Content integrity across chunking: tight budget yields same records as unbounded read
+query II
+SELECT read_id, sequence1 FROM read_fastx('data/fastq/small_a.fq', max_batch_bytes='16B') ORDER BY read_id;
+----
+read_a1	AAAA
+read_a2	TTTT


### PR DESCRIPTION
… records

  Three interlocking changes: prevent the wol2 bacterial-genome pipeline from
  OOMing, keep gzip writes inside MiniZ's 4 GiB-per-call limit, and eliminate
  redundant copies of multi-MB sequences in the COPY sinks.

  read_fastx
  - SequenceReader::read(n, max_bytes): new byte-budget overload. Polls in chunks of 16, drains until n or max_bytes, pushes unused tail back into buffered_read{1,2}_ so nothing is dropped across calls. Starvation guard accepts at least one record per call even when it alone exceeds the budget.
  - read_fastx max_batch_bytes parameter (VARCHAR, default "512MB"): parsed via StringUtil::TryParseFormattedBytes.
  - ReadFastxCardinality: file size / 50 bytes-per-record, 4x for gzip, 10M fallback for stdin/remote. Intentional over-estimate so the optimizer always treats the scan as large -- before this, joins picked read_fastx as the hash build side on multi-GB inputs and OOM'd at ~28 GiB building a hash table on wol2 genomes.

  COPY FASTA / FASTQ
  - FlushFormatBuffer slices the underlying file.Write into <=1 GiB pieces so a single flush can never trip MiniZStreamWrapper's internal unsigned-int cast on >4 GiB buffers.
  - Flush check moved inside the per-record loop (not just at end of chunk) so the local MemoryStream stays bounded to ~flush_size + one_record even when a chunk contains many multi-MB records.
  - WriteFastaRecordToBuffer / WriteFastqRecordToBuffer now write header, sequence, and quality bytes directly to the MemoryStream. Call sites use string_t::GetData()/GetSize() instead of GetString() on sequence columns, removing two copies per record on bacterial-genome FASTA (~5 MB each). FASTQ quality encoding uses a scratch buffer reused across rows.

  Tests
  - SequenceReader byte_budget C++ tests (SE + PE, starvation, preservation).
  - read_fastx_max_batch_bytes SQL test covering parameter parsing and budget behavior.

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>