### PR TITLE
Rewrite align_mafft to take a relation name instead of a file path

### DIFF
--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -27,7 +27,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`align_minimap2_sharded`](#align_minimap2_shardedquery_table-shard_directory-read_to_shard-options) - Sharded minimap2 alignment
 - [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) - Bowtie2 alignment
 - [`align_bowtie2_sharded`](#align_bowtie2_shardedquery_table-shard_directory-read_to_shard-options) - Sharded bowtie2 alignment
-- [`align_mafft`](#align_mafftfilename) - MAFFT multiple sequence alignment (PartTree)
+- [`align_mafft`](#align_maffttable_name) - MAFFT multiple sequence alignment (PartTree)
 - [`detect_chimera_uchime`](#detect_chimera_uchimequery_table-dbrefs_table-options) - Reference-based chimera detection (UCHIME)
 - [`detect_chimera_uchime_denovo`](#detect_chimera_uchime_denovoinput_table-options) - De novo chimera detection (UCHIME)
 - [`search_sequences_vsearch`](#search_sequences_vsearchquery_table-dbref_table-idthreshold-options) - Global sequence search
@@ -1898,22 +1898,21 @@ SELECT * FROM align_bowtie2_sharded('queries',
 | Parallelism | Single aligner thread(s) | One aligner per shard, concurrent |
 | Use case | Single reference database | Sharded reference databases (e.g., from prior classification) |
 
-## `align_mafft(filename)`
+## `align_mafft(table_name)`
 
-Multiple sequence alignment using MAFFT's PartTree algorithm. Reads all sequences from a FASTA file, aligns them, and returns the aligned sequences with gap characters inserted.
+Multiple sequence alignment using MAFFT's PartTree algorithm. Reads all sequences from a sequence table/view, aligns them, and returns the aligned sequences with gap characters inserted.
 
 MAFFT is embedded as a statically linked C library (no external binary required). The PartTree algorithm uses O(N log N) guide tree construction with k-tuple distances, making it suitable for large datasets (tested up to 5,000+ sequences).
 
 **Parameters:**
-- `filename` (VARCHAR): Path to a FASTA file containing sequences to align. Minimum 2 sequences, each at least 6 characters. DNA and protein sequences are auto-detected.
+- `table_name` (VARCHAR): Name of a table or view containing sequences to align. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns. Minimum 2 sequences, each at least 6 characters. DNA and protein sequences are auto-detected. Paired-end tables (those with a `sequence2` column) are rejected at bind.
 
 **Output schema:**
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `sequence_index` | BIGINT | 0-based position matching input order |
-| `read_id` | VARCHAR | Sequence identifier from FASTA header |
-| `comment` | VARCHAR | Header text after first space (NULL if absent) |
+| `read_id` | VARCHAR | Sequence identifier from the input `read_id` column |
 | `aligned_sequence` | VARCHAR | Aligned sequence with `-` gap characters |
 | `original_length` | INTEGER | Length of the input sequence (no gaps) |
 | `aligned_length` | INTEGER | Length of aligned sequences (same for all rows) |
@@ -1926,27 +1925,28 @@ MAFFT is embedded as a statically linked C library (no external binary required)
 
 ```sql
 -- Basic multiple sequence alignment
-SELECT * FROM align_mafft('sequences.fasta');
+CREATE TABLE seqs AS SELECT read_id, sequence1 FROM read_fastx('sequences.fasta');
+SELECT * FROM align_mafft('seqs');
 
 -- Align, then analyze gap content
+CREATE TABLE ref_16s AS SELECT read_id, sequence1 FROM read_fastx('16s_sequences.fasta');
 SELECT read_id,
        original_length,
        aligned_length,
        aligned_length - original_length AS gaps_inserted
-FROM align_mafft('16s_sequences.fasta')
+FROM align_mafft('ref_16s')
 ORDER BY gaps_inserted DESC;
 
--- Combine with read_fastx for filtering before alignment
-COPY (
-  SELECT read_id, sequence1
-  FROM read_fastx('large_dataset.fasta')
-  WHERE length(sequence1) >= 100
-) TO '/tmp/filtered.fasta' (FORMAT FASTA);
-SELECT * FROM align_mafft('/tmp/filtered.fasta');
+-- Filter before alignment — operate entirely in SQL, no temp files
+CREATE TABLE filtered AS
+  SELECT read_id, sequence1 FROM read_fastx('large_dataset.fasta')
+  WHERE length(sequence1) >= 100;
+SELECT * FROM align_mafft('filtered');
 
 -- Compute pairwise identity from aligned sequences
+CREATE TABLE seqs2 AS SELECT read_id, sequence1 FROM read_fastx('seqs.fasta');
 WITH aligned AS (
-  SELECT read_id, aligned_sequence FROM align_mafft('seqs.fasta')
+  SELECT read_id, aligned_sequence FROM align_mafft('seqs2')
 )
 SELECT a.read_id AS seq1, b.read_id AS seq2,
        sum(CASE WHEN a.c = b.c AND a.c != '-' THEN 1 ELSE 0 END)::FLOAT
@@ -1954,7 +1954,8 @@ SELECT a.read_id AS seq1, b.read_id AS seq2,
 FROM aligned a, aligned b,
      unnest(string_split(a.aligned_sequence, '')) WITH ORDINALITY AS a(c, pos),
      unnest(string_split(b.aligned_sequence, '')) WITH ORDINALITY AS b(c, bpos)
-WHERE a.read_id < b.read_id AND a.pos = b.bpos;
+WHERE a.read_id < b.read_id AND a.pos = b.bpos
+GROUP BY a.read_id, b.read_id;
 ```
 
 **Performance:** ~2x faster than native `mafft --parttree` for 1,000-5,000 sequences (no shell script overhead or temp file I/O). For 36 sequences, ~15x faster.
@@ -2251,7 +2252,7 @@ CREATE TABLE dereplicated AS
 -- For same-length amplicons without indels, this step can be skipped.
 CREATE TABLE aligned AS
   SELECT a.read_id, a.aligned_sequence AS sequence1, d.abundance
-  FROM align_mafft('dereplicated_seqs.fa') a
+  FROM align_mafft('dereplicated') a
   JOIN dereplicated d ON a.read_id = d.read_id;
 
 -- 4. Deblur

--- a/onboarding-tutorials/advanced.md
+++ b/onboarding-tutorials/advanced.md
@@ -481,7 +481,7 @@ miint supports a much broader range of bioinformatics workflows:
 - **Alignment** &mdash; align with
   [minimap2](../docs/table-functions.md#align_minimap2query_table-subject_tablenull-index_pathnull-options),
   [Bowtie2](../docs/table-functions.md#align_bowtie2query_table-subject_table-options),
-  [MAFFT](../docs/table-functions.md#align_mafftfilename) (multiple sequence
+  [MAFFT](../docs/table-functions.md#align_maffttable_name) (multiple sequence
   alignment), or compute
   [pairwise alignment scores](../docs/analysis-functions.md#pairwise-alignment-functions)
   with WFA2.

--- a/src/align_mafft.cpp
+++ b/src/align_mafft.cpp
@@ -1,16 +1,16 @@
 #include "align_mafft.hpp"
 #include "MafftAligner.hpp"
-#include "SequenceReader.hpp"
-#include "table_function_common.hpp"
+#include "sequence_table_reader.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
+#include <unordered_set>
 
 namespace duckdb {
 
 struct AlignMafftData : public TableFunctionData {
-	std::string input_path;
+	std::string table_name;
 };
 
 struct AlignMafftGlobalState : public GlobalTableFunctionState {
@@ -18,7 +18,6 @@ struct AlignMafftGlobalState : public GlobalTableFunctionState {
 	// simultaneously because MAFFT's PartTree needs the complete set
 	// before it can produce any aligned output.
 	std::vector<std::string> names;
-	std::vector<std::string> comments;
 	std::vector<std::string> sequences;
 	std::vector<int32_t> original_lengths;
 	int32_t aligned_length = 0;
@@ -32,24 +31,21 @@ struct AlignMafftGlobalState : public GlobalTableFunctionState {
 static unique_ptr<FunctionData> AlignMafftBind(ClientContext &context, TableFunctionBindInput &input,
                                                vector<LogicalType> &return_types, vector<string> &names) {
 	if (input.inputs.empty() || input.inputs[0].IsNull()) {
-		throw InvalidInputException("align_mafft requires a file path argument");
+		throw BinderException("align_mafft requires a sequence table name argument");
 	}
-	auto path = input.inputs[0].GetValue<string>();
+	auto table_name = input.inputs[0].ToString();
 
-	// Validate file exists (skip for stdin — materializing from stdin is fine)
-	if (!IsStdinPath(path)) {
-		auto &fs = FileSystem::GetFileSystem(context);
-		if (!fs.FileExists(path)) {
-			throw IOException("File not found: " + path);
-		}
+	auto schema = ValidateSequenceTableSchema(context, table_name);
+	if (schema.has_sequence2) {
+		throw BinderException("align_mafft does not support paired-end data");
 	}
 
 	auto data = make_uniq<AlignMafftData>();
-	data->input_path = path;
+	data->table_name = std::move(table_name);
 
-	names = {"sequence_index", "read_id", "comment", "aligned_sequence", "original_length", "aligned_length"};
-	return_types = {LogicalType::BIGINT,  LogicalType::VARCHAR, LogicalType::VARCHAR,
-	                LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER};
+	names = {"sequence_index", "read_id", "aligned_sequence", "original_length", "aligned_length"};
+	return_types = {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER,
+	                LogicalType::INTEGER};
 
 	return data;
 }
@@ -59,35 +55,41 @@ static unique_ptr<GlobalTableFunctionState> AlignMafftInitGlobal(ClientContext &
 	auto &data = input.bind_data->Cast<AlignMafftData>();
 	auto gstate = make_uniq<AlignMafftGlobalState>();
 
-	// Read all sequences from input file
-	miint::SequenceReader reader(data.input_path);
-	std::vector<std::string> seq_names;
-	std::vector<std::string> seq_comments;
-	std::vector<std::string> seq_data;
+	auto loaded = LoadSingleEndSequences(context, data.table_name, "align_mafft", /*strict=*/true);
 
-	while (true) {
-		auto batch = reader.read(STANDARD_VECTOR_SIZE);
-		if (batch.size() == 0) {
-			break;
-		}
-		for (idx_t i = 0; i < batch.size(); i++) {
-			seq_names.push_back(batch.read_ids[i]);
-			// SequenceReader produces empty string (not NULL) for missing comments
-			seq_comments.push_back(batch.comments[i]);
-			seq_data.push_back(batch.sequences1[i]);
-		}
-	}
-
-	if (seq_data.size() < 2) {
+	if (loaded.sequences.size() < 2) {
 		throw InvalidInputException("align_mafft requires at least 2 sequences, got %d",
-		                            static_cast<int>(seq_data.size()));
+		                            static_cast<int>(loaded.sequences.size()));
 	}
+
+	// MAFFT requires sequences of at least 6 characters; guard up-front so the
+	// user gets a row-specific error instead of an opaque std::invalid_argument
+	// out of the aligner.
+	for (size_t i = 0; i < loaded.sequences.size(); i++) {
+		if (loaded.sequences[i].size() < 6) {
+			throw InvalidInputException("align_mafft: sequence for read_id '%s' is too short (%d chars, minimum 6)",
+			                            loaded.labels[i], static_cast<int>(loaded.sequences[i].size()));
+		}
+	}
+
+	// Duplicate read_ids make it impossible to join align_mafft output back to
+	// the input table unambiguously (e.g., the deblur workflow pattern).
+	std::unordered_set<std::string> seen;
+	seen.reserve(loaded.labels.size());
+	for (const auto &id : loaded.labels) {
+		if (!seen.insert(id).second) {
+			throw InvalidInputException("align_mafft: duplicate read_id '%s' in input table", id);
+		}
+	}
+
+	// MafftAligner::align requires a comments vector sized to match names/sequences;
+	// empty strings are ignored when building FASTA headers.
+	std::vector<std::string> comments(loaded.labels.size(), "");
 
 	miint::MafftAligner aligner;
-	auto result = aligner.align(seq_names, seq_comments, seq_data);
+	auto result = aligner.align(loaded.labels, comments, loaded.sequences);
 
 	gstate->names = std::move(result.names);
-	gstate->comments = std::move(result.comments);
 	gstate->sequences = std::move(result.sequences);
 	gstate->aligned_length = static_cast<int32_t>(result.aligned_length);
 	gstate->original_lengths.reserve(result.original_lengths.size());
@@ -116,18 +118,11 @@ static void AlignMafftExecute(ClientContext &context, TableFunctionInput &data_p
 
 		FlatVector::GetData<string_t>(output.data[1])[i] = StringVector::AddString(output.data[1], gstate.names[row]);
 
-		if (gstate.comments[row].empty()) {
-			FlatVector::Validity(output.data[2]).SetInvalid(i);
-		} else {
-			FlatVector::GetData<string_t>(output.data[2])[i] =
-			    StringVector::AddString(output.data[2], gstate.comments[row]);
-		}
+		FlatVector::GetData<string_t>(output.data[2])[i] =
+		    StringVector::AddString(output.data[2], gstate.sequences[row]);
 
-		FlatVector::GetData<string_t>(output.data[3])[i] =
-		    StringVector::AddString(output.data[3], gstate.sequences[row]);
-
-		FlatVector::GetData<int32_t>(output.data[4])[i] = gstate.original_lengths[row];
-		FlatVector::GetData<int32_t>(output.data[5])[i] = gstate.aligned_length;
+		FlatVector::GetData<int32_t>(output.data[3])[i] = gstate.original_lengths[row];
+		FlatVector::GetData<int32_t>(output.data[4])[i] = gstate.aligned_length;
 	}
 
 	gstate.current_row += count;
@@ -137,6 +132,9 @@ static void AlignMafftExecute(ClientContext &context, TableFunctionInput &data_p
 TableFunction AlignMafftTableFunction::GetFunction() {
 	auto tf =
 	    TableFunction("align_mafft", {LogicalType::VARCHAR}, AlignMafftExecute, AlignMafftBind, AlignMafftInitGlobal);
+	// Match sibling aligners — allow downstream CTAS pipelines to parallelize.
+	// Callers that want deterministic order should ORDER BY sequence_index.
+	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	return tf;
 }
 

--- a/test/sql/align_mafft.test
+++ b/test/sql/align_mafft.test
@@ -21,50 +21,103 @@ require miint
 
 require-env MAFFT_AVAILABLE
 
+# --- Build sequence tables used across the test ---
+
+statement ok
+CREATE TABLE tiny AS SELECT read_id, sequence1 FROM read_fastx('data/mafft/tiny.fa');
+
+statement ok
+CREATE TABLE test_fa AS SELECT read_id, sequence1 FROM read_fastx('data/fastq/test.fa');
+
+statement ok
+CREATE TABLE mixed_case AS SELECT read_id, sequence1 FROM read_fastx('data/mafft/mixed_case.fa');
+
+statement ok
+CREATE TABLE single AS SELECT read_id, sequence1 FROM read_fastx('data/mafft/single.fa');
+
+statement ok
+CREATE TABLE sample_tbl AS
+  SELECT format('seq{:d}', row_number() OVER ()) AS read_id, sequence1
+  FROM read_fastx('data/mafft/sample.fa');
+
 # --- Error handling ---
 
-# Missing file
+# Missing table
 statement error
-SELECT * FROM align_mafft('nonexistent_file.fa');
+SELECT * FROM align_mafft('no_such_table');
 ----
-IO Error
+Binder Error
+
+# Paired-end data is rejected at bind
+statement ok
+CREATE TABLE paired AS
+  SELECT 'a' AS read_id, 'ACGTACGT' AS sequence1, 'TGCAACGT' AS sequence2
+  UNION ALL
+  SELECT 'b', 'ACGAACGT', 'TGCAAACG';
+
+statement error
+SELECT * FROM align_mafft('paired');
+----
+Binder Error
 
 # Single sequence (need at least 2)
 statement error
-SELECT * FROM align_mafft('data/mafft/single.fa');
+SELECT * FROM align_mafft('single');
 ----
 Invalid Input Error
 
-# --- tiny.fa: exact expected output ---
+# Sequence shorter than MAFFT's 6-char minimum — must surface the offending read_id
+statement ok
+CREATE TABLE too_short AS
+  SELECT 'a' AS read_id, 'ACGT' AS sequence1 UNION ALL SELECT 'b', 'ACGTACGT';
+
+statement error
+SELECT * FROM align_mafft('too_short');
+----
+sequence for read_id 'a' is too short
+
+# Duplicate read_id makes output ambiguous — reject up front
+statement ok
+CREATE TABLE dupe_ids AS
+  SELECT 'a' AS read_id, 'ACGTACGT' AS sequence1
+  UNION ALL SELECT 'a', 'ACGAACGT'
+  UNION ALL SELECT 'b', 'ACGTACGA';
+
+statement error
+SELECT * FROM align_mafft('dupe_ids');
+----
+duplicate read_id 'a'
+
+# --- tiny: exact expected output ---
 # Input: s1=ACGTACGT, s2=ACGAACGT, s3=ACGTACGA (3 DNA, 8bp each)
 # Expected: no gaps (same length, high similarity), case preserved
 
 query ITTII
 SELECT sequence_index, read_id, aligned_sequence, original_length, aligned_length
-FROM align_mafft('data/mafft/tiny.fa') ORDER BY sequence_index;
+FROM align_mafft('tiny') ORDER BY sequence_index;
 ----
 0	s1	ACGTACGT	8	8
 1	s2	ACGAACGT	8	8
 2	s3	ACGTACGA	8	8
 
-# --- test.fa: exact expected output ---
+# --- test_fa: exact expected output ---
 # Input: seq1=ATGCATGCATGC, seq2=GGCCGGCCGGCC (2 DNA, 12bp each)
 # Expected: no gaps (same length), case preserved
 
 query ITTII
 SELECT sequence_index, read_id, aligned_sequence, original_length, aligned_length
-FROM align_mafft('data/fastq/test.fa') ORDER BY sequence_index;
+FROM align_mafft('test_fa') ORDER BY sequence_index;
 ----
 0	seq1	ATGCATGCATGC	12	12
 1	seq2	GGCCGGCCGGCC	12	12
 
-# --- mixed_case.fa: case preservation ---
+# --- mixed_case: case preservation ---
 # Input: s1=AcGtAcGt, s2=aCgTaCgT (mixed case DNA)
 # Expected: original case preserved after MAFFT's internal lowercasing
 
 query ITTII
 SELECT sequence_index, read_id, aligned_sequence, original_length, aligned_length
-FROM align_mafft('data/mafft/mixed_case.fa') ORDER BY sequence_index;
+FROM align_mafft('mixed_case') ORDER BY sequence_index;
 ----
 0	s1	AcGtAcGt	8	8
 1	s2	aCgTaCgT	8	8
@@ -72,57 +125,42 @@ FROM align_mafft('data/mafft/mixed_case.fa') ORDER BY sequence_index;
 # --- Column types ---
 
 query I
-SELECT typeof(sequence_index) FROM align_mafft('data/mafft/tiny.fa') LIMIT 1;
+SELECT typeof(sequence_index) FROM align_mafft('tiny') LIMIT 1;
 ----
 BIGINT
 
-# --- Nullable comment ---
-
-query T
-SELECT comment FROM align_mafft('data/mafft/tiny.fa') WHERE read_id = 's1';
-----
-first sequence
-
-query I
-SELECT comment IS NULL FROM align_mafft('data/mafft/tiny.fa') WHERE read_id = 's2';
-----
-true
-
-# --- sample.fa: 36 opsin protein sequences ---
+# --- sample_tbl: 36 opsin protein sequences ---
 # Expected aligned_length = 732 (verified against splittbfast binary output)
 
 query I
-SELECT COUNT(*) FROM align_mafft('data/mafft/sample.fa');
+SELECT COUNT(*) FROM align_mafft('sample_tbl');
 ----
 36
 
 query I
-SELECT DISTINCT aligned_length FROM align_mafft('data/mafft/sample.fa');
+SELECT DISTINCT aligned_length FROM align_mafft('sample_tbl');
 ----
 732
 
-# Ungapped content matches original input for every sequence
+# Ungapped content matches original input: every aligned sequence (with gaps
+# removed) appears in the input. Set-based check — robust to duplicate or
+# empty read_ids in sample.fa.
 query I
-SELECT COUNT(*) FROM (
-  SELECT s.sequence1 AS original, replace(a.aligned_sequence, '-', '') AS ungapped
-  FROM align_mafft('data/mafft/sample.fa') a
-  JOIN (SELECT row_number() OVER () - 1 AS idx, * FROM read_fastx('data/mafft/sample.fa')) s
-    ON a.sequence_index = s.idx
-  WHERE original != ungapped
-);
+SELECT COUNT(*) FROM align_mafft('sample_tbl')
+WHERE replace(aligned_sequence, '-', '') NOT IN (SELECT sequence1 FROM sample_tbl);
 ----
 0
 
 # aligned_length > max original_length (gaps inserted)
 query I
-SELECT aligned_length > MAX(original_length) FROM align_mafft('data/mafft/sample.fa') GROUP BY aligned_length;
+SELECT aligned_length > MAX(original_length) FROM align_mafft('sample_tbl') GROUP BY aligned_length;
 ----
 true
 
 # --- Sequential calls (global state cleanup) ---
 
 query I
-SELECT (SELECT COUNT(*) FROM align_mafft('data/mafft/tiny.fa'))
-     + (SELECT COUNT(*) FROM align_mafft('data/mafft/tiny.fa'));
+SELECT (SELECT COUNT(*) FROM align_mafft('tiny'))
+     + (SELECT COUNT(*) FROM align_mafft('tiny'));
 ----
 6


### PR DESCRIPTION
MAFFT is embedded as a static library, so requiring callers to materialize sequences to disk before alignment was inconsistent with every other alignment/search table function in the extension (align_minimap2, align_bowtie2, detect_chimera_uchime, etc.). This replaces the file-path signature with a relation-name input, using the standard ValidateSequenceTableSchema + LoadSingleEndSequences composition.

Breaking change. The comment output column is dropped. Paired-end tables are rejected at bind. Runtime guards (added in response to code review): reject sequences shorter than MAFFT's 6-char minimum with a row-specific message, and reject duplicate read_ids since they corrupt downstream JOIN-based workflows (e.g., deblur). The table function now sets NO_ORDER to let downstream CTAS pipelines parallelize, matching the sibling aligners.