### PR TITLE
Ensure remote-file cache temp directory exists before write

### DIFF
--- a/src/remote_file_helper.cpp
+++ b/src/remote_file_helper.cpp
@@ -104,6 +104,11 @@ ResolvedFile RemoteFileHelper::ResolveToLocal(duckdb::FileSystem &fs, duckdb::Cl
 	auto source = fs.OpenFile(path, FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ));
 
 	auto temp_dir = GetTempDirectory(context);
+	// DuckDB creates the temp directory lazily when the buffer manager spills;
+	// a pure-read workload may never trigger that path, so ensure it exists
+	// before we try to write. Recursive form handles user-configured nested
+	// paths (e.g. SET temp_directory = '/var/run/myapp/nested/tmp').
+	fs.CreateDirectoriesRecursive(temp_dir);
 	auto temp_path = fs.JoinPath(temp_dir, GenerateTempFileName());
 
 	try {


### PR DESCRIPTION
RemoteFileHelper::ResolveToLocal downloads remote files (SFF, BIOM — formats that need seekable local access) into BufferManager::GetTemporaryDirectory(). That directory is created lazily by DuckDB only when the buffer manager actually spills; pure-read workloads never trigger that path, leaving the OpenFile(FILE_FLAGS_FILE_CREATE_NEW) call to fail with a confusing "No such file or directory" for a file we were about to create ourselves.

Fix: call CreateDirectoriesRecursive (mkdir -p semantics) immediately before computing the temp path. Idempotent and handles user-configured nested temp_directory settings. Verified by deleting .tmp/ and confirming SFF/BIOM HTTPS tests now pass on a freshly-missing-directory state.