### PR TITLE
Fix .gitmodules to use HTTPS URLs for rype and vsearch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,10 +15,10 @@
 	url = https://github.com/smarco/WFA2-lib.git
 [submodule "ext/rype"]
 	path = ext/rype
-	url = git@github.com:the-miint/rype.git
+	url = https://github.com/the-miint/rype.git
 [submodule "ext/vsearch"]
 	path = ext/vsearch
-	url = git@github.com:the-miint/vsearch.git
+	url = https://github.com/the-miint/vsearch.git
 	branch = v2.30.5-miint
 [submodule "ext/mafft"]
 	path = ext/mafft


### PR DESCRIPTION
SSH URLs in `.gitmodules` fail for contributors using GitHub's default HTTPS/PAT auth (`gh auth`) or on HPC login nodes where outbound port 22 is firewalled. Other submodules already use HTTPS; this brings `ext/rype` and `ext/vsearch` in line.