### PR TITLE
Migrate deprecated lambda arrow syntax

### DIFF
--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -104,7 +104,7 @@ const std::string PARSE_GFF_ATTRIBUTES = // NOLINT
     "  map_from_entries( "
     "    list_transform( "
     "      string_split(kvp_string, ';'), "
-    "      x : struct_pack( "
+    "      lambda x: struct_pack( "
     "        key := string_split(x, '=')[1], "
     "        value := string_split(x, '=')[2] "
     "      ) "
@@ -616,7 +616,7 @@ const std::string MZML_OR_CARDINALITY = // NOLINT
 // Returns NULL if base_peak_intensity is NULL (natural NULL propagation).
 const std::string MZML_I_NORM = // NOLINT
     "CREATE OR REPLACE MACRO mzml_i_norm(intensity_array, base_peak_intensity) AS ("
-    "  list_transform(intensity_array, x : x / base_peak_intensity)"
+    "  list_transform(intensity_array, lambda x: x / base_peak_intensity)"
     ");";
 
 // mzml_i_tic_norm(intensity_array, total_ion_current)
@@ -625,7 +625,7 @@ const std::string MZML_I_NORM = // NOLINT
 // Returns NULL if total_ion_current is NULL (natural NULL propagation).
 const std::string MZML_I_TIC_NORM = // NOLINT
     "CREATE OR REPLACE MACRO mzml_i_tic_norm(intensity_array, total_ion_current) AS ("
-    "  list_transform(intensity_array, x : x / total_ion_current)"
+    "  list_transform(intensity_array, lambda x: x / total_ion_current)"
     ");";
 
 // mzml_excluded_ms2prod(relation, target_mz, tolerance := 0.1)

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -104,7 +104,7 @@ const std::string PARSE_GFF_ATTRIBUTES = // NOLINT
     "  map_from_entries( "
     "    list_transform( "
     "      string_split(kvp_string, ';'), "
-    "      x -> struct_pack( "
+    "      x : struct_pack( "
     "        key := string_split(x, '=')[1], "
     "        value := string_split(x, '=')[2] "
     "      ) "
@@ -616,7 +616,7 @@ const std::string MZML_OR_CARDINALITY = // NOLINT
 // Returns NULL if base_peak_intensity is NULL (natural NULL propagation).
 const std::string MZML_I_NORM = // NOLINT
     "CREATE OR REPLACE MACRO mzml_i_norm(intensity_array, base_peak_intensity) AS ("
-    "  list_transform(intensity_array, x -> x / base_peak_intensity)"
+    "  list_transform(intensity_array, x : x / base_peak_intensity)"
     ");";
 
 // mzml_i_tic_norm(intensity_array, total_ion_current)
@@ -625,7 +625,7 @@ const std::string MZML_I_NORM = // NOLINT
 // Returns NULL if total_ion_current is NULL (natural NULL propagation).
 const std::string MZML_I_TIC_NORM = // NOLINT
     "CREATE OR REPLACE MACRO mzml_i_tic_norm(intensity_array, total_ion_current) AS ("
-    "  list_transform(intensity_array, x -> x / total_ion_current)"
+    "  list_transform(intensity_array, x : x / total_ion_current)"
     ");";
 
 // mzml_excluded_ms2prod(relation, target_mz, tolerance := 0.1)

--- a/test/sql/read_ena_sequences.test
+++ b/test/sql/read_ena_sequences.test
@@ -75,7 +75,7 @@ true
 # Quality scores should be in valid Phred+33 range (0-41 typical)
 query I
 SELECT COUNT(*) = 0 AS valid_qual FROM ena_reads
-WHERE list_any_value(list_transform(qual1, x -> x > 60));
+WHERE list_any_value(list_transform(qual1, x : x > 60));
 ----
 true
 

--- a/test/sql/read_ena_sequences.test
+++ b/test/sql/read_ena_sequences.test
@@ -75,7 +75,7 @@ true
 # Quality scores should be in valid Phred+33 range (0-41 typical)
 query I
 SELECT COUNT(*) = 0 AS valid_qual FROM ena_reads
-WHERE list_any_value(list_transform(qual1, x : x > 60));
+WHERE list_any_value(list_transform(qual1, lambda x: x > 60));
 ----
 true
 


### PR DESCRIPTION
Closes #21.

## Summary
Replace `x -> expr` with `x : expr` in the three macros in `src/include/miint_macros.hpp` that use the deprecated lambda arrow syntax:

- `parse_gff_attributes` (line 107)
- `mzml_i_norm` (line 619)
- `mzml_i_tic_norm` (line 628)

## Motivation
DuckDB 1.5.1+ emits the following warning on every `LOAD miint`:

```
WARNING:
Deprecated lambda arrow (->) detected. Please transition to the new lambda syntax,
i.e., lambda x, i: x + i, before DuckDB's next release.
```

Per the warning, the new syntax uses `:` as the separator. The change is three mechanical character substitutions; no behavior change.

## Verification
- Three-line diff, scope-limited to `src/include/miint_macros.hpp`.
- No other `->` lambda occurrences in miint source code (verified via `grep -rn ' -> ' src/`).
- Test coverage exists for the affected macros in `test/sql/read_mzml.test` (covers `mzml_i_norm`, `mzml_i_tic_norm`) and `test/sql/read_gff.test` (exercises `parse_gff_attributes` via `read_gff`).