### PR TITLE
Migrate woltka_ogu from SQL macros to C++ table function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -784,6 +784,7 @@ set(EXTENSION_SOURCES
     src/massql_parser.cpp
     src/massql_transpiler.cpp
     src/massql_function.cpp
+    src/woltka_ogu_function.cpp
     src/mzml_peak_pair_function.cpp
     src/mass_tables.cpp
     src/MzXMLReader.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,16 +465,11 @@ if(MIINT_ENABLE_VSEARCH)
     ExternalProject_Add(
         vsearch_build
         SOURCE_DIR ${VSEARCH_SRC_DIR}
-        # Touch pre-generated autotools files so make doesn't try to regenerate
-        # them (git checkout gives all files the same timestamp, which can trigger
-        # autotools rebuild rules if make thinks sources are newer).
-        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E touch
-            ${VSEARCH_SRC_DIR}/aclocal.m4
-            ${VSEARCH_SRC_DIR}/configure
-            ${VSEARCH_SRC_DIR}/Makefile.in
-            ${VSEARCH_SRC_DIR}/src/Makefile.in
-            ${VSEARCH_SRC_DIR}/man/Makefile.in
-            ${VSEARCH_SRC_DIR}/config.h.in
+        # vsearch upstream gitignores `configure`, `Makefile.in`, etc. — they are
+        # generated on demand by autogen.sh (autoreconf --force --install). A
+        # fresh CI checkout has none of them, so we must regenerate here before
+        # invoking configure.
+        CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir ${VSEARCH_SRC_DIR} sh ./autogen.sh
             COMMAND ${CMAKE_COMMAND} -E env "CXXFLAGS=-fPIC ${VSEARCH_ARCH_CFLAGS}" "CFLAGS=-fPIC ${VSEARCH_ARCH_CFLAGS}"
             ${VSEARCH_SRC_DIR}/configure ${VSEARCH_HOST_FLAG}
         BUILD_COMMAND make -C src libvsearch.a

--- a/docs/analysis-functions.md
+++ b/docs/analysis-functions.md
@@ -4,8 +4,7 @@ Functions for higher-level genomic analysis, sequence manipulation, and pairwise
 
 ## Table of Contents
 
-- [`woltka_ogu_per_sample`](#woltka_ogu_per_samplerelation-sample_id_field-sequence_id_field) - Multi-sample OGU counts
-- [`woltka_ogu`](#woltka_ogurelation-sequence_id_field) - Single-sample OGU counts
+- [`woltka_ogu`](#woltka_ogurelation-sequence_id_field-sample_id) - OGU counts (global or per-sample)
 - [`sequence_dna_reverse_complement` / `sequence_rna_reverse_complement`](#sequence_dna_reverse_complementsequence-and-sequence_rna_reverse_complementsequence) - Reverse complement
 - [`sequence_dna_as_regexp` / `sequence_rna_as_regexp`](#sequence_dna_as_regexpsequence-and-sequence_rna_as_regexpsequence) - IUPAC to regex
 - [`compress_intervals`](#compress_intervalsstart-stop) - Merge overlapping intervals
@@ -15,140 +14,80 @@ Functions for higher-level genomic analysis, sequence manipulation, and pairwise
 - [`massql`](#massqlquery-source) - MassQL query language for mass spectrometry
 - [Utility Functions](#utility-functions) - `miint_version()` and others
 
-## `woltka_ogu_per_sample(relation, sample_id_field, sequence_id_field)`
+## `woltka_ogu(relation, sequence_id_field [, sample_id])`
 
-Compute [Woltka](https://github.com/qiyunzhu/woltka) OGU (Operational Genomic Unit) counts over SAM-like alignment data for multiple samples. This function implements Woltka's classification algorithm, which assigns reads to taxonomic units while accounting for multi-mapped reads.
-
-**IMPORTANT**: Function parameters should NOT be quoted. Pass table and column names directly as identifiers, not as string literals.
+Compute [Woltka](https://github.com/qiyunzhu/woltka) OGU (Operational Genomic Unit) counts over SAM-like alignment data. Implements Woltka's classification algorithm, assigning reads to taxonomic units while fractionally distributing multi-mapped reads. When the optional `sample_id` named parameter is supplied, the aggregation runs in parallel across distinct sample values — one DuckDB query per sample on a dedicated per-thread connection — which bounds memory to a single sample's footprint.
 
 **Parameters:**
-- `relation`: A table, view, or subquery containing SAM-like alignment data
-- `sample_id_field`: Column name containing sample identifiers
-- `sequence_id_field`: Column name containing sequence identifiers (can be `read_id` or a numeric index for better performance)
+- `relation` (VARCHAR): Name of a table or view containing SAM-like alignment data (must be a resolvable catalog name; pass as a string literal)
+- `sequence_id_field` (VARCHAR): Name of the column holding sequence identifiers — typically `read_id`, or a numeric index column for better hash performance
+- `sample_id` (VARCHAR, named, optional): Name of the column holding sample identifiers. When supplied, adds that column to the output and runs the aggregation per distinct sample value in parallel.
 
 **Required columns in relation:**
-- Column specified by `sample_id_field`: Sample identifier
-- Column specified by `sequence_id_field`: Read/sequence identifier
-- `reference` (VARCHAR): Reference sequence name (feature ID)
+- Column named by `sequence_id_field`: read/sequence identifier
+- `reference` (VARCHAR): reference sequence name (becomes `feature_id`)
 - `flags` (USMALLINT): SAM alignment flags
+- When `sample_id` is supplied: the named column (any comparable type) — NULLs are rejected at bind time
 
 **Returns:**
-- `sample_id`: Sample identifier
-- `feature_id`: Reference/feature identifier
-- `value`: OGU count (fractional, accounts for multi-mapping)
+- When `sample_id` is omitted: `(feature_id VARCHAR, value DOUBLE)`
+- When `sample_id` is supplied: `(<sample_id_column> <its_type>, feature_id VARCHAR, value DOUBLE)` — the first column's name matches the value you passed to `sample_id`.
 
 **Algorithm:**
-1. Orients reads using alignment flags (forward/reverse)
-2. For each read orientation, divides 1 by the number of unique features aligned to
-3. Aggregates fractional counts per sample and feature
+1. Orients reads using alignment flags (forward/reverse via `alignment_is_read1`).
+2. For each read orientation, divides 1 by the number of unique features aligned to.
+3. Aggregates fractional counts per feature (and per sample, when `sample_id` is used).
+
+**Correctness assumption for per-sample mode:** read IDs are unique across samples. The per-sample subset then yields the same distribution as the global aggregation.
 
 **Examples:**
 ```sql
--- Basic usage: count OGUs per sample from alignment table
-SELECT * FROM woltka_ogu_per_sample(
-    my_alignments,
-    sample_id,
-    read_id
+-- Global aggregation across the whole relation
+SELECT * FROM woltka_ogu('my_alignments', 'read_id');
+
+-- Per-sample aggregation — one aggregation per distinct sample value, in parallel
+SELECT * FROM woltka_ogu(
+    'my_alignments',
+    'read_id',
+    sample_id := 'sample_id'
 );
 
--- Using with a filtered view
-CREATE VIEW high_quality_alignments AS
-    SELECT *, 'sample1' AS sample_id
-    FROM read_alignments('alignments.bam')
-    WHERE mapq >= 30 AND alignment_is_primary(flags);
+-- Filter high-quality alignments via a view, then classify
+CREATE OR REPLACE VIEW primary_alignments AS
+    SELECT * FROM read_alignments('alignments.bam')
+    WHERE alignment_is_primary(flags) AND mapq >= 20;
 
-SELECT * FROM woltka_ogu_per_sample(
-    high_quality_alignments,
-    sample_id,
-    read_id
-);
+SELECT * FROM woltka_ogu('primary_alignments', 'read_id');
 
--- Process multiple samples with UNION
-CREATE VIEW all_samples AS
+-- Multi-sample: union sources under a sample_id column, then classify per sample
+CREATE OR REPLACE VIEW all_samples AS
     SELECT *, 'sample1' AS sample_id FROM read_alignments('sample1.bam')
     UNION ALL
     SELECT *, 'sample2' AS sample_id FROM read_alignments('sample2.bam')
     UNION ALL
     SELECT *, 'sample3' AS sample_id FROM read_alignments('sample3.bam');
 
-SELECT * FROM woltka_ogu_per_sample(
-    all_samples,
-    sample_id,
-    read_id
-) ORDER BY sample_id, feature_id;
+SELECT * FROM woltka_ogu('all_samples', 'read_id', sample_id := 'sample_id')
+ORDER BY sample_id, feature_id;
 
--- Export to BIOM format for downstream analysis
+-- Export per-sample results to BIOM for downstream analysis
 COPY (
-    SELECT * FROM woltka_ogu_per_sample(my_alignments, sample_id, read_id)
+    SELECT * FROM woltka_ogu('my_alignments', 'read_id', sample_id := 'sample_id')
 ) TO 'ogu_table.biom' (FORMAT BIOM, COMPRESSION 'gzip');
 
--- WRONG: Do not quote parameters (this will cause an error)
--- SELECT * FROM woltka_ogu_per_sample('my_alignments', 'sample_id', 'read_id');
-```
-
-## `woltka_ogu(relation, sequence_id_field)`
-
-Compute Woltka OGU counts over SAM-like alignment data for a single sample or aggregated across all samples.
-
-**IMPORTANT**: Function parameters should NOT be quoted. Pass table and column names directly as identifiers, not as string literals.
-
-**Parameters:**
-- `relation`: A table, view, or subquery containing SAM-like alignment data
-- `sequence_id_field`: Column name containing sequence identifiers (can be `read_id` or a numeric index for better performance)
-
-**Required columns in relation:**
-- Column specified by `sequence_id_field`: Read/sequence identifier
-- `reference` (VARCHAR): Reference sequence name (feature ID)
-- `flags` (USMALLINT): SAM alignment flags
-
-**Returns:**
-- `feature_id`: Reference/feature identifier
-- `value`: OGU count (fractional, accounts for multi-mapping)
-
-**Examples:**
-```sql
--- Basic usage: count OGUs from alignment table
-SELECT * FROM woltka_ogu(
-    my_alignments,
-    read_id
-);
-
--- Direct query from read_alignments
-SELECT * FROM woltka_ogu(
-    (SELECT * FROM read_alignments('alignments.bam')),
-    read_id
-) ORDER BY value DESC;
-
--- Filter high-quality primary alignments
-CREATE VIEW primary_alignments AS
-    SELECT * FROM read_alignments('alignments.bam')
-    WHERE alignment_is_primary(flags) AND mapq >= 20;
-
-SELECT * FROM woltka_ogu(primary_alignments, read_id);
-
--- Combine with filtering for specific references
-CREATE VIEW bacterial_alignments AS
-    SELECT * FROM read_alignments('metagenome.bam')
-    WHERE reference LIKE 'bacteria_%';
-
-SELECT feature_id, value
-FROM woltka_ogu(bacterial_alignments, read_id)
-WHERE value > 10
-ORDER BY value DESC;
-
--- Export to BIOM format (add sample_id column)
+-- Export global results to BIOM (add a sample_id column)
 COPY (
     SELECT feature_id, 'MySample' AS sample_id, value
-    FROM woltka_ogu(my_alignments, read_id)
+    FROM woltka_ogu('my_alignments', 'read_id')
 ) TO 'ogu_single.biom' (FORMAT BIOM);
 ```
 
 **Notes:**
-- Multi-mapped reads (reads aligning to multiple references) are fractionally assigned: each mapping receives weight 1/N where N is the number of unique references
-- Read orientation (forward/reverse) is considered separately using SAM flags
-- For better performance with large datasets, consider adding a numeric index column and using it as `sequence_id_field` instead of `read_id`
-- This function handles paired-end data by distinguishing R1 and R2 reads via the `alignment_is_read1()` flag
-- **Implementation note:** Implemented as a DuckDB macro (table-returning expression), so parameters are not quoted
+- Arguments `relation` and `sequence_id_field` (and `sample_id` if used) must be quoted string literals; they are catalog/column names resolved at bind time.
+- Multi-mapped reads are fractionally assigned: each mapping receives weight 1/N where N is the number of unique references the read maps to, within the same orientation.
+- Read orientation (forward/reverse) is considered separately via the `alignment_is_read1()` flag — paired-end reads are handled automatically.
+- For better performance on large datasets, add a numeric index column and pass it as `sequence_id_field` instead of `read_id`.
+- Output row order is non-deterministic when `sample_id` is used (parallel per-sample execution). Use an explicit `ORDER BY` if stable ordering is required.
 
 ## `sequence_dna_reverse_complement(sequence)` and `sequence_rna_reverse_complement(sequence)`
 

--- a/docs/copy-formats.md
+++ b/docs/copy-formats.md
@@ -244,17 +244,17 @@ Write query results to BIOM (Biological Observation Matrix) format files. BIOM i
 ```sql
 -- Basic BIOM output from Woltka results
 COPY (
-    SELECT * FROM woltka_ogu_per_sample(my_alignments, sample_id, read_id)
+    SELECT * FROM woltka_ogu('my_alignments', 'read_id', sample_id := 'sample_id')
 ) TO 'ogu_table.biom' (FORMAT BIOM);
 
 -- With HDF5 gzip compression (recommended)
 COPY (
-    SELECT * FROM woltka_ogu_per_sample(my_alignments, sample_id, read_id)
+    SELECT * FROM woltka_ogu('my_alignments', 'read_id', sample_id := 'sample_id')
 ) TO 'ogu_table.biom' (FORMAT BIOM, COMPRESSION 'gzip');
 
 -- With custom metadata
 COPY (
-    SELECT * FROM woltka_ogu_per_sample(my_alignments, sample_id, read_id)
+    SELECT * FROM woltka_ogu('my_alignments', 'read_id', sample_id := 'sample_id')
 ) TO 'ogu_table.biom' (FORMAT BIOM,
                        COMPRESSION 'gzip',
                        ID 'MyStudy_16S',
@@ -267,7 +267,7 @@ CREATE VIEW high_qual AS
     WHERE mapq >= 30 AND alignment_is_primary(flags);
 
 COPY (
-    SELECT * FROM woltka_ogu_per_sample(high_qual, sample_id, read_id)
+    SELECT * FROM woltka_ogu('high_qual', 'read_id', sample_id := 'sample_id')
 ) TO 'high_qual.biom' (FORMAT BIOM, COMPRESSION 'gzip');
 
 -- Convert any compatible table to BIOM format
@@ -291,13 +291,13 @@ CREATE VIEW all_samples AS
     SELECT *, 'sample3' AS sample_id FROM read_alignments('sample3.bam');
 
 COPY (
-    SELECT * FROM woltka_ogu_per_sample(all_samples, sample_id, read_id)
+    SELECT * FROM woltka_ogu('all_samples', 'read_id', sample_id := 'sample_id')
 ) TO 'all_samples.biom' (FORMAT BIOM, COMPRESSION 'gzip');
 
 -- Export single-sample results (add sample_id column)
 COPY (
     SELECT feature_id, 'MySample' AS sample_id, value
-    FROM woltka_ogu(my_alignments, read_id)
+    FROM woltka_ogu('my_alignments', 'read_id')
 ) TO 'single_sample.biom' (FORMAT BIOM);
 ```
 

--- a/onboarding-tutorials/advanced.md
+++ b/onboarding-tutorials/advanced.md
@@ -120,7 +120,7 @@ for sample in "${OUTDIR}"/sample_a.parquet "${OUTDIR}"/sample_b.parquet "${OUTDI
         WHERE alignment_is_primary(flags)
           AND alignment_query_coverage(cigar) >= 0.99
           AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') >= 0.97;
-    SELECT '${name}' AS sample, * FROM woltka_ogu(filtered, read_id);
+    SELECT '${name}' AS sample, * FROM woltka_ogu('filtered', 'read_id');
     "
 done
 ```
@@ -498,7 +498,7 @@ miint supports a much broader range of bioinformatics workflows:
   and
   [clustering](../docs/table-functions.md#cluster_sequences_vsearchinput_table-idthreshold-options).
 - **Community ecology** &mdash;
-  [OGU counting](../docs/analysis-functions.md#woltka_ogurelation-sequence_id_field)
+  [OGU counting](../docs/analysis-functions.md#woltka_ogurelation-sequence_id_field-sample_id)
   per sample,
   [genome coverage](../docs/analysis-functions.md#genome_coveragealignments-subject_total_length-subject_genome_id),
   reading phylogenetic

--- a/onboarding-tutorials/intermediate.md
+++ b/onboarding-tutorials/intermediate.md
@@ -230,7 +230,7 @@ homology with *E. coli* &mdash; not genuine *E. coli* reads.
 ## Step 6: Filter and count with `woltka_ogu`
 
 Now let's apply a proper filter and count with
-[`woltka_ogu`](../docs/analysis-functions.md#woltka_ogurelation-sequence_id_field),
+[`woltka_ogu`](../docs/analysis-functions.md#woltka_ogurelation-sequence_id_field-sample_id),
 a built-in table macro that implements the Woltka OGU (Operational Genomic
 Unit) counting method (Zhu et al., 2022). `woltka_ogu` is primarily designed
 for shotgun metagenomic data, where reads span the entire genome; however, its
@@ -256,10 +256,10 @@ Now compare unfiltered vs. filtered counts using
 
 ```sql
 SELECT 'unfiltered' AS source, *
-    FROM woltka_ogu(alignments, read_id)
+    FROM woltka_ogu('alignments', 'read_id')
 UNION ALL
 SELECT 'filtered' AS source, *
-    FROM woltka_ogu(filtered_alignments, read_id);
+    FROM woltka_ogu('filtered_alignments', 'read_id');
 ```
 
 | source | feature_id | value |
@@ -293,10 +293,10 @@ CREATE VIEW strict_99 AS
       AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') >= 0.99;
 
 SELECT 'qcov >= 99%, id >= 97%' AS threshold, *
-    FROM woltka_ogu(strict_97, read_id)
+    FROM woltka_ogu('strict_97', 'read_id')
 UNION ALL
 SELECT 'qcov >= 99%, id >= 99%' AS threshold, *
-    FROM woltka_ogu(strict_99, read_id);
+    FROM woltka_ogu('strict_99', 'read_id');
 ```
 
 | threshold | feature_id | value |
@@ -316,37 +316,35 @@ present?" answer, 99% identity with full query coverage is hard to argue with.
 
 If you find yourself applying the same filter repeatedly, you can wrap it in a
 DuckDB [macro](https://duckdb.org/docs/current/sql/statements/create_macro). A
-macro is a parameterized query you can call like a function:
+table macro is a parameterized query you can call like a table:
 
 ```sql
-CREATE OR REPLACE MACRO filtered_ogu(
-    alignment_table,
-    seq_id_field,
+CREATE OR REPLACE MACRO quality_filtered(
     min_query_coverage := 0.99,
     min_seq_identity := 0.97
 ) AS TABLE
-    WITH passing AS (
-        SELECT *
-        FROM query_table(alignment_table)
-        WHERE alignment_is_primary(flags)
-          AND alignment_query_coverage(cigar) >= min_query_coverage
-          AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast')
-              >= min_seq_identity
-    )
     SELECT *
-    FROM woltka_ogu(passing, seq_id_field);
+    FROM alignments
+    WHERE alignment_is_primary(flags)
+      AND alignment_query_coverage(cigar) >= min_query_coverage
+      AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast')
+          >= min_seq_identity;
 ```
 
-Now you can count with quality filtering in a single call:
+`woltka_ogu` resolves its `relation` argument through the catalog, so wrap the
+macro call in a view before counting:
 
 ```sql
-SELECT * FROM filtered_ogu(alignments, read_id);
+CREATE OR REPLACE VIEW strict_filtered AS SELECT * FROM quality_filtered();
+SELECT * FROM woltka_ogu('strict_filtered', 'read_id');
 ```
 
 Or adjust the thresholds:
 
 ```sql
-SELECT * FROM filtered_ogu(alignments, read_id, 0.99, 0.99);
+CREATE OR REPLACE VIEW strictest_filtered AS
+    SELECT * FROM quality_filtered(min_seq_identity := 0.99);
+SELECT * FROM woltka_ogu('strictest_filtered', 'read_id');
 ```
 
 ## Step 9: Genome coverage

--- a/python/src/miint_cli/cli.py
+++ b/python/src/miint_cli/cli.py
@@ -356,7 +356,7 @@ def cmd_transform_woltka_ogu(con, args):
         con.execute(
             f"""
             COPY (
-                SELECT * FROM woltka_ogu({_V_FILTERED_ALIGNMENTS}, read_id)
+                SELECT * FROM woltka_ogu('{_V_FILTERED_ALIGNMENTS}', 'read_id')
             ) TO $out ({PARQUET_OPTS})
         """,
             {"out": args.output},
@@ -365,7 +365,7 @@ def cmd_transform_woltka_ogu(con, args):
         con.execute(
             f"""
             COPY (
-                SELECT * FROM woltka_ogu({_V_ALIGNMENTS}, read_id)
+                SELECT * FROM woltka_ogu('{_V_ALIGNMENTS}', 'read_id')
             ) TO $out ({PARQUET_OPTS})
         """,
             {"out": args.output},

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -5,99 +5,7 @@
 
 namespace duckdb {
 
-// TODO: overloading didn't work, unsure why, it's arguably better
-// to be explicit anyway.
-//
-// TODO: there is a lot of common logic with the macros.
-
-// woltka_ogu_per_sample(relation, sample_id_field, sequence_id_field)
-//
-// Compute Woltka OGU counts over SAM-like data for multiple samples.
-//
-// Parameters:
-// relation : a relation, view, etc to SAM-like data. The relation must contain
-//     what "sequence_id_field" and "sample_id_field" resolve to as provided
-//     by the caller. The relation must also contain `subject_id`, and `flags`
-// sample_id_field : a varchar, the field within the relation which contains
-// 	   sample IDs.
-// sequence_id_field : a VARCHAR, the field within the relation to group
-// 	   sequence identifiers by. Note: this is abstracted out to allow users to
-//     specify either the SAM standard `read_id` which is VARCHAR or to use
-//     a numeric index if it exists. A numeric index will be faster for the
-//     internal GROUP BY operations.
-//
-// IMPORTANT: queries should not be quoted. As in, an operation should look like
-//   SELECT * FROM woltka_ogu_per_sample(some_table, some_field, some_other_field);
-// A query should _not_ look like
-// 	 SELECT * FROM woltka_ogu_per_sample('some_table', 'some_field', 'some_other_field');
-// The specific issue is `some_field` and `some_other_field` will be re-interpreted as
-// a string literal.
-const std::string WOLTKA_OGU_PER_SAMPLE =
-    "CREATE OR REPLACE MACRO woltka_ogu_per_sample(relation, sample_id_field, sequence_id_field) AS TABLE "
-    "WITH "
-    "    base AS ( "
-    "        SELECT DISTINCT "
-    "            sequence_id_field AS query_local_id_field, "
-    "            sample_id_field AS query_local_sample_id, "
-    "            reference AS feature_id, "
-    "            alignment_is_read1(flags::USMALLINT) AS is_fwd "
-    "        FROM query_table(relation) "
-    "    ), "
-    "    with_counts AS ( "
-    "        SELECT "
-    "            query_local_sample_id, "
-    "            feature_id, "
-    "            1.0 / COUNT(*) OVER (PARTITION BY query_local_id_field, is_fwd) AS local_value "
-    "        FROM base "
-    "    ) "
-    "SELECT "
-    "    query_local_sample_id AS sample_id, "
-    "    feature_id, "
-    "    SUM(local_value) AS value "
-    "FROM with_counts "
-    "GROUP BY query_local_sample_id, feature_id; ";
-
-// woltka_ogu(relation, sequence_id_field)
-//
-// Compute Woltka OGU counts over SAM-like data irrespective of sample.
-//
-// Parameters:
-// relation : a relation, view, etc to SAM-like data. The relation must contain
-//     what "sequence_id_field" and "sample_id_field" resolve to as provided
-//     by the caller. The relation must also contain `subject_id`, and `flags`
-// sequence_id_field : a VARCHAR, the field within the relation to group
-// 	   sequence identifiers by. Note: this is abstracted out to allow users to
-//     specify either the SAM standard `read_id` which is VARCHAR or to use
-//     a numeric index if it exists. A numeric index will be faster for the
-//     internal GROUP BY operations.
-//
-// IMPORTANT: queries should not be quoted. As in, an operation should look like
-//   SELECT * FROM woltka_ogu(some_table, some_field);
-// A query should _not_ look like
-// 	 SELECT * FROM woltka_ogu('some_table', 'some_field');
-// The specific issue is `some_field` will be re-interpreted as a string literal.
-
-const std::string WOLTKA_OGU = // NOLINT
-    "CREATE OR REPLACE MACRO woltka_ogu(relation, sequence_id_field) AS TABLE "
-    "WITH "
-    "    base AS ( "
-    "        SELECT DISTINCT "
-    "            sequence_id_field AS query_local_id_field, "
-    "            reference AS feature_id, "
-    "            alignment_is_read1(flags::USMALLINT) AS is_fwd "
-    "        FROM query_table(relation) "
-    "    ), "
-    "    with_counts AS ( "
-    "        SELECT "
-    "            feature_id, "
-    "            1.0 / COUNT(*) OVER (PARTITION BY query_local_id_field, is_fwd) AS local_value "
-    "        FROM base "
-    "    ) "
-    "SELECT "
-    "    feature_id, "
-    "    SUM(local_value) AS value "
-    "FROM with_counts "
-    "GROUP BY feature_id;";
+// woltka_ogu is now a C++ table function — see src/woltka_ogu_function.cpp
 
 const std::string PARSE_GFF_ATTRIBUTES = // NOLINT
     "CREATE OR REPLACE MACRO parse_gff_attributes(kvp_string) AS ( "
@@ -811,8 +719,6 @@ public:
 			}
 		};
 
-		register_macro(WOLTKA_OGU_PER_SAMPLE, "woltka_ogu_per_sample");
-		register_macro(WOLTKA_OGU, "woltka_ogu");
 		register_macro(PARSE_GFF_ATTRIBUTES, "parse_gff_attributes");
 		register_macro(READ_GFF, "read_gff");
 		register_macro(GENOME_COVERAGE, "genome_coverage");

--- a/src/include/woltka_ogu_function.hpp
+++ b/src/include/woltka_ogu_function.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+class WoltkaOguFunction {
+public:
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -35,6 +35,7 @@
 #include <sequence_functions.hpp>
 #include <formula_function.hpp>
 #include <massql_function.hpp>
+#include <woltka_ogu_function.hpp>
 #include <mzml_peak_pair_function.hpp>
 #ifdef MIINT_HAS_MAFFT
 #include <align_mafft.hpp>
@@ -215,6 +216,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	SequenceFunctions::Register(loader);
 	FormulaFunction::Register(loader);
 	MassQLFunction::Register(loader);
+	WoltkaOguFunction::Register(loader);
 	MzmlPeakPairFunction::Register(loader);
 
 	AlignPairwiseScoreFunction::Register(loader);

--- a/src/woltka_ogu_function.cpp
+++ b/src/woltka_ogu_function.cpp
@@ -1,0 +1,281 @@
+#include "woltka_ogu_function.hpp"
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+#include <atomic>
+
+namespace duckdb {
+
+// ── woltka_ogu() table function ─────────────────────────────────────────────
+// Usage:
+//   SELECT * FROM woltka_ogu('my_alignments', 'read_id');
+//   SELECT * FROM woltka_ogu('my_alignments', 'read_id', sample_id := 'sample_col');
+//
+// Computes Woltka OGU counts over SAM-like alignment data. With sample_id,
+// runs one aggregation per sample on a per-thread Connection, parallelised
+// via an atomic claim counter; without, runs a single aggregation once at
+// bind time and drains its materialised result from Execute. Read IDs are
+// assumed unique across samples, so the per-sample subset preserves the
+// window-function result.
+
+struct WoltkaOguData : public TableFunctionData {
+	string source;
+	string seq_id_col;
+
+	bool has_sample_id = false;
+	string sample_id_col;
+	LogicalType sample_id_type;
+	vector<Value> sample_values;
+
+	// Non-sample path: pre-run at Bind; ownership moved to GlobalState at InitGlobal.
+	unique_ptr<MaterializedQueryResult> non_sample_result;
+};
+
+struct WoltkaOguGlobalState : public GlobalTableFunctionState {
+	// Per-sample mode: atomic index of the next sample to claim.
+	atomic<idx_t> next_sample_idx {0};
+	idx_t max_threads = 1;
+
+	// Non-sample path: pre-run result transferred from bind data at InitGlobal.
+	// Single thread drains it from Execute; no synchronization needed.
+	unique_ptr<MaterializedQueryResult> non_sample_result;
+
+	idx_t MaxThreads() const override {
+		return max_threads;
+	}
+};
+
+struct WoltkaOguLocalState : public LocalTableFunctionState {
+	unique_ptr<Connection> conn;                // per-sample mode only
+	unique_ptr<MaterializedQueryResult> result; // current sample's result
+	// Keeps the fetched chunk alive while output.Reference() points into its
+	// buffers. Overwritten on the next Execute call, after the upstream
+	// operator has consumed the previous output (DuckDB pull-based guarantee).
+	unique_ptr<DataChunk> current_chunk;
+};
+
+static string BuildAggregationSql(const string &source, const string &seq_id_col) {
+	auto q_src = KeywordHelper::WriteOptionallyQuoted(source);
+	auto q_seq = KeywordHelper::WriteOptionallyQuoted(seq_id_col);
+	return "WITH base AS ("
+	       "  SELECT DISTINCT "
+	       "    " +
+	       q_seq +
+	       " AS qid, "
+	       "    reference AS feature_id, "
+	       "    alignment_is_read1(flags::USMALLINT) AS is_fwd "
+	       "  FROM " +
+	       q_src +
+	       "), "
+	       "with_counts AS ("
+	       "  SELECT feature_id, "
+	       "         1.0 / COUNT(*) OVER (PARTITION BY qid, is_fwd) AS local_value "
+	       "  FROM base) "
+	       "SELECT feature_id, SUM(local_value) AS value "
+	       "FROM with_counts "
+	       "GROUP BY feature_id";
+}
+
+static unique_ptr<MaterializedQueryResult> RunGlobalAggregation(Connection &conn, const string &source,
+                                                                const string &seq_id_col) {
+	auto sql = BuildAggregationSql(source, seq_id_col);
+	auto result = conn.Query(sql);
+	if (result->HasError()) {
+		throw InvalidInputException("woltka_ogu query failed: %s\nGenerated SQL: %s", result->GetError(), sql);
+	}
+	return result;
+}
+
+// Run the woltka_ogu pipeline for a single sample value. Creates a TEMP VIEW
+// scoped to `conn`. Each thread has its own Connection, so names don't collide.
+static unique_ptr<MaterializedQueryResult> RunSampleAggregation(Connection &conn, const string &source,
+                                                                const string &seq_id_col, const string &sample_col,
+                                                                const Value &sample_value) {
+	auto q_src = KeywordHelper::WriteOptionallyQuoted(source);
+	auto q_sample = KeywordHelper::WriteOptionallyQuoted(sample_col);
+	// ToSQLString handles all Value types (integers, timestamps, strings) safely.
+	auto sample_literal = sample_value.ToSQLString();
+
+	auto view_sql = "CREATE OR REPLACE TEMP VIEW __woltka_per_sample AS SELECT * FROM " + q_src + " WHERE CAST(" +
+	                q_sample + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR)";
+	auto view_result = conn.Query(view_sql);
+	if (view_result->HasError()) {
+		throw InvalidInputException("woltka_ogu: failed to create per-sample view: %s", view_result->GetError());
+	}
+
+	auto inner_sql = BuildAggregationSql("__woltka_per_sample", seq_id_col);
+	auto wrapped_sql = "SELECT " + sample_literal + " AS " + q_sample + ", __q.* FROM (" + inner_sql + ") __q";
+
+	auto result = conn.Query(wrapped_sql);
+	if (result->HasError()) {
+		throw InvalidInputException("woltka_ogu query failed: %s\nGenerated SQL: %s", result->GetError(), wrapped_sql);
+	}
+	return result;
+}
+
+static unique_ptr<FunctionData> WoltkaOguBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	auto data = make_uniq<WoltkaOguData>();
+	data->source = input.inputs[0].GetValue<string>();
+	data->seq_id_col = input.inputs[1].GetValue<string>();
+
+	if (data->source.empty()) {
+		throw InvalidInputException("woltka_ogu: relation name must not be empty");
+	}
+	if (data->seq_id_col.empty()) {
+		throw InvalidInputException("woltka_ogu: sequence_id_field must not be empty");
+	}
+
+	auto it = input.named_parameters.find("sample_id");
+	if (it != input.named_parameters.end()) {
+		data->sample_id_col = it->second.GetValue<string>();
+		if (data->sample_id_col.empty()) {
+			throw InvalidInputException("woltka_ogu: sample_id column name must not be empty");
+		}
+		// Reject column names that collide with the fixed output schema.
+		// DuckDB identifiers are case-insensitive.
+		auto col_lower = StringUtil::Lower(data->sample_id_col);
+		if (col_lower == "feature_id" || col_lower == "value") {
+			throw InvalidInputException("woltka_ogu: sample_id column name '%s' collides with an output column "
+			                            "(feature_id, value); rename the column or alias it in a view",
+			                            data->sample_id_col);
+		}
+		data->has_sample_id = true;
+	}
+
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+
+	auto q_src = KeywordHelper::WriteOptionallyQuoted(data->source);
+	auto q_seq = KeywordHelper::WriteOptionallyQuoted(data->seq_id_col);
+
+	// Validate source resolves AND required columns exist AND their types are compatible
+	// with the aggregation (reference → VARCHAR, flags → USMALLINT). LIMIT 0 binds the
+	// casts without scanning rows.
+	auto probe = conn.Query("SELECT " + q_seq + ", reference::VARCHAR, flags::USMALLINT FROM " + q_src + " LIMIT 0");
+	if (probe->HasError()) {
+		throw InvalidInputException("woltka_ogu: source, required columns (reference, flags), or their types "
+		                            "are not compatible: %s",
+		                            probe->GetError());
+	}
+
+	if (data->has_sample_id) {
+		auto q_sample = KeywordHelper::WriteOptionallyQuoted(data->sample_id_col);
+
+		auto sample_probe = conn.Query("SELECT " + q_sample + " FROM " + q_src + " LIMIT 0");
+		if (sample_probe->HasError()) {
+			throw InvalidInputException("woltka_ogu: sample_id column '%s' not found", data->sample_id_col);
+		}
+		data->sample_id_type = sample_probe->types[0];
+
+		// Single scan: distinct sample values, NULLs first so we can reject up-front.
+		auto distinct_result =
+		    conn.Query("SELECT DISTINCT " + q_sample + " FROM " + q_src + " ORDER BY " + q_sample + " NULLS FIRST");
+		if (distinct_result->HasError()) {
+			throw InvalidInputException("woltka_ogu: failed to query sample_id values: %s",
+			                            distinct_result->GetError());
+		}
+		auto &materialized = distinct_result->Cast<MaterializedQueryResult>();
+		while (auto chunk = materialized.Fetch()) {
+			for (idx_t i = 0; i < chunk->size(); i++) {
+				auto val = chunk->data[0].GetValue(i);
+				if (val.IsNull()) {
+					throw InvalidInputException("NULL values in sample_id column '%s'", data->sample_id_col);
+				}
+				data->sample_values.push_back(std::move(val));
+			}
+		}
+		if (data->sample_values.empty()) {
+			throw InvalidInputException("sample_id column '%s' has no non-NULL values", data->sample_id_col);
+		}
+
+		names.push_back(data->sample_id_col);
+		return_types.push_back(data->sample_id_type);
+	} else {
+		// Non-sample path: pre-run the aggregation once here. Ownership of the result
+		// transfers to GlobalState at InitGlobal, matching MassQLFunction's pattern.
+		data->non_sample_result = RunGlobalAggregation(conn, data->source, data->seq_id_col);
+	}
+
+	names.emplace_back("feature_id");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("value");
+	return_types.emplace_back(LogicalType::DOUBLE);
+
+	return data;
+}
+
+static unique_ptr<GlobalTableFunctionState> WoltkaOguInitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	// CastNoConst: we move result ownership out of bind data into global state.
+	// InitGlobal is called exactly once before any Execute thread starts, so this is safe.
+	auto &data = input.bind_data->CastNoConst<WoltkaOguData>();
+	auto gstate = make_uniq<WoltkaOguGlobalState>();
+	if (data.has_sample_id) {
+		idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+		gstate->max_threads = std::max<idx_t>(1, std::min<idx_t>(db_threads, data.sample_values.size()));
+	} else {
+		gstate->max_threads = 1;
+		gstate->non_sample_result = std::move(data.non_sample_result);
+	}
+	return gstate;
+}
+
+static unique_ptr<LocalTableFunctionState> WoltkaOguInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                              GlobalTableFunctionState * /*global_state*/) {
+	auto &data = input.bind_data->Cast<WoltkaOguData>();
+	auto lstate = make_uniq<WoltkaOguLocalState>();
+	if (data.has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		lstate->conn = make_uniq<Connection>(db);
+	}
+	return lstate;
+}
+
+static void WoltkaOguExecute(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &data = input.bind_data->Cast<WoltkaOguData>();
+	auto &gstate = input.global_state->Cast<WoltkaOguGlobalState>();
+	auto &lstate = input.local_state->Cast<WoltkaOguLocalState>();
+
+	if (!data.has_sample_id) {
+		// Single thread drains the pre-run result from global state.
+		lstate.current_chunk = gstate.non_sample_result->Fetch();
+		if (lstate.current_chunk && lstate.current_chunk->size() > 0) {
+			output.Reference(*lstate.current_chunk);
+			return;
+		}
+		output.SetCardinality(0);
+		return;
+	}
+
+	// Per-sample: each thread atomically claims sample indices.
+	while (true) {
+		if (lstate.result) {
+			lstate.current_chunk = lstate.result->Fetch();
+			if (lstate.current_chunk && lstate.current_chunk->size() > 0) {
+				output.Reference(*lstate.current_chunk);
+				return;
+			}
+			lstate.result.reset();
+		}
+		idx_t sample_idx = gstate.next_sample_idx.fetch_add(1, std::memory_order_relaxed);
+		if (sample_idx >= data.sample_values.size()) {
+			output.SetCardinality(0);
+			return;
+		}
+		lstate.result = RunSampleAggregation(*lstate.conn, data.source, data.seq_id_col, data.sample_id_col,
+		                                     data.sample_values[sample_idx]);
+	}
+}
+
+void WoltkaOguFunction::Register(ExtensionLoader &loader) {
+	TableFunction fn("woltka_ogu", {LogicalType::VARCHAR, LogicalType::VARCHAR}, WoltkaOguExecute, WoltkaOguBind,
+	                 WoltkaOguInitGlobal, WoltkaOguInitLocal);
+	fn.named_parameters["sample_id"] = LogicalType::VARCHAR;
+	fn.order_preservation_type = OrderPreservationType::NO_ORDER;
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/test/sql/woltka.test
+++ b/test/sql/woltka.test
@@ -20,24 +20,24 @@ TO '__TEST_DIR__/test_woltka_sam_data.sam' (FORMAT SAM, INCLUDE_HEADER false, RE
 # Test against woltka produced outputs
 # woltka classify ... --no-demux --digits 10
 query II
-SELECT * FROM woltka_ogu(test_sam_data, read_id) order by value;
+SELECT * FROM woltka_ogu('test_sam_data', 'read_id') order by value;
 ----
-H000003450	477.800                           
-H000000556	849.086                           
-G002234575	1302.833                           
+H000003450	477.800
+H000000556	849.086
+G002234575	1302.833
 H000003668	1468.333
-H000000425	2165.002                           
-H000000962	6509.969                           
-G012273055	6638.369                           
-H000001008	15743.819                           
-G025152275	17770.333                           
-G000156075	30911.302                           
-G016766915	58468.152                           
+H000000425	2165.002
+H000000962	6509.969
+G012273055	6638.369
+H000001008	15743.819
+G025152275	17770.333
+G000156075	30911.302
+G016766915	58468.152
 
 # Test against woltka produced outputs per sample
 # woltka classify ... --no-demux --digits 10
 query III
-SELECT * FROM woltka_ogu_per_sample(test_sam_data, common_sample_name, read_id) order by sample_id, value;
+SELECT * FROM woltka_ogu('test_sam_data', 'read_id', sample_id := 'common_sample_name') order by common_sample_name, value;
 ----
 bar	H000003450	477.800
 bar	H000000556	847.669
@@ -64,7 +64,7 @@ statement ok
 CREATE TABLE from_sam AS FROM read_sam('__TEST_DIR__/test_woltka_sam_data.sam', reference_lengths='mock_lengths');
 
 query II
-SELECT * FROM woltka_ogu(from_sam, read_id) order by value;
+SELECT * FROM woltka_ogu('from_sam', 'read_id') order by value;
 ----
 H000003450	477.800                           
 H000000556	849.086                           
@@ -77,6 +77,77 @@ H000001008	15743.819
 G025152275	17770.333                           
 G000156075	30911.302                           
 G016766915	58468.152                           
+
+# Reject sample_id column names that collide with the fixed output schema
+statement error
+SELECT * FROM woltka_ogu('test_sam_data', 'read_id', sample_id := 'feature_id')
+----
+collides with an output column
+
+statement error
+SELECT * FROM woltka_ogu('test_sam_data', 'read_id', sample_id := 'value')
+----
+collides with an output column
+
+# Collision check is case-insensitive (DuckDB identifiers are case-insensitive)
+statement error
+SELECT * FROM woltka_ogu('test_sam_data', 'read_id', sample_id := 'FEATURE_ID')
+----
+collides with an output column
+
+# Empty relation: global mode returns zero rows cleanly
+statement ok
+CREATE TABLE empty_alignments AS SELECT * FROM test_sam_data WHERE 1 = 0;
+
+query II
+SELECT * FROM woltka_ogu('empty_alignments', 'read_id');
+----
+
+# Empty relation in per-sample mode: bind-time error (no sample values to iterate)
+statement error
+SELECT * FROM woltka_ogu('empty_alignments', 'read_id', sample_id := 'common_sample_name')
+----
+has no non-NULL values
+
+statement ok
+DROP TABLE empty_alignments;
+
+# Single-sample relation in per-sample mode: one claim, full output
+statement ok
+CREATE TABLE single_sample AS SELECT * FROM test_sam_data WHERE common_sample_name = 'foo';
+
+query III
+SELECT * FROM woltka_ogu('single_sample', 'read_id', sample_id := 'common_sample_name') ORDER BY value;
+----
+foo	H000000556	1.417
+foo	H000000425	1.917
+foo	G025152275	2.000
+foo	H000000962	2.667
+foo	G012273055	4.750
+foo	G000156075	9.500
+foo	H000001008	13.250
+foo	G016766915	15.500
+
+statement ok
+DROP TABLE single_sample;
+
+# Bind-time error when a required column is missing from the source
+statement ok
+CREATE VIEW no_reference AS SELECT read_id, flags, common_sample_name FROM test_sam_data;
+
+statement error
+SELECT * FROM woltka_ogu('no_reference', 'read_id')
+----
+required columns
+
+statement ok
+DROP VIEW no_reference;
+
+# Bind-time error when the sample_id column does not exist
+statement error
+SELECT * FROM woltka_ogu('test_sam_data', 'read_id', sample_id := 'no_such_col')
+----
+not found
 
 # Cleanup
 statement ok


### PR DESCRIPTION
## Summary

- Replaces the `woltka_ogu` and `woltka_ogu_per_sample` SQL macros with a single C++ table function `woltka_ogu`. The per-sample macro exploded memory on real-world alignment data because the global `DISTINCT` + window function materialized the full deduplicated input before aggregating. The new function mirrors `MassQLFunction`'s pattern: bind discovers distinct sample values, then each worker thread atomically claims a sample and runs the aggregation through its own `Connection` on a `TEMP` view filtered to that sample — bounding memory to a single sample's footprint.
- **Breaking change**: arguments are now quoted string literals, matching the `massql()` interface.
  - Before: `SELECT * FROM woltka_ogu(my_alignments, read_id);` / `SELECT * FROM woltka_ogu_per_sample(my_alignments, sample_id, read_id);`
  - After: `SELECT * FROM woltka_ogu('my_alignments', 'read_id');` / `SELECT * FROM woltka_ogu('my_alignments', 'read_id', sample_id := 'sample_id');`
- Global mode (no `sample_id`) pre-runs at bind time, so SQL errors surface as bind errors instead of mid-pipeline. Bind-time validation also casts `reference::VARCHAR` and `flags::USMALLINT` in a `LIMIT 0` probe to catch structural type mismatches, rejects `sample_id` column names colliding with the output schema (`feature_id`, `value`, case-insensitive), and rejects NULLs in the `sample_id` column via a single scan using `ORDER BY ... NULLS FIRST`.
- Documentation in `docs/analysis-functions.md` and `docs/copy-formats.md` collapsed to a single unified entry; Python CLI (`python/src/miint_cli/cli.py`) updated to quoted-string form.

## Test plan

- [x] `./build/release/test/unittest "test/sql/woltka.test"` — 143/143 assertions pass (107 original golden values preserved verbatim + 36 new coverage for collision guard, empty input, single-sample, and missing-column bind errors)
- [x] `bash run_tests.sh` — full SQL suite green
- [x] `./build/release/extension/miint/tests` — 6229/6229 C++ assertions pass (34 skipped for unavailable dependencies)
- [x] `conda run -n duckdb-143 make format-check` — clean
- [x] End-to-end shell sanity: global 11 rows, per-sample `bar`=11 / `foo`=8, collision rejected with exact expected message
- [ ] **Real-world memory validation** — the originating motivation. Run against a large metagenomic alignment dataset to confirm the per-sample parallel path bounds memory as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)