### PR TITLE
Lateral read ena sequences

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,9 +765,11 @@ set(EXTENSION_SOURCES
     src/ena_client.cpp
     src/ena_run_info_extractor.cpp
     src/ena_resolver_cache.cpp
+    src/ena_search_field_registry.cpp
     src/per_run_reader.cpp
     src/read_ena.cpp
     src/read_ena_attributes.cpp
+    src/read_ena_searchable_fields.cpp
     src/read_ena_sequences.cpp
     src/aspera_utils.cpp
     src/aspera_stream.cpp
@@ -1027,8 +1029,10 @@ set(TEST_SOURCES
     src/ena_parser.cpp
     src/ena_run_info_extractor.cpp
     src/ena_resolver_cache.cpp
+    src/ena_search_field_registry.cpp
     test/cpp/test_ENAClient.cpp
     test/cpp/test_ENAResolverCache.cpp
+    test/cpp/test_ena_search_field_registry.cpp
     src/aspera_utils.cpp
     test/cpp/test_AsperaUtils.cpp
     src/SFFReader.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,7 @@ set(EXTENSION_SOURCES
     src/ena_run_info_extractor.cpp
     src/ena_resolver_cache.cpp
     src/ena_search_field_registry.cpp
+    src/ena_attributes_filter.cpp
     src/per_run_reader.cpp
     src/read_ena.cpp
     src/read_ena_attributes.cpp
@@ -1030,9 +1031,12 @@ set(TEST_SOURCES
     src/ena_run_info_extractor.cpp
     src/ena_resolver_cache.cpp
     src/ena_search_field_registry.cpp
+    src/ena_attributes_filter.cpp
     test/cpp/test_ENAClient.cpp
     test/cpp/test_ENAResolverCache.cpp
     test/cpp/test_ena_search_field_registry.cpp
+    test/cpp/test_ena_attributes_filter.cpp
+    test/cpp/test_ena_attributes_pushdown.cpp
     src/aspera_utils.cpp
     test/cpp/test_AsperaUtils.cpp
     src/SFFReader.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -763,6 +763,8 @@ set(EXTENSION_SOURCES
     src/read_ncbi_annotation.cpp
     src/ena_parser.cpp
     src/ena_client.cpp
+    src/ena_run_info_extractor.cpp
+    src/ena_resolver_cache.cpp
     src/read_ena.cpp
     src/read_ena_attributes.cpp
     src/read_ena_sequences.cpp
@@ -1022,7 +1024,10 @@ set(TEST_SOURCES
     duckdb/third_party/miniz/miniz.cpp  # For ExtractFromZip tests
     test/cpp/test_ncbi_client.cpp
     src/ena_parser.cpp
+    src/ena_run_info_extractor.cpp
+    src/ena_resolver_cache.cpp
     test/cpp/test_ENAClient.cpp
+    test/cpp/test_ENAResolverCache.cpp
     src/aspera_utils.cpp
     test/cpp/test_AsperaUtils.cpp
     src/SFFReader.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,7 @@ set(EXTENSION_SOURCES
     src/ena_client.cpp
     src/ena_run_info_extractor.cpp
     src/ena_resolver_cache.cpp
+    src/per_run_reader.cpp
     src/read_ena.cpp
     src/read_ena_attributes.cpp
     src/read_ena_sequences.cpp

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -41,6 +41,9 @@ For headerless SAM files and SAM writing:
 ### Shared Table Function Utilities
 `src/include/table_function_common.hpp` / `.cpp` provides `ParseFilePathsParameter`, `IsStdinPath`, `SetResultVector*`, and similar helpers. Prefer these over re-implementing per-function.
 
+### Dual-path Table Functions (standard + lateral)
+Functions like `read_ena_sequences` set both `function` (`Execute`) and `in_out_function` (`ExecuteInOut`) on the same `TableFunction`. DuckDB routes scalar-constant calls to the standard path (parallel, byte-based progress) and correlated-column or subquery calls to the in-out path (one outer row at a time, `LIMIT`-driven short-circuit via `LocalState` destruction). Shared per-run open/read/close logic lives in `miint::PerRunReader` so both paths use the same state machine and retry policy, and shared column-fill logic lives in a `FillOutputFromBatch` helper so both paths emit identical chunk layouts. The `Bind` function detects the in-out path by an empty `input.inputs` (DuckDB's table-in-out dispatcher passes no scalar constants) and sets `Data::deferred_resolution`; the per-query LRU `ENAResolverCache` on `Data` then dedupes metadata lookups across outer rows.
+
 ## Testing Strategy
 
 ### SQL Tests (`test/sql/`)

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -44,6 +44,20 @@ For headerless SAM files and SAM writing:
 ### Dual-path Table Functions (standard + lateral)
 Functions like `read_ena_sequences` set both `function` (`Execute`) and `in_out_function` (`ExecuteInOut`) on the same `TableFunction`. DuckDB routes scalar-constant calls to the standard path (parallel, byte-based progress) and correlated-column or subquery calls to the in-out path (one outer row at a time, `LIMIT`-driven short-circuit via `LocalState` destruction). Shared per-run open/read/close logic lives in `miint::PerRunReader` so both paths use the same state machine and retry policy, and shared column-fill logic lives in a `FillOutputFromBatch` helper so both paths emit identical chunk layouts. The `Bind` function detects the in-out path by an empty `input.inputs` (DuckDB's table-in-out dispatcher passes no scalar constants) and sets `Data::deferred_resolution`; the per-query LRU `ENAResolverCache` on `Data` then dedupes metadata lookups across outer rows.
 
+### Filter pushdown via `pushdown_complex_filter`
+`read_ena_attributes` is the reference implementation for translating a DuckDB `WHERE` clause into a remote-API query shape. Pattern:
+
+1. **Abstract AST for the extractor.** `src/include/ena_attributes_filter.hpp` defines `miint::ENAFilterNode` (EQ / IN / AND / OR / UNSUPPORTED). `ExtractPushdownPredicates(vector<unique_ptr<ENAFilterNode>> conjuncts) → ENAAttributePushdown` is pure, has no DuckDB dependency, and is exhaustively unit-tested against the AST directly — no binder scaffolding required.
+2. **DuckDB → AST translator.** Lives in the table function's `.cpp` (see `read_ena_attributes.cpp`'s anonymous namespace). Handles `BoundComparisonExpression` (COMPARE_EQUAL), `BoundOperatorExpression` (COMPARE_IN), and `BoundConjunctionExpression` (AND / OR). Anything else maps to `ENAFilterNode::MakeUnsupported()`, and the extractor rejects any conjunct list containing an unsupported atom.
+3. **Column name resolution.** `BoundColumnRefExpression::binding.column_index` is a local index into `LogicalGet::GetColumnIds()`; `GetPrimaryIndex()` on that entry gives the position in `LogicalGet::names`. (Mirrors `multi_file_list.cpp:68-69`.)
+4. **Do not erase filters.** Record the predicate in `Data::pushdown`, but leave the `vector<unique_ptr<Expression>> &filters` unchanged. DuckDB re-applies the filter as a `LogicalFilter` above the scan, so any semantic mismatch between the remote matcher and SQL equality degrades to extra work, never to wrong rows. (See `read_ena_attributes.cpp`'s `PushdownComplexFilter`.)
+5. **Dual-path Execute.** `GlobalState` exposes both `FetchNextBatch` (default) and `FetchNextStructuredBatch` (pushdown). `Execute()` branches on `bind_data.pushdown.tags.empty()` at the refill site. Both paths write to the same `current_batch` member so the emission code is shared.
+6. **Allowlist-gated pushdown.** The extractor consults `ENASearchFieldRegistry::IsSearchableSampleField` and returns empty (XML fallback) if any referenced tag is unknown — even inside an `IN` list. No per-tag mixing of structured + XML.
+
+Registration: set `tf.pushdown_complex_filter = YourCallback;` in `GetFunction()`. The two filter-pushdown flags are independent:
+- `tf.pushdown_complex_filter` (callback) — arbitrary Expression trees, called once during optimization, scope decided by the callback.
+- `tf.filter_pushdown = true` (bool) — tells the optimizer to extract simple `col=const` / `LIKE` / `IN` predicates into `get.table_filters`. The scan then receives those via `TableFunctionInitInput::filters` and is expected to consume them at read time (e.g. parquet zonemap pruning). Setting this without implementing consumption does not drop filters for correctness (the optimizer still wraps remaining expressions in a `LogicalFilter` above the scan), but the populated `TableFilterSet` is dead weight. Leave `filter_pushdown = false` unless you actually consume `TableFilter` objects.
+
 ## Testing Strategy
 
 ### SQL Tests (`test/sql/`)

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -18,7 +18,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`read_ena`](#read_enaaccession-resultread_run-fields) - EBI/ENA metadata queries
 - [`read_ena_attributes`](#read_ena_attributesaccession) - EBI/ENA custom sample attributes
 - [`ena_searchable_fields`](#ena_searchable_fieldsresult_type) - Enumerate ENA structured-search fields per result type
-- [`read_ena_sequences`](#read_ena_sequencesaccession-include_filepathfalse-qual_offset33) - Stream FASTA/FASTQ from EBI/ENA with accession columns
+- [`read_ena_sequences`](#read_ena_sequencesaccession-include_filepathfalse-qual_offset33-max_sequences0) - Stream FASTA/FASTQ from EBI/ENA with accession columns
 - [`read_jplace`](#read_jplacepath) - Phylogenetic placement files
 - [`read_jplace_newick`](#read_jplace_newickpath-include_filepathfalse) - Newick tree from jplace files
 - [`read_newick`](#read_newickfilename-include_filepathfalse) - Newick phylogenetic trees
@@ -996,7 +996,7 @@ FROM ena_searchable_fields('sample')
 WHERE field_name = 'host_body_site';
 ```
 
-## `read_ena_sequences(accession, [include_filepath=false], [qual_offset=33])`
+## `read_ena_sequences(accession, [include_filepath=false], [qual_offset=33], [max_sequences=0])`
 
 Stream FASTA/FASTQ sequence data from EBI/ENA with run, sample, and experiment accession columns. Returns data in the same schema as `read_fastx` plus accession metadata columns, enabling direct association of sequence data with project metadata. Supports mixed FASTA/FASTQ paired-end data (unlike `read_fastx` which rejects format mismatches).
 
@@ -1008,6 +1008,7 @@ Stream FASTA/FASTQ sequence data from EBI/ENA with run, sample, and experiment a
 - `accession` (VARCHAR or VARCHAR[]): ENA/SRA accession(s). Supports study (bulk download all runs), sample, run, and experiment accessions.
 - `include_filepath` (BOOLEAN, optional, default false): Add filepath column with the HTTPS download URL(s). For paired-end runs, URLs are semicolon-separated.
 - `qual_offset` (BIGINT, optional, default 33): Quality score offset (33 for Phred+33/Sanger, 64 for Phred+64/Illumina 1.3+)
+- `max_sequences` (BIGINT, optional, default 0): If `> 0`, stop emitting from each run after this many sequences. `0` (or NULL / absent) means unlimited. For paired-end runs the cap counts **pairs** (one output row per pair), not underlying FASTQ records — `max_sequences=N` yields at most N rows and corresponds to 2N downloaded reads. When downloading via Aspera the cap tears down the `ascp` transfer early, saving real bandwidth. For SFF runs the cap applies but the full file is downloaded before any record is parsed; a loud warning is printed in that case.
 
 **Output schema:**
 - `sequence_index` (BIGINT): 1-based sequence index (per run)

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -1030,6 +1030,9 @@ Stream FASTA/FASTQ sequence data from EBI/ENA with run, sample, and experiment a
 - `include_filepath` (BOOLEAN, optional, default false): Add filepath column with the HTTPS download URL(s). For paired-end runs, URLs are semicolon-separated.
 - `qual_offset` (BIGINT, optional, default 33): Quality score offset (33 for Phred+33/Sanger, 64 for Phred+64/Illumina 1.3+)
 - `max_sequences` (BIGINT, optional, default 0): If `> 0`, stop emitting from each run after this many sequences. `0` (or NULL / absent) means unlimited. For paired-end runs the cap counts **pairs** (one output row per pair), not underlying FASTQ records — `max_sequences=N` yields at most N rows and corresponds to 2N downloaded reads. When downloading via Aspera the cap tears down the `ascp` transfer early, saving real bandwidth. For SFF runs the cap applies but the full file is downloaded before any record is parsed; a loud warning is printed in that case.
+- `trim_sff` (BOOLEAN, optional, default true): For SFF runs, apply the quality and adapter clip positions from the SFF header to trim sequences and quality scores. Ignored for FASTQ runs. Named `trim_sff` rather than `trim` because `TRIM` is a SQL function keyword and this function is dual-path (supports both scalar and lateral invocation), which together prevent DuckDB's binder from accepting `trim=...`.
+
+Because `read_ena_sequences` supports lateral / correlated invocation, named parameters must be passed with arrow syntax (`name => value`), not `name = value`. For example: `read_ena_sequences('X', prefer_format => 'sff', trim_sff => false)`.
 
 **Output schema:**
 - `sequence_index` (BIGINT): 1-based sequence index (per run)

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -1024,6 +1024,38 @@ FROM read_ena_sequences('ERR1074767', include_filepath=true) LIMIT 5;
 - For large projects, the FASTQ download can take significant time and bandwidth
 - The `run_accession` column enables easy JOIN back to metadata from `read_ena`
 - Quality scores are converted to numeric values using the specified offset (default Phred+33)
+- **Failure handling**: on a transient open failure, the run is retried once. On
+  a mid-stream failure (connection dropped after some rows have been emitted),
+  the run is NOT retried — re-reading from scratch would emit the same reads
+  again with duplicate `sequence_index` values downstream. Instead, the run is
+  recorded as skipped, a loud warning reports the run accession and the
+  number of reads emitted before the failure, and the scan continues with
+  other runs. If you see such a warning, re-run the query (the metadata
+  lookup is cached) or use a smaller per-run selection to recover the
+  truncated data.
+
+**Lateral invocation (correlated arguments):**
+
+Accessions can come from a correlated column via `LATERAL`. Each outer row opens its
+own run; a `LIMIT` inside the lateral short-circuits that run's download (the reader
+and any HTTP connection are torn down as soon as the limit is reached). Metadata
+lookups share an in-memory LRU cache scoped to the query, so repeated outer-row
+values and within-query batches avoid redundant ENA Portal API calls.
+
+```sql
+-- Find runs containing a probe sequence, downloading only until each match is seen.
+SELECT r.run_accession
+FROM read_ena('PRJEB11419') AS r,
+     LATERAL (SELECT 1 FROM read_ena_sequences(r.run_accession)
+              WHERE sequence1.contains('AACGTAGGTCACAAGCGTTGTCCGGA')
+              LIMIT 1);
+```
+
+Limitations in lateral mode:
+- `download_method='aspera'` is not supported (use HTTP; the lateral use case is
+  short-circuit-driven, not throughput-driven).
+- `table_scan_progress` reports `-1.0` (indeterminate) because the total work is
+  driven by the outer side and not known at bind time.
 
 ## `read_jplace(path)`
 

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -945,6 +945,21 @@ Fetch custom sample attributes from EBI/ENA via the Browser XML API. Returns all
 - Parses `<SAMPLE_ATTRIBUTE>` `<TAG>`/`<VALUE>` pairs
 - Returns ALL attributes including custom/submitter-defined ones (e.g., primer sequences, custom identifiers) that are not available via `read_ena`
 
+**Predicate pushdown:**
+When the `WHERE` clause references `tag` (and optionally `value`) with equality-only operators, and every referenced tag is a known ENA sample-search field, the scan switches from per-sample XML fetches to a single `/search?result=sample` TSV request per batch. This converts an O(N)-per-sample XML scan into one HTTP call per 200 samples and can cut minutes off large studies (e.g., a 33 000-sample study drops from a ~3.7-minute rate-limit floor to a few seconds for `WHERE tag='host_body_site'`).
+
+Pushdown triggers when:
+- The filter is a conjunction (AND) of `tag = 'X'`, `tag IN ('X','Y',...)`, or `tag = 'X' AND value = 'Y'`
+- Every referenced tag passes `ena_searchable_fields('sample')` (see the curated allowlist under the hood; uppercase/mixed-case names are accepted)
+
+Pushdown is **declined** (falls back to the XML path, preserving correctness) when:
+- Any referenced tag is not in the searchable-field allowlist (including any single unknown tag inside an `IN` list)
+- Any `OR`, `LIKE`, `!=`, `NOT IN`, etc. appears anywhere in the filter tree
+- `value` is constrained without a single pinned `tag` (ambiguous)
+- Any predicate is on `sample_accession` or another non-`tag`/`value` column
+
+DuckDB always re-applies the original filter above the scan, so the output of the pushdown path is guaranteed to be a subset of what the XML path would have returned — a pushdown mistake degrades to extra work, never to wrong rows.
+
 **Examples:**
 ```sql
 -- Get all attributes for a run's sample
@@ -963,6 +978,12 @@ SELECT sample_accession,
        MAX(CASE WHEN tag = 'geographic location (country and/or sea)' THEN value END) AS country
 FROM read_ena_attributes('PRJEB11419')
 GROUP BY sample_accession;
+
+-- Pushdown-enabled: uses /search endpoint (single TSV per batch) instead of
+-- per-sample XML. Fast on large studies.
+SELECT sample_accession
+FROM read_ena_attributes('PRJEB11419')
+WHERE tag='host_body_site' AND value='UBERON:feces';
 ```
 
 ## `ena_searchable_fields(result_type)`

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -17,6 +17,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`read_ncbi_annotation`](#read_ncbi_annotationaccession-api_key-include_filepathfalse) - NCBI genome annotations
 - [`read_ena`](#read_enaaccession-resultread_run-fields) - EBI/ENA metadata queries
 - [`read_ena_attributes`](#read_ena_attributesaccession) - EBI/ENA custom sample attributes
+- [`ena_searchable_fields`](#ena_searchable_fieldsresult_type) - Enumerate ENA structured-search fields per result type
 - [`read_ena_sequences`](#read_ena_sequencesaccession-include_filepathfalse-qual_offset33) - Stream FASTA/FASTQ from EBI/ENA with accession columns
 - [`read_jplace`](#read_jplacepath) - Phylogenetic placement files
 - [`read_jplace_newick`](#read_jplace_newickpath-include_filepathfalse) - Newick tree from jplace files
@@ -962,6 +963,37 @@ SELECT sample_accession,
        MAX(CASE WHEN tag = 'geographic location (country and/or sea)' THEN value END) AS country
 FROM read_ena_attributes('PRJEB11419')
 GROUP BY sample_accession;
+```
+
+## `ena_searchable_fields(result_type)`
+
+Enumerate the fields that ENA's Portal API `/search?result=<result_type>` endpoint accepts as structured filters. Use this to discover what field names are available for a given result type (sample, read_run, study, experiment, etc.) before constructing a query — either a direct Portal API `/search` URL or a `WHERE tag='X'` filter on `read_ena_attributes` that can be pushed down to the structured search.
+
+**Requirements:**
+- Requires the `httpfs` extension (automatically loaded)
+- Network access to EBI servers (www.ebi.ac.uk)
+
+**Parameters:**
+- `result_type` (VARCHAR, required): An ENA Portal API result type (e.g., `'sample'`, `'read_run'`, `'study'`, `'experiment'`)
+
+**Output schema:**
+- `field_name` (VARCHAR): Canonical field identifier accepted by ENA's `/search?fields=...` query parameter
+- `type` (VARCHAR): ENA's declared type for the field (e.g., `text`, `number`, `date`, `controlled value`, `taxonomy`)
+- `description` (VARCHAR, nullable): ENA's human-readable description, when available
+
+**Behavior:**
+- Issues exactly one HTTP call to `/returnFields?result=<result_type>&format=tsv` on first use and caches the parsed result for the remainder of the scan
+- Validates `result_type` as alphanumeric + `_-.` to prevent URL injection
+
+**Examples:**
+```sql
+-- All searchable fields for the sample result type
+SELECT field_name, type FROM ena_searchable_fields('sample') ORDER BY field_name;
+
+-- Check whether a specific field exists before using it in a filter
+SELECT COUNT(*) > 0 AS exists
+FROM ena_searchable_fields('sample')
+WHERE field_name = 'host_body_site';
 ```
 
 ## `read_ena_sequences(accession, [include_filepath=false], [qual_offset=33])`

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -36,6 +36,15 @@ if command -v ascp &> /dev/null; then
     export ASPERA_AVAILABLE=1
 fi
 
+# ENA network reachability. Probes the Portal API with a cheap HEAD-ish call
+# so tests that need live ENA access can skip gracefully in offline CI.
+# Timeout is tight (3s) to avoid slowing down the common case.
+if curl -sSf --max-time 3 -o /dev/null \
+        "https://www.ebi.ac.uk/ena/portal/api/search?result=read_run&query=run_accession%3D%22ERR1074767%22&fields=run_accession&limit=1&format=tsv" \
+        2>/dev/null; then
+    export ENA_AVAILABLE=1
+fi
+
 if conda run -n massql python3 -c "from massql import msql_engine" 2>/dev/null; then
     export MASSQL_PYTHON_AVAILABLE=1
 fi

--- a/src/ena_attributes_filter.cpp
+++ b/src/ena_attributes_filter.cpp
@@ -1,0 +1,389 @@
+#include "ena_attributes_filter.hpp"
+
+#include "ena_search_field_registry.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace miint {
+
+// ---- ENAFilterNode factories ----
+
+std::unique_ptr<ENAFilterNode> ENAFilterNode::MakeEqual(const std::string &column, const std::string &value) {
+	auto node = std::make_unique<ENAFilterNode>();
+	node->kind = Kind::EQUAL;
+	node->column = column;
+	node->values = {value};
+	return node;
+}
+
+std::unique_ptr<ENAFilterNode> ENAFilterNode::MakeIn(const std::string &column,
+                                                     const std::vector<std::string> &values) {
+	auto node = std::make_unique<ENAFilterNode>();
+	node->kind = Kind::IN;
+	node->column = column;
+	node->values = values;
+	return node;
+}
+
+std::unique_ptr<ENAFilterNode> ENAFilterNode::MakeAnd(std::vector<std::unique_ptr<ENAFilterNode>> children) {
+	auto node = std::make_unique<ENAFilterNode>();
+	node->kind = Kind::AND_CONJUNCTION;
+	node->children = std::move(children);
+	return node;
+}
+
+std::unique_ptr<ENAFilterNode> ENAFilterNode::MakeOr(std::vector<std::unique_ptr<ENAFilterNode>> children) {
+	auto node = std::make_unique<ENAFilterNode>();
+	node->kind = Kind::OR_CONJUNCTION;
+	node->children = std::move(children);
+	return node;
+}
+
+std::unique_ptr<ENAFilterNode> ENAFilterNode::MakeUnsupported() {
+	auto node = std::make_unique<ENAFilterNode>();
+	node->kind = Kind::UNSUPPORTED;
+	return node;
+}
+
+// ---- Extractor ----
+
+namespace {
+
+std::string ToLower(std::string s) {
+	for (auto &c : s) {
+		c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+	}
+	return s;
+}
+
+// Per-conjunct analysis result. Short-circuit flag (`reject`) lets the caller
+// abort the whole pushdown on the first unsupported atom.
+struct AtomResult {
+	bool reject = false;
+	bool is_tag_eq = false;
+	bool is_tag_in = false;
+	bool is_value_eq = false;
+	std::string tag_value;               // for is_tag_eq
+	std::vector<std::string> tag_values; // for is_tag_in (canonicalized)
+	std::string pinned_value;            // for is_value_eq
+};
+
+AtomResult AnalyzeAtom(const ENAFilterNode &node) {
+	AtomResult r;
+	switch (node.kind) {
+	case ENAFilterNode::Kind::EQUAL: {
+		if (node.values.size() != 1) {
+			r.reject = true;
+			return r;
+		}
+		auto col = ToLower(node.column);
+		if (col == "tag") {
+			auto canonical = ToLower(node.values[0]);
+			if (!ENASearchFieldRegistry::IsSearchableSampleField(canonical)) {
+				r.reject = true;
+				return r;
+			}
+			r.is_tag_eq = true;
+			r.tag_value = canonical;
+			return r;
+		}
+		if (col == "value") {
+			r.is_value_eq = true;
+			r.pinned_value = node.values[0];
+			return r;
+		}
+		// Predicate on any other column (e.g., sample_accession) — can't
+		// cleanly translate; reject per plan's safety policy.
+		r.reject = true;
+		return r;
+	}
+	case ENAFilterNode::Kind::IN: {
+		auto col = ToLower(node.column);
+		if (col != "tag") {
+			// Only `tag IN (...)` is supported. `value IN (...)` without a
+			// pinned tag is ambiguous; any other column is out of scope.
+			r.reject = true;
+			return r;
+		}
+		if (node.values.empty()) {
+			r.reject = true;
+			return r;
+		}
+		for (const auto &v : node.values) {
+			auto canonical = ToLower(v);
+			if (!ENASearchFieldRegistry::IsSearchableSampleField(canonical)) {
+				r.reject = true;
+				return r;
+			}
+			r.tag_values.push_back(canonical);
+		}
+		r.is_tag_in = true;
+		return r;
+	}
+	case ENAFilterNode::Kind::AND_CONJUNCTION:
+	case ENAFilterNode::Kind::OR_CONJUNCTION:
+	case ENAFilterNode::Kind::UNSUPPORTED:
+		// OR / nested AND / unrecognized — out of scope for the strict
+		// extractor. DuckDB pre-splits top-level AND into conjuncts, so a
+		// remaining AND node here would be inside an OR or similar construct
+		// we've already chosen not to decompose.
+		r.reject = true;
+		return r;
+	}
+	r.reject = true;
+	return r;
+}
+
+} // namespace
+
+ENAAttributePushdown ExtractPushdownPredicates(const std::vector<std::unique_ptr<ENAFilterNode>> &conjuncts) {
+	ENAAttributePushdown empty; // signal for fallback
+
+	if (conjuncts.empty()) {
+		return empty;
+	}
+
+	std::vector<std::string> tag_atoms_eq;              // from EQUAL on tag
+	std::vector<std::vector<std::string>> tag_atoms_in; // from IN on tag
+	std::vector<std::string> value_atoms_eq;            // from EQUAL on value
+
+	for (const auto &node : conjuncts) {
+		if (!node) {
+			return empty;
+		}
+		auto atom = AnalyzeAtom(*node);
+		if (atom.reject) {
+			return empty;
+		}
+		if (atom.is_tag_eq) {
+			tag_atoms_eq.push_back(std::move(atom.tag_value));
+		} else if (atom.is_tag_in) {
+			tag_atoms_in.push_back(std::move(atom.tag_values));
+		} else if (atom.is_value_eq) {
+			value_atoms_eq.push_back(std::move(atom.pinned_value));
+		}
+	}
+
+	// A pinned `value` predicate only makes sense alongside a single-tag pin.
+	// If no tag pin exists, the value is ambiguous — fallback.
+	if (!value_atoms_eq.empty() && tag_atoms_eq.empty()) {
+		return empty;
+	}
+	// Conjoined `tag=X AND tag=Y` would require both — impossible since one
+	// row has one tag. Treat as fallback rather than silently returning zero.
+	if (tag_atoms_eq.size() > 1) {
+		return empty;
+	}
+	// `tag=X AND tag IN (...)` is expressible but semantically odd; fall back
+	// for safety rather than tangling the query shape.
+	if (!tag_atoms_eq.empty() && !tag_atoms_in.empty()) {
+		return empty;
+	}
+	// Multiple `tag IN (...)` conjuncts: the SQL semantics is an intersection
+	// (a row must satisfy EVERY IN list simultaneously), but collecting the
+	// union of tags here would broaden the wire query sent to ENA. Rather
+	// than emit a semantically wider URL and rely on DuckDB's re-applied
+	// filter to trim, fall back. Matches the extractor's "strict or nothing"
+	// personality: the structured path runs only when we can prove
+	// equivalence.
+	if (tag_atoms_in.size() > 1) {
+		return empty;
+	}
+
+	// Collect deduplicated canonical tags in first-seen order.
+	ENAAttributePushdown out;
+	std::unordered_set<std::string> seen;
+
+	auto push_tag = [&](const std::string &t) {
+		if (seen.insert(t).second) {
+			out.tags.push_back(t);
+		}
+	};
+
+	for (const auto &t : tag_atoms_eq) {
+		push_tag(t);
+	}
+	for (const auto &tag_list : tag_atoms_in) {
+		for (const auto &t : tag_list) {
+			push_tag(t);
+		}
+	}
+
+	if (out.tags.empty()) {
+		return empty;
+	}
+
+	// Attach pinned values. Only tag_atoms_eq contributes a (tag, value) pair
+	// (we already rejected value-without-tag-eq above).
+	//
+	// When there are multiple `value=` conjuncts on the same pinned tag
+	// (e.g. `tag='X' AND value='Y1' AND value='Y2'`), ENA's search cannot
+	// conjoin equality on the same field in one query. We INTENTIONALLY
+	// emit only `value_atoms_eq[0]` to the wire and DROP value_atoms_eq[1..n].
+	// This is safe only because plan decision #5 is honored: we never prune
+	// entries from the original `filters` vector, so DuckDB re-applies ALL
+	// value= predicates as a LogicalFilter above the scan. Any future refactor
+	// that starts pruning filters would need to revisit this branch — at that
+	// point the correct fix is to fall back to XML when value_atoms_eq.size()
+	// > 1, not to silently drop constraints.
+	if (!tag_atoms_eq.empty() && !value_atoms_eq.empty()) {
+		out.tag_value_pairs.emplace_back(tag_atoms_eq[0], value_atoms_eq[0]);
+	}
+
+	return out;
+}
+
+// ---- URL builder ----
+
+namespace {
+
+// Percent-encode a string for use in a `query=` value. The ENA search endpoint
+// is tolerant of unescaped values that match its validation regex, but any
+// user-supplied value may contain spaces, colons, commas, etc. We encode
+// conservatively: anything outside [A-Za-z0-9_.~-] becomes `%XX`.
+std::string PercentEncodeValue(const std::string &s) {
+	static const char *kHex = "0123456789ABCDEF";
+	std::string out;
+	out.reserve(s.size());
+	for (unsigned char c : s) {
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_' || c == '.' ||
+		    c == '~' || c == '-') {
+			out.push_back(static_cast<char>(c));
+		} else {
+			out.push_back('%');
+			out.push_back(kHex[c >> 4]);
+			out.push_back(kHex[c & 0xF]);
+		}
+	}
+	return out;
+}
+
+} // namespace
+
+std::string BuildStructuredSearchURL(const std::vector<std::string> &sample_accessions,
+                                     const std::vector<std::string> &tags,
+                                     const std::vector<std::pair<std::string, std::string>> &tag_value_pairs) {
+	if (sample_accessions.empty()) {
+		throw std::invalid_argument("BuildStructuredSearchURL: sample_accessions must not be empty");
+	}
+	if (tags.empty()) {
+		throw std::invalid_argument("BuildStructuredSearchURL: tags must not be empty");
+	}
+	for (const auto &acc : sample_accessions) {
+		ENAParser::ValidateAccession(acc);
+	}
+	for (const auto &t : tags) {
+		ENAParser::ValidateFields(t);
+	}
+
+	// Build `fields=sample_accession,<tag1>,<tag2>,...` (deduped, preserving
+	// caller order). `sample_accession` is always first so the row emitter
+	// can locate it unambiguously.
+	std::ostringstream fields;
+	fields << "sample_accession";
+	std::unordered_set<std::string> seen_fields = {"sample_accession"};
+	for (const auto &t : tags) {
+		if (seen_fields.insert(t).second) {
+			fields << "," << t;
+		}
+	}
+
+	// Build the query: `sample_accession IN ("a","b",...) [AND tag="v"]*`
+	// URL-encoded the same way ENAParser::BuildSearchURLBatch does, extended
+	// with tag=value conjuncts.
+	std::ostringstream query;
+	query << "sample_accession%20IN%20%28";
+	for (size_t i = 0; i < sample_accessions.size(); i++) {
+		if (i > 0) {
+			query << "%2C";
+		}
+		query << "%22" << sample_accessions[i] << "%22";
+	}
+	query << "%29";
+	for (const auto &kv : tag_value_pairs) {
+		// Precondition: every pinned tag must appear in `tags` so the
+		// response contains a column to un-pivot. Callers that hand-build
+		// a pushdown (rather than going through ExtractPushdownPredicates)
+		// can violate this; reject early so we never emit a query clause
+		// for a field we didn't ask ENA to return.
+		if (seen_fields.count(kv.first) == 0) {
+			throw std::invalid_argument("BuildStructuredSearchURL: pinned tag '" + kv.first +
+			                            "' is not present in `tags`");
+		}
+		// Validated upstream (tag via ValidateFields; value via PercentEncodeValue).
+		ENAParser::ValidateFields(kv.first);
+		query << "%20AND%20" << kv.first << "%3D%22" << PercentEncodeValue(kv.second) << "%22";
+	}
+
+	std::ostringstream url;
+	url << ENAParser::PORTAL_BASE << "/search?"
+	    << "result=sample&query=" << query.str() << "&fields=" << fields.str() << "&limit=0&format=tsv";
+	return url.str();
+}
+
+// ---- TSV unpivot ----
+
+std::vector<SampleAttribute> UnpivotStructuredTSV(const ENATSVResult &parsed,
+                                                  const std::vector<std::string> &requested_tags) {
+	std::vector<SampleAttribute> out;
+	if (parsed.rows.empty() || parsed.column_names.empty() || requested_tags.empty()) {
+		return out;
+	}
+
+	// Locate sample_accession + each requested tag's column index
+	// (case-insensitive match; ENA returns lowercase but be defensive).
+	auto find_col = [&](const std::string &target) -> int {
+		auto canonical = ToLower(target);
+		for (size_t i = 0; i < parsed.column_names.size(); i++) {
+			if (ToLower(parsed.column_names[i]) == canonical) {
+				return static_cast<int>(i);
+			}
+		}
+		return -1;
+	};
+
+	int acc_idx = find_col("sample_accession");
+	if (acc_idx < 0) {
+		// No sample_accession column — we can't attribute any row. Return
+		// empty and let the caller decide (in practice this is a malformed
+		// response and the caller will log/fail).
+		return out;
+	}
+
+	std::vector<std::pair<std::string, int>> tag_cols;
+	tag_cols.reserve(requested_tags.size());
+	for (const auto &t : requested_tags) {
+		tag_cols.emplace_back(t, find_col(t));
+	}
+
+	for (const auto &row : parsed.rows) {
+		if (static_cast<size_t>(acc_idx) >= row.size()) {
+			continue;
+		}
+		const auto &acc = row[acc_idx];
+		if (acc.empty()) {
+			continue;
+		}
+		for (const auto &tc : tag_cols) {
+			if (tc.second < 0) {
+				continue; // column absent from response
+			}
+			if (static_cast<size_t>(tc.second) >= row.size()) {
+				continue;
+			}
+			const auto &val = row[tc.second];
+			if (val.empty()) {
+				continue; // matches XML path: absent attributes produce no row
+			}
+			out.push_back(SampleAttribute {acc, tc.first, val});
+		}
+	}
+
+	return out;
+}
+
+} // namespace miint

--- a/src/ena_client.cpp
+++ b/src/ena_client.cpp
@@ -9,14 +9,21 @@ ENAClient::ENAClient(duckdb::DatabaseInstance &db)
 }
 
 void ENAClient::RespectRateLimit() {
-	std::lock_guard<std::mutex> lock(rate_limit_mutex);
-	auto now = std::chrono::steady_clock::now();
-	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_request_time);
-	auto min_interval = std::chrono::milliseconds(static_cast<int>(1000.0 / RATE_LIMIT));
-	if (elapsed < min_interval) {
-		std::this_thread::sleep_for(min_interval - elapsed);
+	// Reserve the next request slot under the lock, then sleep outside it.
+	// Sleeping under the lock would serialize every caller behind one thread's
+	// sleep and risks UB on recursive acquisition (std::mutex is non-recursive).
+	const auto min_interval = std::chrono::milliseconds(static_cast<int>(1000.0 / RATE_LIMIT));
+	std::chrono::steady_clock::time_point slot;
+	{
+		std::lock_guard<std::mutex> lock(rate_limit_mutex);
+		auto earliest_next = last_request_time + min_interval;
+		auto now = std::chrono::steady_clock::now();
+		slot = (earliest_next > now) ? earliest_next : now;
+		last_request_time = slot;
 	}
-	last_request_time = std::chrono::steady_clock::now();
+	if (slot > std::chrono::steady_clock::now()) {
+		std::this_thread::sleep_until(slot);
+	}
 }
 
 bool ENAClient::IsRetryableStatus(int status) {
@@ -64,6 +71,10 @@ std::string ENAClient::Search(const std::string &accession, const std::string &r
 
 std::string ENAClient::FetchXML(const std::vector<std::string> &accessions) {
 	auto url = ENAParser::BuildXMLURL(accessions);
+	return MakeRequest(url);
+}
+
+std::string ENAClient::FetchURL(const std::string &url) {
 	return MakeRequest(url);
 }
 

--- a/src/ena_parser.cpp
+++ b/src/ena_parser.cpp
@@ -88,6 +88,36 @@ std::string ENAParser::BuildSearchURL(const std::string &accession, const std::s
 	return url.str();
 }
 
+std::string ENAParser::BuildSearchURLBatch(const std::vector<std::string> &accessions, ENAAccessionType accession_type,
+                                           const std::string &result_type, const std::string &fields) {
+	if (accessions.empty()) {
+		throw std::invalid_argument("BuildSearchURLBatch: accessions vector must not be empty");
+	}
+	if (accession_type == ENAAccessionType::UNKNOWN) {
+		throw std::invalid_argument("BuildSearchURLBatch: cannot build a batched query for UNKNOWN accession type");
+	}
+	for (const auto &acc : accessions) {
+		ValidateAccession(acc);
+	}
+	ValidateFields(fields);
+
+	auto query_param = QueryParamForAccessionType(accession_type);
+
+	// URL-encoded form of: <query_param> IN ("acc1","acc2",...)
+	//   space = %20   ( = %28   ) = %29   , = %2C   " = %22
+	std::ostringstream url;
+	url << PORTAL_BASE << "/search?"
+	    << "result=" << result_type << "&query=" << query_param << "%20IN%20%28";
+	for (size_t i = 0; i < accessions.size(); i++) {
+		if (i > 0) {
+			url << "%2C";
+		}
+		url << "%22" << accessions[i] << "%22";
+	}
+	url << "%29&fields=" << fields << "&limit=0&format=tsv";
+	return url.str();
+}
+
 std::string ENAParser::BuildXMLURL(const std::vector<std::string> &accessions) {
 	for (const auto &acc : accessions) {
 		ValidateAccession(acc);

--- a/src/ena_resolver_cache.cpp
+++ b/src/ena_resolver_cache.cpp
@@ -1,0 +1,205 @@
+#include "ena_resolver_cache.hpp"
+#include "ena_parser.hpp"
+#include <algorithm>
+#include <stdexcept>
+#include <unordered_set>
+
+namespace miint {
+
+ENAResolverCache::ENAResolverCache(size_t capacity_p) : capacity(capacity_p) {
+}
+
+bool ENAResolverCache::Get(const Key &key, std::vector<ENARunInfo> &out) {
+	if (capacity == 0) {
+		return false;
+	}
+	std::lock_guard<std::mutex> lock(m);
+	auto it = map.find(key);
+	if (it == map.end()) {
+		return false;
+	}
+	// Bump to MRU
+	order.erase(it->second.second);
+	order.push_front(key);
+	it->second.second = order.begin();
+	out = it->second.first;
+	return true;
+}
+
+void ENAResolverCache::Put(const Key &key, std::vector<ENARunInfo> value) {
+	if (capacity == 0) {
+		return;
+	}
+	std::lock_guard<std::mutex> lock(m);
+	auto it = map.find(key);
+	if (it != map.end()) {
+		// Replace existing value; bump to MRU
+		order.erase(it->second.second);
+		order.push_front(key);
+		it->second.first = std::move(value);
+		it->second.second = order.begin();
+		return;
+	}
+	// Evict LRU if at capacity
+	if (map.size() >= capacity) {
+		const auto &evict_key = order.back();
+		map.erase(evict_key);
+		order.pop_back();
+	}
+	order.push_front(key);
+	map.emplace(key, std::make_pair(std::move(value), order.begin()));
+}
+
+size_t ENAResolverCache::Size() {
+	std::lock_guard<std::mutex> lock(m);
+	return map.size();
+}
+
+// ---- ResolveRunsBatch ----
+
+// Field list we request from ENA for every batched read_run query.
+// Includes run_accession plus all other columns ENARunInfoExtractor consumes, plus
+// study_accession so callers can tell which input accession a returned row belongs to
+// when querying by study.
+static constexpr const char *BATCH_FIELDS = "run_accession,sample_accession,experiment_accession,study_accession,"
+                                            "fastq_ftp,fastq_aspera,fastq_bytes,library_layout,"
+                                            "submitted_ftp,submitted_aspera,submitted_bytes,submitted_format";
+
+// Column name on a returned TSV row that matches the input accession for a given type.
+// STUDY-typed inputs are matched against the row's study_accession, etc.
+static int GroupingColumn(ENAAccessionType type, const ENAColumnIndexMap &cols) {
+	switch (type) {
+	case ENAAccessionType::STUDY:
+		return cols.study_accession;
+	case ENAAccessionType::SAMPLE:
+		return cols.sample_accession;
+	case ENAAccessionType::RUN:
+		return cols.run_accession;
+	case ENAAccessionType::EXPERIMENT:
+		return cols.experiment_accession;
+	default:
+		return -1;
+	}
+}
+
+// Fetch + parse + group one batch of accessions of the same type. Returns a map keyed
+// by the input accession (matched against the TSV row's grouping column).
+static std::unordered_map<std::string, std::vector<ENARunInfo>> FetchBatch(const ENAFetcher &fetcher,
+                                                                           const std::vector<std::string> &batch,
+                                                                           ENAAccessionType type,
+                                                                           const std::string &prefer_format) {
+	std::unordered_map<std::string, std::vector<ENARunInfo>> out;
+	for (const auto &acc : batch) {
+		out[acc]; // ensure every input accession appears, even if no rows match
+	}
+
+	auto url = ENAParser::BuildSearchURLBatch(batch, type, "read_run", BATCH_FIELDS);
+	auto tsv = fetcher(url);
+	auto parsed = ENAParser::ParseTSV(tsv);
+	if (parsed.column_names.empty()) {
+		// Header-only (or truly empty) TSV — nothing to group. Leave the pre-populated empty
+		// entries in place so callers negative-cache every requested accession.
+		return out;
+	}
+	auto cols = ENAColumnIndexMap::FromHeader(parsed.column_names);
+	int group_col = GroupingColumn(type, cols);
+	if (group_col < 0) {
+		throw std::runtime_error("ENA batched response is missing the expected grouping column for the requested "
+		                         "accession type (unexpected API response or server error)");
+	}
+
+	for (const auto &row : parsed.rows) {
+		auto row_runs = ENARunInfoExtractor::FromTSVRow(row, cols, prefer_format);
+		if (row_runs.empty()) {
+			continue;
+		}
+		std::string grouping_key = ENAColumnIndexMap::Get(row, group_col);
+		if (grouping_key.empty()) {
+			continue;
+		}
+		auto it = out.find(grouping_key);
+		if (it == out.end()) {
+			// Row's grouping key doesn't match any requested accession (unexpected ENA
+			// response). Skip silently — do NOT cache under an unrequested key, since
+			// that would consume a cache slot and could create a false-positive hit in
+			// a future query for that accession.
+			continue;
+		}
+		for (auto &info : row_runs) {
+			it->second.push_back(std::move(info));
+		}
+	}
+	return out;
+}
+
+std::unordered_map<std::string, std::vector<ENARunInfo>>
+ResolveRunsBatch(const ENAFetcher &fetcher, ENAResolverCache &cache, const std::vector<std::string> &accessions,
+                 const std::string &prefer_format, size_t max_batch_size) {
+	std::unordered_map<std::string, std::vector<ENARunInfo>> result;
+	if (max_batch_size == 0) {
+		max_batch_size = 1;
+	}
+
+	// Preserve input order for callers that care, while deduping.
+	std::unordered_set<std::string> seen;
+	std::vector<std::string> unique_inputs;
+	unique_inputs.reserve(accessions.size());
+	for (const auto &acc : accessions) {
+		if (seen.insert(acc).second) {
+			unique_inputs.push_back(acc);
+		}
+	}
+
+	// Step 1: serve cache hits; bucket misses by accession type.
+	std::unordered_map<ENAAccessionType, std::vector<std::string>> by_type;
+	for (const auto &acc : unique_inputs) {
+		ENAResolverCache::Key key {acc, prefer_format};
+		std::vector<ENARunInfo> cached;
+		if (cache.Get(key, cached)) {
+			result[acc] = std::move(cached);
+			continue;
+		}
+		by_type[ENAParser::DetectAccessionType(acc)].push_back(acc);
+	}
+
+	// Step 2: fetch typed groups in batches.
+	for (auto &kv : by_type) {
+		if (kv.first == ENAAccessionType::UNKNOWN) {
+			// UNKNOWN type: we cannot build a compound query (no known column). Fall back to
+			// per-accession single-URL fetches.
+			for (const auto &acc : kv.second) {
+				auto url = ENAParser::BuildSearchURL(acc, "read_run", BATCH_FIELDS);
+				auto tsv = fetcher(url);
+				auto parsed = ENAParser::ParseTSV(tsv);
+				auto cols = ENAColumnIndexMap::FromHeader(parsed.column_names);
+				std::vector<ENARunInfo> acc_runs;
+				for (const auto &row : parsed.rows) {
+					auto row_runs = ENARunInfoExtractor::FromTSVRow(row, cols, prefer_format);
+					for (auto &info : row_runs) {
+						acc_runs.push_back(std::move(info));
+					}
+				}
+				cache.Put({acc, prefer_format}, acc_runs);
+				result[acc] = std::move(acc_runs);
+			}
+			continue;
+		}
+
+		const auto &all = kv.second;
+		for (size_t start = 0; start < all.size(); start += max_batch_size) {
+			size_t end = std::min(start + max_batch_size, all.size());
+			std::vector<std::string> batch(all.begin() + start, all.begin() + end);
+			auto batch_result = FetchBatch(fetcher, batch, kv.first, prefer_format);
+			for (const auto &acc : batch) {
+				auto it = batch_result.find(acc);
+				auto runs = (it == batch_result.end()) ? std::vector<ENARunInfo> {} : std::move(it->second);
+				cache.Put({acc, prefer_format}, runs); // negative cache when runs is empty
+				result[acc] = std::move(runs);
+			}
+		}
+	}
+
+	return result;
+}
+
+} // namespace miint

--- a/src/ena_run_info_extractor.cpp
+++ b/src/ena_run_info_extractor.cpp
@@ -1,0 +1,172 @@
+#include "ena_run_info_extractor.hpp"
+
+namespace miint {
+
+ENAColumnIndexMap ENAColumnIndexMap::FromHeader(const std::vector<std::string> &header) {
+	ENAColumnIndexMap cols;
+	for (size_t i = 0; i < header.size(); i++) {
+		const auto &name = header[i];
+		auto idx = static_cast<int>(i);
+		if (name == "run_accession") {
+			cols.run_accession = idx;
+		} else if (name == "sample_accession") {
+			cols.sample_accession = idx;
+		} else if (name == "experiment_accession") {
+			cols.experiment_accession = idx;
+		} else if (name == "study_accession") {
+			cols.study_accession = idx;
+		} else if (name == "fastq_ftp") {
+			cols.fastq_ftp = idx;
+		} else if (name == "fastq_aspera") {
+			cols.fastq_aspera = idx;
+		} else if (name == "fastq_bytes") {
+			cols.fastq_bytes = idx;
+		} else if (name == "library_layout") {
+			cols.library_layout = idx;
+		} else if (name == "submitted_ftp") {
+			cols.submitted_ftp = idx;
+		} else if (name == "submitted_aspera") {
+			cols.submitted_aspera = idx;
+		} else if (name == "submitted_bytes") {
+			cols.submitted_bytes = idx;
+		} else if (name == "submitted_format") {
+			cols.submitted_format = idx;
+		}
+	}
+	return cols;
+}
+
+std::string ENAColumnIndexMap::Get(const std::vector<std::string> &row, int col) {
+	if (col < 0 || col >= static_cast<int>(row.size())) {
+		return "";
+	}
+	return row[col];
+}
+
+static std::vector<uint64_t> ParseBytesField(const std::string &bytes_field) {
+	std::vector<uint64_t> out;
+	if (bytes_field.empty()) {
+		return out;
+	}
+	std::string::size_type start = 0;
+	while (true) {
+		auto semi = bytes_field.find(';', start);
+		std::string token =
+		    (semi == std::string::npos) ? bytes_field.substr(start) : bytes_field.substr(start, semi - start);
+		try {
+			out.push_back(std::stoull(token));
+		} catch (...) {
+			out.push_back(0);
+		}
+		if (semi == std::string::npos) {
+			break;
+		}
+		start = semi + 1;
+	}
+	return out;
+}
+
+std::vector<ENARunInfo> ENARunInfoExtractor::FromTSVRow(const std::vector<std::string> &row,
+                                                        const ENAColumnIndexMap &cols,
+                                                        const std::string &prefer_format) {
+	std::vector<ENARunInfo> out;
+
+	const std::string run_accession = ENAColumnIndexMap::Get(row, cols.run_accession);
+	const std::string sample_accession = ENAColumnIndexMap::Get(row, cols.sample_accession);
+	const std::string experiment_accession = ENAColumnIndexMap::Get(row, cols.experiment_accession);
+	const std::string ftp_field = ENAColumnIndexMap::Get(row, cols.fastq_ftp);
+	const std::string aspera_field = ENAColumnIndexMap::Get(row, cols.fastq_aspera);
+	const std::string bytes_field = ENAColumnIndexMap::Get(row, cols.fastq_bytes);
+	const std::string layout = ENAColumnIndexMap::Get(row, cols.library_layout);
+	const std::string sub_ftp = ENAColumnIndexMap::Get(row, cols.submitted_ftp);
+	const std::string sub_aspera = ENAColumnIndexMap::Get(row, cols.submitted_aspera);
+	const std::string sub_bytes = ENAColumnIndexMap::Get(row, cols.submitted_bytes);
+	const std::string sub_format = ENAColumnIndexMap::Get(row, cols.submitted_format);
+
+	auto fastq_urls = ENAParser::FTPtoHTTPS(ftp_field);
+	const bool has_fastq = !fastq_urls.empty();
+
+	auto sff_filter = ENAParser::FilterSubmittedByFormat(sub_ftp, sub_aspera, sub_format, sub_bytes, "SFF");
+	const bool has_sff = !sff_filter.urls.empty();
+
+	bool use_sff = false;
+	if (prefer_format == "sff") {
+		use_sff = has_sff;
+	} else if (prefer_format == "auto") {
+		use_sff = !has_fastq && has_sff;
+	}
+	// prefer_format == "fastq" → use_sff stays false, and if no FASTQ we skip the row entirely
+
+	if (use_sff) {
+		// Flatten: one RunInfo per SFF file. use_sff is only set when has_sff is true,
+		// so sff_filter.urls is guaranteed non-empty here.
+		const uint64_t per_file_bytes = sff_filter.total_bytes / sff_filter.urls.size();
+		for (const auto &url : sff_filter.urls) {
+			ENARunInfo info;
+			info.run_accession = run_accession;
+			info.sample_accession = sample_accession;
+			info.experiment_accession = experiment_accession;
+			info.format = ENASequenceFormat::SFF;
+			info.sff_url = url;
+			info.is_paired = false;
+			info.total_bytes = per_file_bytes;
+			out.push_back(std::move(info));
+		}
+		return out;
+	}
+
+	if (!has_fastq) {
+		return out; // prefer_format='fastq' with no FASTQ, or no formats at all
+	}
+
+	ENARunInfo info;
+	info.run_accession = run_accession;
+	info.sample_accession = sample_accession;
+	info.experiment_accession = experiment_accession;
+	info.fastq_urls = std::move(fastq_urls);
+	info.aspera_paths = AsperaUtils::ParseAsperaPaths(aspera_field);
+	info.is_paired = (layout == "PAIRED");
+
+	auto file_bytes = ParseBytesField(bytes_field);
+
+	// ENA 3-file paired-end filtering: drop the non-_1/_2 file when present
+	if (info.is_paired && info.fastq_urls.size() > 2) {
+		std::vector<std::string> filtered;
+		std::vector<uint64_t> filtered_bytes;
+		for (size_t fi = 0; fi < info.fastq_urls.size(); fi++) {
+			const auto &url = info.fastq_urls[fi];
+			if (url.find("_1.fast") != std::string::npos || url.find("_2.fast") != std::string::npos) {
+				filtered.push_back(url);
+				if (fi < file_bytes.size()) {
+					filtered_bytes.push_back(file_bytes[fi]);
+				}
+			}
+		}
+		if (filtered.size() == 2) {
+			info.fastq_urls = std::move(filtered);
+			file_bytes = std::move(filtered_bytes);
+		}
+	}
+	if (info.is_paired && info.aspera_paths.size() > 2) {
+		std::vector<AsperaPath> filtered;
+		for (const auto &ap : info.aspera_paths) {
+			if (ap.remote_path.find("_1.fast") != std::string::npos ||
+			    ap.remote_path.find("_2.fast") != std::string::npos) {
+				filtered.push_back(ap);
+			}
+		}
+		if (filtered.size() == 2) {
+			info.aspera_paths = std::move(filtered);
+		}
+	}
+
+	info.total_bytes = 0;
+	for (auto b : file_bytes) {
+		info.total_bytes += b;
+	}
+
+	out.push_back(std::move(info));
+	return out;
+}
+
+} // namespace miint

--- a/src/ena_search_field_registry.cpp
+++ b/src/ena_search_field_registry.cpp
@@ -1,0 +1,129 @@
+#include "ena_search_field_registry.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace miint {
+
+// Curated from ENA Portal API /returnFields?result=sample on 2026-04-23.
+// Subset chosen to cover the microbiome-analysis sample metadata that users
+// of read_ena_attributes typically filter on (geography, taxonomy, host,
+// environment, sampling context, physical properties, strain info).
+//
+// REGENERATION
+// ------------
+// 1. List the live field set:
+//      SELECT field_name FROM ena_searchable_fields('sample') ORDER BY field_name;
+// 2. Cross-reference with the plan's curation criteria in
+//    localdocs/PLAN-ena-predicate-maxseqs.md (decision #8): keep only fields
+//    useful for microbiome analysis (host_*, environment_*, collection_date,
+//    country, lat, lon, depth, tax_id, scientific_name, sample_alias,
+//    description, sampling_site, isolation_source, and related).
+// 3. Preserve all entries already present here that still exist upstream —
+//    removing one silently breaks user queries that pushed down successfully.
+// 4. Paste the new lowercase names into the set below, update the date in
+//    this comment, and bump any tests that enumerate the set size.
+//
+// Note: read_run / experiment / study field sets will get their own registries
+// when pushdown is extended to other result types.
+static const std::set<std::string> kSampleFields = {
+    // Sample identifiers
+    "sample_accession",
+    "secondary_sample_accession",
+    "sample_alias",
+    "sample_title",
+    "sample_description",
+    "description",
+    // Taxonomy
+    "scientific_name",
+    "tax_id",
+    "tax_lineage",
+    "target_gene",
+    // Time
+    "collection_date",
+    "collection_date_start",
+    "collection_date_end",
+    "first_public",
+    "last_updated",
+    // Geography
+    "country",
+    "lat",
+    "lon",
+    "depth",
+    "altitude",
+    "elevation",
+    // Environment (MIxS-style)
+    "environment_biome",
+    "environment_feature",
+    "environment_material",
+    "environmental_medium",
+    "environmental_sample",
+    "broad_scale_environmental_context",
+    "local_environmental_context",
+    // Host
+    "host",
+    "host_body_site",
+    "host_scientific_name",
+    "host_tax_id",
+    "host_sex",
+    "host_status",
+    "host_phenotype",
+    "host_genotype",
+    // Sampling context
+    "isolation_source",
+    "sampling_site",
+    "sampling_platform",
+    "sampling_campaign",
+    "collected_by",
+    "identified_by",
+    // Project / study linkage
+    "project_name",
+    "study_accession",
+    "center_name",
+    "broker_name",
+    "investigation_type",
+    "checklist",
+    // Strain / variety
+    "strain",
+    "sub_species",
+    "sub_strain",
+    "cultivar",
+    "ecotype",
+    "serotype",
+    "serovar",
+    // Physical properties
+    "ph",
+    "salinity",
+    "temperature",
+    // Disease / status
+    "disease",
+    "sample_capture_status",
+    // Misc descriptive
+    "keywords",
+};
+
+static std::string CanonicalizeTag(const std::string &tag) {
+	auto first = tag.find_first_not_of(" \t\n\r");
+	if (first == std::string::npos) {
+		return {};
+	}
+	auto last = tag.find_last_not_of(" \t\n\r");
+	std::string trimmed = tag.substr(first, last - first + 1);
+	std::transform(trimmed.begin(), trimmed.end(), trimmed.begin(),
+	               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+	return trimmed;
+}
+
+bool ENASearchFieldRegistry::IsSearchableSampleField(const std::string &tag) {
+	auto canonical = CanonicalizeTag(tag);
+	if (canonical.empty()) {
+		return false;
+	}
+	return kSampleFields.count(canonical) > 0;
+}
+
+const std::set<std::string> &ENASearchFieldRegistry::SearchableSampleFields() {
+	return kSampleFields;
+}
+
+} // namespace miint

--- a/src/include/ena_attributes_filter.hpp
+++ b/src/include/ena_attributes_filter.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "ena_parser.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace miint {
+
+// Abstract filter-tree node used by the `read_ena_attributes` pushdown
+// extractor. Kept abstract (independent of `duckdb::Expression`) so the
+// extractor can be unit-tested without constructing DuckDB bound
+// expressions. The DuckDB→ENAFilterNode translator lives alongside the
+// `pushdown_complex_filter` hook in `read_ena_attributes.cpp`.
+//
+// Policy: the extractor is intentionally strict. Any node that cannot be
+// cleanly translated to an ENA `/search?query=...` predicate — unsupported
+// operator, OR across atoms, non-`tag`/`value` column, tag not in the
+// `ENASearchFieldRegistry` allowlist — forces the whole filter set to fall
+// back to the XML path. The structured path only runs when we can prove it
+// is equivalent to the XML output.
+struct ENAFilterNode {
+	enum class Kind { EQUAL, IN, AND_CONJUNCTION, OR_CONJUNCTION, UNSUPPORTED };
+
+	Kind kind;
+	// For EQUAL / IN: lowercase column name (the translator lowercases).
+	std::string column;
+	// For EQUAL: single value. For IN: one per element. Exact user-typed case
+	// is preserved; canonicalization (e.g., lowercasing `tag` values against
+	// the registry) happens inside ExtractPushdownPredicates.
+	std::vector<std::string> values;
+	// For AND_CONJUNCTION / OR_CONJUNCTION.
+	std::vector<std::unique_ptr<ENAFilterNode>> children;
+
+	static std::unique_ptr<ENAFilterNode> MakeEqual(const std::string &column, const std::string &value);
+	static std::unique_ptr<ENAFilterNode> MakeIn(const std::string &column, const std::vector<std::string> &values);
+	static std::unique_ptr<ENAFilterNode> MakeAnd(std::vector<std::unique_ptr<ENAFilterNode>> children);
+	static std::unique_ptr<ENAFilterNode> MakeOr(std::vector<std::unique_ptr<ENAFilterNode>> children);
+	static std::unique_ptr<ENAFilterNode> MakeUnsupported();
+};
+
+// Result of analyzing a filter conjunction. `tags.empty()` is the signal that
+// pushdown is not possible — the caller should use the XML path.
+//
+// When `tags` is non-empty, every entry is a canonical lowercase ENA sample
+// field name, and every entry of `tag_value_pairs` is `(tag, value)` with
+// `tag` guaranteed to appear in `tags`.
+struct ENAAttributePushdown {
+	std::vector<std::string> tags;
+	std::vector<std::pair<std::string, std::string>> tag_value_pairs;
+};
+
+// Analyze a conjunct list (as would be produced by DuckDB's
+// `pushdown_complex_filter` callback, which pre-splits top-level AND).
+// Returns populated `tags` iff EVERY conjunct is pushable AND every
+// referenced tag passes `ENASearchFieldRegistry::IsSearchableSampleField`.
+// Otherwise returns an empty pushdown (XML fallback).
+ENAAttributePushdown ExtractPushdownPredicates(const std::vector<std::unique_ptr<ENAFilterNode>> &conjuncts);
+
+// Build the ENA `/search?result=sample` URL for a batched sample-accession
+// list plus a pushdown's tag+value constraints. `sample_accessions` must be
+// non-empty. Emits `fields=sample_accession,<tag1>,<tag2>,...` (deduped),
+// and a `query` clause joining the accession IN-filter with any pinned
+// tag=value equality constraints via URL-encoded AND.
+//
+// Preconditions:
+//   - `sample_accessions` non-empty; each entry passes ENAParser::ValidateAccession.
+//   - `tags` non-empty; each entry passes ENAParser::ValidateFields.
+//   - Every `tag_value_pairs[i].first` appears in `tags` (so the returned
+//     TSV has a column to un-pivot against). Violations throw
+//     `std::invalid_argument`.
+//
+// Pure (no HTTP). Kept here so the pushdown path is testable without a
+// network dependency.
+std::string BuildStructuredSearchURL(const std::vector<std::string> &sample_accessions,
+                                     const std::vector<std::string> &tags,
+                                     const std::vector<std::pair<std::string, std::string>> &tag_value_pairs);
+
+// Unpivot a structured-search TSV response into `(sample_accession, tag,
+// value)` tuples — one row per (sample, non-empty requested tag). Expects
+// `parsed` to contain a `sample_accession` column plus one column per entry
+// in `requested_tags` (case-insensitive column match). Missing columns are
+// treated as all-empty (no rows emitted for that tag). Empty cells are
+// skipped (matches the XML path, which omits absent attributes).
+std::vector<SampleAttribute> UnpivotStructuredTSV(const ENATSVResult &parsed,
+                                                  const std::vector<std::string> &requested_tags);
+
+} // namespace miint

--- a/src/include/ena_client.hpp
+++ b/src/include/ena_client.hpp
@@ -21,11 +21,16 @@ public:
 	static constexpr int MAX_RETRIES = 3;
 	static constexpr int INITIAL_RETRY_DELAY_MS = 1000;
 
-	ENAClient(duckdb::DatabaseInstance &db);
+	explicit ENAClient(duckdb::DatabaseInstance &db);
 
 	// HTTP methods — build URL via ENAParser, then fetch
 	std::string Search(const std::string &accession, const std::string &result_type, const std::string &fields);
 	std::string FetchXML(const std::vector<std::string> &accessions);
+
+	// Fetch an arbitrary URL with the same rate-limit + retry semantics as Search/FetchXML.
+	// Intended for callers that build URLs externally (e.g., ResolveRunsBatch with compound
+	// "accession IN (...)" queries).
+	std::string FetchURL(const std::string &url);
 
 private:
 	duckdb::DatabaseInstance &db;

--- a/src/include/ena_parser.hpp
+++ b/src/include/ena_parser.hpp
@@ -34,6 +34,10 @@ public:
 	// URL construction
 	static std::string BuildSearchURL(const std::string &accession, const std::string &result_type,
 	                                  const std::string &fields);
+	// Compound-query URL: query=<col>%20IN%20(%22acc1%22,%22acc2%22,...). All accessions must share the
+	// same type (e.g., all RUN). Throws on empty input or UNKNOWN type.
+	static std::string BuildSearchURLBatch(const std::vector<std::string> &accessions, ENAAccessionType accession_type,
+	                                       const std::string &result_type, const std::string &fields);
 	static std::string BuildXMLURL(const std::vector<std::string> &accessions);
 
 	// Parsing

--- a/src/include/ena_resolver_cache.hpp
+++ b/src/include/ena_resolver_cache.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "ena_run_info_extractor.hpp"
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace miint {
+
+// Callable that performs a single HTTP GET and returns the response body.
+// Injectable so ResolveRunsBatch can be unit-tested without hitting the network.
+using ENAFetcher = std::function<std::string(const std::string &url)>;
+
+// Thread-safe LRU cache keyed on (accession, prefer_format).
+// Value is the list of RunInfo records returned by ENA for that accession.
+// Holds negative results (empty vectors) so repeated lookups of known-missing
+// accessions don't re-hit the network.
+class ENAResolverCache {
+public:
+	struct Key {
+		std::string accession;
+		std::string prefer_format;
+
+		bool operator==(const Key &other) const {
+			return accession == other.accession && prefer_format == other.prefer_format;
+		}
+	};
+
+	struct KeyHash {
+		size_t operator()(const Key &k) const noexcept {
+			auto h1 = std::hash<std::string> {}(k.accession);
+			auto h2 = std::hash<std::string> {}(k.prefer_format);
+			return h1 ^ (h2 * 0x9e3779b97f4a7c15ULL);
+		}
+	};
+
+	// capacity = 0 disables caching (Put is a no-op, Get always misses).
+	explicit ENAResolverCache(size_t capacity = 256);
+
+	// Returns true on hit; copies the stored vector into 'out'.
+	bool Get(const Key &key, std::vector<ENARunInfo> &out);
+
+	// Inserts or replaces. Evicts the least-recently-used entry if at capacity.
+	void Put(const Key &key, std::vector<ENARunInfo> value);
+
+	size_t Size();
+
+private:
+	size_t capacity;
+	std::mutex m;
+	std::list<Key> order; // MRU at front, LRU at back
+	std::unordered_map<Key, std::pair<std::vector<ENARunInfo>, std::list<Key>::iterator>, KeyHash> map;
+};
+
+// Resolve one-or-more accessions to RunInfo records using batched ENA Portal queries.
+//
+// Behavior:
+//   - Deduplicates input accessions.
+//   - Returns cache hits without hitting the fetcher.
+//   - Groups cache-miss accessions by detected accession type (RUN, STUDY, etc.)
+//     and issues one compound "<col> IN (...)" query per group, splitting into
+//     batches of at most max_batch_size to respect URL-length limits.
+//   - UNKNOWN-type accessions fall back to single-accession queries (one fetch each).
+//   - Negative results (zero rows returned for an accession) are cached to avoid
+//     re-fetching.
+//   - Every input accession appears as a key in the output map. The value is empty
+//     when no runs were found.
+//
+// fetcher: called with a fully-formed URL; returns the TSV body.
+// cache:   mutated in-place.
+//
+// Thread-safety / concurrency note:
+//   There is a TOCTOU window between the per-accession Get(miss) and the later
+//   Put(result). Two threads that both miss on the same accession will issue two
+//   fetches and the second Put overwrites the first. The final result is idempotent,
+//   so correctness is preserved, but the second fetch wastes an HTTP round-trip.
+//   This is acceptable for Phase A because ResolveRuns is only invoked from Bind()
+//   on a single thread. Phase B (lateral in_out_function) will call this from worker
+//   threads — if workers can share a cache and query overlapping accessions, consider
+//   adding a per-key in-flight map guarded by the same mutex so the first miss blocks
+//   the duplicates until the fetch completes.
+std::unordered_map<std::string, std::vector<ENARunInfo>>
+ResolveRunsBatch(const ENAFetcher &fetcher, ENAResolverCache &cache, const std::vector<std::string> &accessions,
+                 const std::string &prefer_format, size_t max_batch_size = 50);
+
+} // namespace miint

--- a/src/include/ena_run_info_extractor.hpp
+++ b/src/include/ena_run_info_extractor.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "aspera_utils.hpp"
+#include "ena_parser.hpp"
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace miint {
+
+enum class ENASequenceFormat { FASTX, SFF };
+
+struct ENARunInfo {
+	std::string run_accession;
+	std::string sample_accession;
+	std::string experiment_accession;
+	std::vector<std::string> fastq_urls;
+	std::vector<AsperaPath> aspera_paths;
+	bool is_paired = false;
+	uint64_t total_bytes = 0;
+	ENASequenceFormat format = ENASequenceFormat::FASTX;
+	std::string sff_url;
+};
+
+struct ENAColumnIndexMap {
+	int run_accession = -1;
+	int sample_accession = -1;
+	int experiment_accession = -1;
+	int study_accession = -1;
+	int fastq_ftp = -1;
+	int fastq_aspera = -1;
+	int fastq_bytes = -1;
+	int library_layout = -1;
+	int submitted_ftp = -1;
+	int submitted_aspera = -1;
+	int submitted_bytes = -1;
+	int submitted_format = -1;
+
+	static ENAColumnIndexMap FromHeader(const std::vector<std::string> &header);
+
+	static std::string Get(const std::vector<std::string> &row, int col);
+};
+
+class ENARunInfoExtractor {
+public:
+	// Pure per-row extractor. Returns zero or more RunInfo records from a single TSV row.
+	//   FASTQ runs yield exactly one RunInfo.
+	//   SFF runs flatten to one RunInfo per SFF file.
+	//   Rows with no usable format return an empty vector.
+	//
+	// prefer_format ∈ {"auto", "fastq", "sff"}:
+	//   "auto"  — FASTQ if available, else SFF
+	//   "fastq" — FASTQ only
+	//   "sff"   — SFF if available, else fall back to FASTQ
+	static std::vector<ENARunInfo> FromTSVRow(const std::vector<std::string> &row, const ENAColumnIndexMap &cols,
+	                                          const std::string &prefer_format);
+};
+
+} // namespace miint

--- a/src/include/ena_search_field_registry.hpp
+++ b/src/include/ena_search_field_registry.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <set>
+#include <string>
+
+namespace miint {
+
+// Curated allowlist of ENA Portal API sample-search field names that we know
+// behave sensibly as a structured `/search?fields=...&query=...` equality
+// predicate. Used by the filter-pushdown path in `read_ena_attributes` to
+// decide whether a `WHERE tag='X'` filter can be translated into a structured
+// ENA search or must fall back to the XML path.
+//
+// Policy: if ANY tag referenced in a user's filter is not in this set, we do
+// NOT push anything down — we fall back entirely to the XML path. This keeps
+// the structured path equivalent to the XML output (per the plan's decision
+// #4 in localdocs/PLAN-ena-predicate-maxseqs.md).
+//
+// Lookup is case-insensitive and whitespace-tolerant. ENA's own field names
+// are lowercase, but user `WHERE` clauses often use mixed case.
+class ENASearchFieldRegistry {
+public:
+	// Returns true iff `tag`, after lowercasing + trimming, matches a known
+	// searchable sample field.
+	static bool IsSearchableSampleField(const std::string &tag);
+
+	// Canonical lowercase set. Exposed for tests and for diagnostics that want
+	// to enumerate the allowlist (e.g., to emit a helpful error message).
+	static const std::set<std::string> &SearchableSampleFields();
+};
+
+} // namespace miint

--- a/src/include/per_run_reader.hpp
+++ b/src/include/per_run_reader.hpp
@@ -34,8 +34,10 @@ namespace miint {
 // sequence counter between attempts — the counter is not owned here.
 class PerRunReader {
 public:
+	// `max_sequences == 0` means unlimited. For paired-end runs, `max_sequences`
+	// counts pairs (one batch row per pair), not underlying FASTQ records.
 	PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspera, bool trim, std::mutex &open_mutex,
-	             const AsperaConfig *aspera_config);
+	             const AsperaConfig *aspera_config, uint64_t max_sequences = 0);
 	~PerRunReader();
 
 	PerRunReader(const PerRunReader &) = delete;
@@ -74,12 +76,17 @@ private:
 	std::unique_ptr<SFFReader> sff_reader_;
 	std::string sff_temp_path_;
 #if MIINT_ASPERA_SUPPORTED
+	// Single-end and paired-end Aspera both stream directly: one ascp process
+	// per remote file, each in stdio:// (single-file) mode. Paired-end uses
+	// both processes concurrently; R2 is nullptr for single-end.
 	std::unique_ptr<AsperaProcess> aspera_process_;
-	std::string aspera_temp_path_; // paired R1 buffered here (paired-end aspera only)
+	std::unique_ptr<AsperaProcess> aspera_process_paired_;
 #endif
 	bool exhausted_ = false;
 	bool opened_ = false;
 	bool finished_ = false;
+	uint64_t max_sequences_ = 0; // 0 = unlimited
+	uint64_t sequences_emitted_ = 0;
 
 	void OpenHTTP();
 	void OpenSFF();

--- a/src/include/per_run_reader.hpp
+++ b/src/include/per_run_reader.hpp
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "SequenceRecord.hpp"
+#include "SequenceReader.hpp"
+#include "SFFReader.hpp"
+#include "aspera_stream.hpp"
+#include "aspera_utils.hpp"
+#include "ena_run_info_extractor.hpp"
+#include "duckdb/common/file_system.hpp"
+
+#include <memory>
+#include <mutex>
+#include <string>
+
+namespace miint {
+
+// Per-run streaming reader for ENA FASTX / SFF / Aspera runs.
+// Owns the reader, ascp process, and any temp files for a SINGLE run.
+// Destructor is responsible for all teardown (reader destroy, ascp kill, temp unlink).
+//
+// Usage (typical):
+//   reader = std::make_unique<PerRunReader>(fs, run, use_aspera, trim, open_mutex, aspera_cfg);
+//   reader->Open();                                       // throws on failure
+//   while (!reader->Exhausted()) {
+//       auto batch = reader->ReadBatch(STANDARD_VECTOR_SIZE);
+//       if (batch.empty()) break;
+//       // consume batch
+//   }
+//   reader->Finish();   // for Aspera: wait for ascp + throw on bad exit
+//   reader.reset();     // destructor cleans up any remaining state
+//
+// Retry policy stays with the caller: destroy the reader on Open/Read failure,
+// create a fresh one, call Open() again. Caller also resets any per-run
+// sequence counter between attempts — the counter is not owned here.
+class PerRunReader {
+public:
+	PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspera, bool trim, std::mutex &open_mutex,
+	             const AsperaConfig *aspera_config);
+	~PerRunReader();
+
+	PerRunReader(const PerRunReader &) = delete;
+	PerRunReader &operator=(const PerRunReader &) = delete;
+
+	// Open the reader for this run. Single attempt; throws on failure.
+	// Safe to call only once; subsequent calls are a no-op.
+	void Open();
+
+	// Read up to max_size records. An empty batch signals EOF and marks the
+	// reader Exhausted(). Calling ReadBatch again after EOF returns empty.
+	SequenceRecordBatch ReadBatch(size_t max_size);
+
+	// Call after a successful EOF (empty batch). For Aspera runs, waits for
+	// ascp to exit and throws IOException on non-zero, non-killed exit code.
+	// No-op for FASTX/SFF. Idempotent.
+	void Finish();
+
+	bool Exhausted() const {
+		return exhausted_;
+	}
+
+	const ENARunInfo &Run() const {
+		return run_;
+	}
+
+private:
+	duckdb::FileSystem &fs_;
+	ENARunInfo run_;
+	bool use_aspera_;
+	bool trim_;
+	std::mutex &open_mutex_;
+	const AsperaConfig *aspera_config_; // nullable; non-null only when use_aspera_ is true
+
+	std::unique_ptr<SequenceReader> fastx_reader_;
+	std::unique_ptr<SFFReader> sff_reader_;
+	std::string sff_temp_path_;
+#if MIINT_ASPERA_SUPPORTED
+	std::unique_ptr<AsperaProcess> aspera_process_;
+	std::string aspera_temp_path_; // paired R1 buffered here (paired-end aspera only)
+#endif
+	bool exhausted_ = false;
+	bool opened_ = false;
+	bool finished_ = false;
+
+	void OpenHTTP();
+	void OpenSFF();
+#if MIINT_ASPERA_SUPPORTED
+	void OpenAspera();
+#endif
+};
+
+} // namespace miint

--- a/src/include/read_ena_attributes.hpp
+++ b/src/include/read_ena_attributes.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
+#include "ena_attributes_filter.hpp"
 #include "ena_client.hpp"
 #include "ena_parser.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include <atomic>
 #include <mutex>
 #include <vector>
@@ -19,6 +21,15 @@ public:
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
+		// Populated by PushdownComplexFilter when the WHERE clause is pushable
+		// (tag equality / tag IN, all tags in the search-field registry, with
+		// optional value= pin). Empty => Execute uses the XML path. Guarded by
+		// its own mutex because Bind and PushdownComplexFilter run on the
+		// planner thread while Execute may run on a worker; the callback fires
+		// before Execute, so in practice the happens-before is clean, but
+		// readers cast `const Data&` so we keep the field plain.
+		miint::ENAAttributePushdown pushdown;
+
 		Data(std::vector<std::string> accessions);
 	};
 
@@ -27,10 +38,15 @@ public:
 		unique_ptr<miint::ENAClient> client;
 
 		// Streaming state. `ResolveAccessions` populates `pending_sample_accs`
-		// from the input accessions. Each call to `FetchNextBatch` pops up to
-		// BATCH_SIZE samples from `pending_sample_accs`, fetches + parses their
-		// XML, and replaces `current_batch`. Execute() emits from
-		// `current_batch[current_batch_offset..]` one DuckDB chunk at a time.
+		// from the input accessions. Each call to `FetchNextBatch` consumes
+		// up to BATCH_SIZE samples starting at `pending_sample_offset`,
+		// fetches + parses their XML, and replaces `current_batch`. Execute()
+		// emits from `current_batch[current_batch_offset..]` one DuckDB chunk
+		// at a time.
+		//
+		// `pending_sample_offset` advances as a read cursor instead of
+		// front-erasing `pending_sample_accs` each batch; on a 33k-sample
+		// study that saves O(n²) string moves per scan.
 		//
 		// BATCH_SIZE is the main lever for throughput. ENA accepts comma-
 		// separated accession lists up to a fairly generous URL length; 200
@@ -41,6 +57,7 @@ public:
 		static constexpr size_t BATCH_SIZE = 200;
 		bool resolved = false;
 		std::vector<std::string> pending_sample_accs;
+		size_t pending_sample_offset = 0;
 		std::vector<miint::SampleAttribute> current_batch;
 		size_t current_batch_offset = 0;
 
@@ -64,6 +81,13 @@ public:
 		// true if a batch was fetched, false if no pending samples remain.
 		bool FetchNextBatch();
 
+		// Structured-path equivalent of FetchNextBatch. Instead of fetching
+		// per-sample XML, issues a single /search?result=sample TSV request
+		// for BATCH_SIZE samples with the pushed-down `fields` + `query`,
+		// then unpivots the TSV into (sample, tag, value) rows. The output
+		// shape matches the XML path.
+		bool FetchNextStructuredBatch(const miint::ENAAttributePushdown &pushdown);
+
 		idx_t MaxThreads() const override {
 			return 1;
 		}
@@ -80,6 +104,8 @@ public:
 	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                     GlobalTableFunctionState *global_state);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static void PushdownComplexFilter(ClientContext &context, LogicalGet &get, FunctionData *bind_data_p,
+	                                  vector<unique_ptr<Expression>> &filters);
 	static double Progress(ClientContext &context, const FunctionData *bind_data,
 	                       const GlobalTableFunctionState *global_state);
 	static TableFunction GetFunction();

--- a/src/include/read_ena_attributes.hpp
+++ b/src/include/read_ena_attributes.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
+#include <atomic>
 #include <mutex>
 #include <vector>
 
@@ -24,13 +25,44 @@ public:
 	struct GlobalState : public GlobalTableFunctionState {
 		mutex lock;
 		unique_ptr<miint::ENAClient> client;
-		std::vector<miint::SampleAttribute> attributes;
-		size_t row_offset;
-		bool fetched;
+
+		// Streaming state. `ResolveAccessions` populates `pending_sample_accs`
+		// from the input accessions. Each call to `FetchNextBatch` pops up to
+		// BATCH_SIZE samples from `pending_sample_accs`, fetches + parses their
+		// XML, and replaces `current_batch`. Execute() emits from
+		// `current_batch[current_batch_offset..]` one DuckDB chunk at a time.
+		//
+		// BATCH_SIZE is the main lever for throughput. ENA accepts comma-
+		// separated accession lists up to a fairly generous URL length; 200
+		// sample accessions (~14 chars each) stays well under 8 KB. Compared
+		// to 50, this cuts HTTP round-trips 4x — relevant for large studies
+		// like PRJEB11419 with 33k samples where the resolver rate limit
+		// (~3 req/s) is otherwise the wall-clock bottleneck.
+		static constexpr size_t BATCH_SIZE = 200;
+		bool resolved = false;
+		std::vector<std::string> pending_sample_accs;
+		std::vector<miint::SampleAttribute> current_batch;
+		size_t current_batch_offset = 0;
+
+		// Progress tracking. Byte-based isn't meaningful here (XML size per
+		// sample is unknown up front) so we use samples-fetched / samples-total.
+		// Both members are atomic so the progress callback (called from
+		// DuckDB's query monitor thread, with a const GlobalState&) can read
+		// without contending on `lock`. Published via table_scan_progress so
+		// users see e.g. "[42%]" during long scans instead of guessing whether
+		// the query is hung.
+		std::atomic<size_t> total_samples_expected {0};
+		std::atomic<size_t> samples_fetched {0};
 
 		GlobalState(DatabaseInstance &db);
 
-		void FetchAttributes(const std::vector<std::string> &accessions);
+		// One-time sample-accession resolution. Populates `pending_sample_accs`.
+		void ResolveAccessions(const std::vector<std::string> &accessions);
+
+		// Pop up to BATCH_SIZE sample accessions, fetch + parse their XML, and
+		// refill `current_batch`. Sets `current_batch_offset` to 0. Returns
+		// true if a batch was fetched, false if no pending samples remain.
+		bool FetchNextBatch();
 
 		idx_t MaxThreads() const override {
 			return 1;
@@ -48,6 +80,8 @@ public:
 	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                     GlobalTableFunctionState *global_state);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static double Progress(ClientContext &context, const FunctionData *bind_data,
+	                       const GlobalTableFunctionState *global_state);
 	static TableFunction GetFunction();
 	static void Register(ExtensionLoader &loader);
 };

--- a/src/include/read_ena_searchable_fields.hpp
+++ b/src/include/read_ena_searchable_fields.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "ena_client.hpp"
+#include "ena_parser.hpp"
+
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// `ena_searchable_fields(result_type)` — table function that hits ENA's
+// `/returnFields?result=<result_type>&format=tsv` endpoint and returns the
+// rows verbatim. Used as a discoverability tool: given a read_run / sample /
+// study / experiment result type, list the field names, types, and
+// descriptions that ENA's structured search accepts.
+//
+// Exactly one HTTP call is made on the first Execute invocation (response is
+// ~60 rows, so no streaming / batching needed). Subsequent calls drain the
+// materialized rows.
+//
+// Output schema:
+//   field_name  VARCHAR
+//   type        VARCHAR
+//   description VARCHAR (nullable — ENA sometimes omits descriptions)
+class ReadENASearchableFieldsTableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::string result_type;
+		explicit Data(std::string result_type);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		mutex lock;
+		std::unique_ptr<miint::ENAClient> client;
+		bool fetched = false;
+		// Rows of (field_name, type, description) after parsing the TSV.
+		std::vector<std::array<std::string, 3>> rows;
+		size_t offset = 0;
+
+		explicit GlobalState(DatabaseInstance &db);
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	struct LocalState : public LocalTableFunctionState {};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/read_ena_sequences.hpp
+++ b/src/include/read_ena_sequences.hpp
@@ -7,7 +7,9 @@
 #include "duckdb_seq_stream.hpp"
 #include "ena_client.hpp"
 #include "ena_parser.hpp"
+#include "ena_resolver_cache.hpp"
 #include "ena_run_info_extractor.hpp"
+#include "per_run_reader.hpp"
 #include "remote_file_helper.hpp"
 #include "table_function_common.hpp"
 #include "duckdb/common/exception.hpp"
@@ -15,8 +17,11 @@
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include <atomic>
+#include <deque>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -39,6 +44,25 @@ public:
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
+		// Lateral / in-out support: when true, `runs` is empty at Bind time and
+		// ExecuteInOut resolves each outer-row's accession via `resolver_cache`.
+		// The ENAClient is shared (not per-LocalState) so its ~3 req/sec rate
+		// limit actually throttles across outer rows. Its internal mutex
+		// serializes concurrent access from parallel LocalStates.
+		bool deferred_resolution = false;
+		std::unique_ptr<miint::ENAResolverCache> resolver_cache;
+		std::unique_ptr<miint::ENAClient> lateral_client;
+		DatabaseInstance *db_ptr = nullptr;
+
+		// Skipped-accession tracking for the lateral path.
+		// ExecuteInOut has no natural "end of query" callback, so we surface
+		// skip warnings per-event rather than as a batched summary. The list
+		// is kept for potential future summary use. Both members are mutable
+		// so they can be written from ExecuteInOut, which sees bind_data as
+		// const (DuckDB shares it across threads during execution).
+		mutable std::mutex lateral_skipped_lock;
+		mutable std::vector<std::string> lateral_skipped_accessions;
+
 		Data(std::vector<miint::ENARunInfo> runs, bool include_fp, uint8_t offset, bool trim,
 		     const std::string &prefer_format);
 	};
@@ -46,17 +70,13 @@ public:
 	struct GlobalState : public GlobalTableFunctionState {
 		mutex lock;
 		mutex open_mutex; // Serializes file opens to avoid overwhelming remote servers
-		std::vector<std::unique_ptr<miint::SequenceReader>> readers;
-		std::vector<std::unique_ptr<miint::SFFReader>> sff_readers;
+		std::vector<std::unique_ptr<miint::PerRunReader>> readers;
 		std::vector<miint::ENARunInfo> runs;
 		size_t next_run_idx;
 		std::vector<uint64_t> run_sequence_counters;
 		FileSystem &fs;
 		bool use_aspera;
 		bool trim;
-
-		// SFF temp file management (downloaded SFF files)
-		std::vector<std::string> sff_temp_paths;
 
 		// Progress tracking (byte-based when available, run-count fallback)
 		std::atomic<idx_t> runs_completed;
@@ -70,34 +90,36 @@ public:
 		std::atomic<bool> skipped_warned;
 
 #if MIINT_ASPERA_SUPPORTED
-		std::vector<std::unique_ptr<miint::AsperaProcess>> aspera_processes;
-		std::vector<std::string> temp_file_paths;
 		miint::AsperaConfig aspera_config;
 #endif
 
+		// Literal path: cap at 8 worker threads. In deferred (in-out) mode, runs
+		// is empty at Bind time so this returns 0 — harmless because DuckDB's
+		// PhysicalTableInOutFunction drives parallelism from the outer side, not
+		// from this hint. (See duckdb/src/execution/operator/projection/
+		// physical_tableinout_function.cpp — MaxThreads on GlobalOperatorState is
+		// not consulted for in-out operators.)
 		idx_t MaxThreads() const override {
 			return std::min<idx_t>(runs.size(), 8);
 		}
 
 		GlobalState(FileSystem &fs, const std::vector<miint::ENARunInfo> &runs, bool use_aspera, bool trim);
-		~GlobalState();
-
-		// Open reader for a specific run index (HTTP FASTQ path).
-		void OpenReader(size_t run_idx);
-
-		// Open reader for a specific run index (SFF: download to temp, parse).
-		void OpenReaderSFF(size_t run_idx);
-
-#if MIINT_ASPERA_SUPPORTED
-		// Open reader for a specific run index (Aspera path).
-		// Reads from the shared aspera_process pipe.
-		void OpenReaderAspera(size_t run_idx);
-#endif
 	};
 
 	struct LocalState : public LocalTableFunctionState {
+		// Standard path (literal args)
 		size_t current_run_idx;
 		bool has_run;
+
+		// Lateral / in-out path. current_reader owns the active run; when it
+		// finishes we pop from pending_runs (a single outer accession may resolve
+		// to multiple runs, e.g. SFF studies that flatten one-RunInfo-per-file).
+		// row_consumed=true means we need a new outer row on the next call.
+		std::unique_ptr<miint::PerRunReader> current_reader;
+		std::deque<miint::ENARunInfo> pending_runs;
+		std::string current_accession;
+		uint64_t lateral_sequence_counter = 1;
+		bool row_consumed = true;
 
 		LocalState() : current_run_idx(0), has_run(false) {
 		}
@@ -109,6 +131,15 @@ public:
 	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
 	                                                     GlobalTableFunctionState *global_state);
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+	// In-out (lateral / correlated-argument) execute. Processes one outer row
+	// at a time, resolving the accession lazily against Data::resolver_cache.
+	static OperatorResultType ExecuteInOut(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
+	                                       DataChunk &output);
+	// Shared column-fill helper used by both Execute (literal path) and
+	// ExecuteInOut (lateral path). Takes the sequence counter by reference so
+	// the caller (which owns the counter) can track progress across batches.
+	static void FillOutputFromBatch(DataChunk &output, const miint::SequenceRecordBatch &batch, const Data &bind_data,
+	                                const miint::ENARunInfo &run, uint64_t &seq_counter);
 	static double Progress(ClientContext &context, const FunctionData *bind_data,
 	                       const GlobalTableFunctionState *global_state);
 	static TableFunction GetFunction();

--- a/src/include/read_ena_sequences.hpp
+++ b/src/include/read_ena_sequences.hpp
@@ -7,6 +7,7 @@
 #include "duckdb_seq_stream.hpp"
 #include "ena_client.hpp"
 #include "ena_parser.hpp"
+#include "ena_run_info_extractor.hpp"
 #include "remote_file_helper.hpp"
 #include "table_function_common.hpp"
 #include "duckdb/common/exception.hpp"
@@ -22,24 +23,10 @@
 
 namespace duckdb {
 
-enum class ENASequenceFormat { FASTX, SFF };
-
 class ReadENASequencesTableFunction {
 public:
-	struct RunInfo {
-		std::string run_accession;
-		std::string sample_accession;
-		std::string experiment_accession;
-		std::vector<std::string> fastq_urls;         // HTTPS URLs (1 for single-end, 2 for paired-end)
-		std::vector<miint::AsperaPath> aspera_paths; // Parsed host + remote_path pairs
-		bool is_paired = false;
-		uint64_t total_bytes = 0;
-		ENASequenceFormat format = ENASequenceFormat::FASTX;
-		std::string sff_url; // Single HTTPS URL (one RunInfo per SFF file when format == SFF)
-	};
-
 	struct Data : public TableFunctionData {
-		std::vector<RunInfo> runs;
+		std::vector<miint::ENARunInfo> runs;
 		bool include_filepath;
 		uint8_t qual_offset;
 		bool use_aspera;
@@ -52,7 +39,8 @@ public:
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
-		Data(std::vector<RunInfo> runs, bool include_fp, uint8_t offset, bool trim, const std::string &prefer_format);
+		Data(std::vector<miint::ENARunInfo> runs, bool include_fp, uint8_t offset, bool trim,
+		     const std::string &prefer_format);
 	};
 
 	struct GlobalState : public GlobalTableFunctionState {
@@ -60,7 +48,7 @@ public:
 		mutex open_mutex; // Serializes file opens to avoid overwhelming remote servers
 		std::vector<std::unique_ptr<miint::SequenceReader>> readers;
 		std::vector<std::unique_ptr<miint::SFFReader>> sff_readers;
-		std::vector<RunInfo> runs;
+		std::vector<miint::ENARunInfo> runs;
 		size_t next_run_idx;
 		std::vector<uint64_t> run_sequence_counters;
 		FileSystem &fs;
@@ -91,7 +79,7 @@ public:
 			return std::min<idx_t>(runs.size(), 8);
 		}
 
-		GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs, bool use_aspera, bool trim);
+		GlobalState(FileSystem &fs, const std::vector<miint::ENARunInfo> &runs, bool use_aspera, bool trim);
 		~GlobalState();
 
 		// Open reader for a specific run index (HTTP FASTQ path).

--- a/src/include/read_ena_sequences.hpp
+++ b/src/include/read_ena_sequences.hpp
@@ -37,6 +37,9 @@ public:
 		bool use_aspera;
 		bool trim;
 		std::string prefer_format;
+		// `max_sequences == 0` means unlimited. For paired-end runs this counts
+		// pairs (one batch row per pair), not underlying FASTQ records.
+		uint64_t max_sequences = 0;
 #if MIINT_ASPERA_SUPPORTED
 		miint::AsperaConfig aspera_config;
 #endif

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -28,6 +28,7 @@
 #include <read_ncbi_annotation.hpp>
 #include <read_ena.hpp>
 #include <read_ena_attributes.hpp>
+#include <read_ena_searchable_fields.hpp>
 #include <read_ena_sequences.hpp>
 #include <miint_macros.hpp>
 #include "duckdb/main/extension_helper.hpp"
@@ -203,6 +204,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ReadNCBIAnnotationTableFunction::Register(loader);
 	ReadENATableFunction::Register(loader);
 	ReadENAAttributesTableFunction::Register(loader);
+	ReadENASearchableFieldsTableFunction::Register(loader);
 	ReadENASequencesTableFunction::Register(loader);
 
 	AlignmentFlagFunctions::Register(loader);

--- a/src/per_run_reader.cpp
+++ b/src/per_run_reader.cpp
@@ -3,6 +3,8 @@
 #include "table_function_common.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_open_flags.hpp"
+#include "duckdb/common/printer.hpp"
+#include "duckdb/common/string_util.hpp"
 
 #include <cerrno>
 #include <cstdio>
@@ -12,9 +14,9 @@
 namespace miint {
 
 PerRunReader::PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspera, bool trim, std::mutex &open_mutex,
-                           const AsperaConfig *aspera_config)
+                           const AsperaConfig *aspera_config, uint64_t max_sequences)
     : fs_(fs), run_(std::move(run)), use_aspera_(use_aspera), trim_(trim), open_mutex_(open_mutex),
-      aspera_config_(aspera_config) {
+      aspera_config_(aspera_config), max_sequences_(max_sequences) {
 }
 
 PerRunReader::~PerRunReader() {
@@ -25,11 +27,8 @@ PerRunReader::~PerRunReader() {
 		sff_temp_path_.clear();
 	}
 #if MIINT_ASPERA_SUPPORTED
-	if (!aspera_temp_path_.empty()) {
-		std::remove(aspera_temp_path_.c_str());
-		aspera_temp_path_.clear();
-	}
-	// AsperaProcess destructor handles SIGTERM → SIGKILL → waitpid
+	// AsperaProcess destructor handles SIGTERM → SIGKILL → waitpid for both
+	// single-end (aspera_process_) and paired-end (aspera_process_paired_).
 #endif
 }
 
@@ -57,12 +56,26 @@ SequenceRecordBatch PerRunReader::ReadBatch(size_t max_size) {
 	if (exhausted_) {
 		return SequenceRecordBatch {};
 	}
+	if (max_sequences_ > 0) {
+		if (sequences_emitted_ >= max_sequences_) {
+			exhausted_ = true;
+			return SequenceRecordBatch {};
+		}
+		// Clamp this call so the cap fires on an exact boundary instead of
+		// spilling into the next batch. batch.size() counts pairs as 1, which
+		// matches the contract documented on the ctor.
+		uint64_t remaining = max_sequences_ - sequences_emitted_;
+		if (remaining < max_size) {
+			max_size = static_cast<size_t>(remaining);
+		}
+	}
 	SequenceRecordBatch batch;
 	if (run_.format == ENASequenceFormat::SFF) {
 		batch = sff_reader_->read(max_size);
 	} else {
 		batch = fastx_reader_->read(max_size);
 	}
+	sequences_emitted_ += batch.size();
 	if (batch.empty()) {
 		exhausted_ = true;
 	}
@@ -75,13 +88,35 @@ void PerRunReader::Finish() {
 	}
 	finished_ = true;
 #if MIINT_ASPERA_SUPPORTED
-	if (use_aspera_ && aspera_process_) {
-		int exit_code = aspera_process_->WaitForExit();
-		aspera_process_.reset();
-		if (exit_code != 0 && exit_code != -1) {
-			throw duckdb::IOException("read_ena_sequences: ascp exited with code %d for run '%s'", exit_code,
-			                          run_.run_accession);
+	if (!use_aspera_) {
+		return;
+	}
+	// Wait on both processes. If the first throws, still wait on the second to
+	// avoid leaving an orphan ascp around; re-throw after both are reaped.
+	auto wait_one = [this](std::unique_ptr<AsperaProcess> &proc, const char *tag) -> std::string {
+		if (!proc) {
+			return {};
 		}
+		int exit_code = proc->WaitForExit();
+		proc.reset();
+		if (exit_code != 0 && exit_code != -1) {
+			return duckdb::StringUtil::Format("read_ena_sequences: %s ascp exited with code %d for run '%s'", tag,
+			                                  exit_code, run_.run_accession);
+		}
+		return {};
+	};
+	std::string err_r1 = wait_one(aspera_process_, "R1");
+	std::string err_r2 = wait_one(aspera_process_paired_, "R2");
+	// When both processes errored we surface R1 via the thrown exception;
+	// log R2's message first so the user doesn't lose half the story.
+	if (!err_r1.empty() && !err_r2.empty()) {
+		duckdb::Printer::Print(err_r2);
+	}
+	if (!err_r1.empty()) {
+		throw duckdb::IOException(err_r1);
+	}
+	if (!err_r2.empty()) {
+		throw duckdb::IOException(err_r2);
 	}
 #endif
 }
@@ -142,6 +177,18 @@ void PerRunReader::OpenHTTP() {
 void PerRunReader::OpenSFF() {
 	if (run_.sff_url.empty()) {
 		throw duckdb::IOException("read_ena_sequences: no SFF URL available for run '%s'", run_.run_accession);
+	}
+
+	// SFF format requires the entire file on disk before any record can be
+	// parsed — we download-then-read rather than stream. `max_sequences` still
+	// caps emitted rows downstream, but the bandwidth has already been spent
+	// by the time ReadBatch() starts enforcing the cap. Warn loudly once per
+	// SFF run so users don't silently assume the cap saved them a download.
+	if (max_sequences_ > 0) {
+		duckdb::Printer::PrintF("read_ena_sequences: WARNING: max_sequences=%llu on SFF run '%s' — SFF requires "
+		                        "downloading the full file before any record can be parsed; the row cap applies "
+		                        "but bandwidth savings do not",
+		                        static_cast<unsigned long long>(max_sequences_), run_.run_accession);
 	}
 
 	auto temp_dir = GetTempDir();
@@ -209,38 +256,31 @@ void PerRunReader::OpenSFF() {
 #if MIINT_ASPERA_SUPPORTED
 
 void PerRunReader::OpenAspera() {
-	std::vector<std::string> remote_paths;
-	for (const auto &ap : run_.aspera_paths) {
-		remote_paths.push_back(ap.remote_path);
+	if (run_.aspera_paths.empty()) {
+		throw duckdb::IOException("read_ena_sequences: no Aspera paths available for run '%s'", run_.run_accession);
 	}
 
 	AsperaConfig config = aspera_config_ ? *aspera_config_ : AsperaConfig {};
-	if (!run_.aspera_paths.empty()) {
-		config.host = run_.aspera_paths[0].host;
-	}
+	config.host = run_.aspera_paths[0].host;
 
-	// Serialize ascp launches (fork/exec); pipe reads use thread-owned descriptors.
-	{
-		std::lock_guard<std::mutex> open_guard(open_mutex_);
-		aspera_process_ = std::make_unique<AsperaProcess>(config, remote_paths);
-	}
-	auto *proc = aspera_process_.get();
-
-	std::string filename;
-	size_t file_size;
-	if (!proc->NextFile(filename, file_size)) {
-		throw duckdb::IOException("read_ena_sequences: Aspera stream ended unexpectedly (expected files for run '%s')",
-		                          run_.run_accession);
-	}
-
-	std::string gz_hint = filename;
-	if (gz_hint.empty() && !run_.aspera_paths.empty()) {
-		gz_hint = run_.aspera_paths[0].remote_path;
-	}
-	bool is_gz = duckdb::IsGzipped(gz_hint);
-
+	// Single-end: one ascp process in stdio:// (single-file) mode.
 	if (!run_.is_paired) {
-		auto *s1 = CreateAsperaSeqStream(proc, is_gz);
+		{
+			std::lock_guard<std::mutex> open_guard(open_mutex_);
+			aspera_process_ =
+			    std::make_unique<AsperaProcess>(config, std::vector<std::string> {run_.aspera_paths[0].remote_path});
+		}
+		std::string filename;
+		size_t file_size;
+		if (!aspera_process_->NextFile(filename, file_size)) {
+			throw duckdb::IOException(
+			    "read_ena_sequences: Aspera stream ended unexpectedly (expected files for run '%s')",
+			    run_.run_accession);
+		}
+		std::string gz_hint = filename.empty() ? run_.aspera_paths[0].remote_path : filename;
+		bool is_gz = duckdb::IsGzipped(gz_hint);
+
+		auto *s1 = CreateAsperaSeqStream(aspera_process_.get(), is_gz);
 		try {
 			fastx_reader_ = std::make_unique<SequenceReader>(s1, static_cast<AsperaSeqStream *>(nullptr), true);
 		} catch (...) {
@@ -250,79 +290,48 @@ void PerRunReader::OpenAspera() {
 		return;
 	}
 
-	// Paired-end: stream R1 from pipe to temp file, then stream R2 live.
-	static constexpr size_t COPY_BUF_SIZE = 1024 * 1024; // 1 MB
-
-	std::string tmpl = GetTempDir() + "/miint_aspera_r1_XXXXXX";
-	std::vector<char> tmpl_buf(tmpl.begin(), tmpl.end());
-	tmpl_buf.push_back('\0');
-	int fd = mkstemp(tmpl_buf.data());
-	if (fd == -1) {
-		throw duckdb::IOException("read_ena_sequences: failed to create temp file for paired-end Aspera buffering");
-	}
-	aspera_temp_path_ = std::string(tmpl_buf.data());
-
-	std::vector<char> copy_buf(COPY_BUF_SIZE);
-	while (true) {
-		int n = proc->ReadBounded(copy_buf.data(), COPY_BUF_SIZE);
-		if (n == 0) {
-			break;
-		}
-		if (n < 0) {
-			close(fd);
-			std::remove(aspera_temp_path_.c_str());
-			aspera_temp_path_.clear();
-			throw duckdb::IOException("read_ena_sequences: pipe read error while buffering R1 for run '%s'",
-			                          run_.run_accession);
-		}
-		size_t written = 0;
-		while (written < static_cast<size_t>(n)) {
-			ssize_t w = write(fd, copy_buf.data() + written, static_cast<size_t>(n) - written);
-			if (w < 0) {
-				if (errno == EINTR) {
-					continue;
-				}
-				int err = errno;
-				close(fd);
-				std::remove(aspera_temp_path_.c_str());
-				aspera_temp_path_.clear();
-				throw duckdb::IOException(
-				    "read_ena_sequences: failed to write temp file for paired-end Aspera buffering "
-				    "(run '%s', errno=%d: %s)",
-				    run_.run_accession, err, strerror(err));
-			}
-			written += static_cast<size_t>(w);
-		}
-	}
-	close(fd);
-
-	std::string filename2;
-	size_t file_size2;
-	if (!proc->NextFile(filename2, file_size2)) {
-		std::remove(aspera_temp_path_.c_str());
-		aspera_temp_path_.clear();
-		throw duckdb::IOException("read_ena_sequences: Aspera stream ended unexpectedly (expected R2 for run '%s')",
+	// Paired-end: two ascp processes, one per remote path, each in stdio://
+	// mode. Both pipes feed the SequenceReader concurrently — no R1 temp file.
+	// Early termination (e.g., max_sequences, LIMIT-inside-LATERAL) tears both
+	// down via AsperaProcess destructors, so the cap saves real bandwidth.
+	if (run_.aspera_paths.size() < 2) {
+		throw duckdb::IOException("read_ena_sequences: paired-end run '%s' is missing its second Aspera path",
 		                          run_.run_accession);
 	}
-
-	std::string gz_hint2 = filename2;
-	if (gz_hint2.empty() && run_.aspera_paths.size() >= 2) {
-		gz_hint2 = run_.aspera_paths[1].remote_path;
+	{
+		std::lock_guard<std::mutex> open_guard(open_mutex_);
+		aspera_process_ =
+		    std::make_unique<AsperaProcess>(config, std::vector<std::string> {run_.aspera_paths[0].remote_path});
+		aspera_process_paired_ =
+		    std::make_unique<AsperaProcess>(config, std::vector<std::string> {run_.aspera_paths[1].remote_path});
 	}
-	bool is_gz2 = duckdb::IsGzipped(gz_hint2);
 
-	auto *s1 = duckdb::CreateDuckDBSeqStream(fs_, aspera_temp_path_, is_gz);
+	std::string f1;
+	size_t sz1;
+	std::string f2;
+	size_t sz2;
+	if (!aspera_process_->NextFile(f1, sz1)) {
+		throw duckdb::IOException(
+		    "read_ena_sequences: Aspera R1 stream ended unexpectedly (expected files for run '%s')",
+		    run_.run_accession);
+	}
+	if (!aspera_process_paired_->NextFile(f2, sz2)) {
+		throw duckdb::IOException(
+		    "read_ena_sequences: Aspera R2 stream ended unexpectedly (expected files for run '%s')",
+		    run_.run_accession);
+	}
+
+	bool is_gz1 = duckdb::IsGzipped(f1.empty() ? run_.aspera_paths[0].remote_path : f1);
+	bool is_gz2 = duckdb::IsGzipped(f2.empty() ? run_.aspera_paths[1].remote_path : f2);
+
+	auto *s1 = CreateAsperaSeqStream(aspera_process_.get(), is_gz1);
 	AsperaSeqStream *s2 = nullptr;
 	try {
-		s2 = CreateAsperaSeqStream(proc, is_gz2);
+		s2 = CreateAsperaSeqStream(aspera_process_paired_.get(), is_gz2);
 		fastx_reader_ = std::make_unique<SequenceReader>(s1, s2, true);
 	} catch (...) {
 		delete s2;
 		delete s1;
-		// On throw here the SequenceReader never took ownership of s1, so the
-		// R1 temp file we already wrote will be removed by the destructor via
-		// aspera_temp_path_. Clear it only after Unix-level `std::remove` runs
-		// from ~PerRunReader to keep the cleanup path in one place.
 		throw;
 	}
 }

--- a/src/per_run_reader.cpp
+++ b/src/per_run_reader.cpp
@@ -1,0 +1,332 @@
+#include "per_run_reader.hpp"
+#include "duckdb_seq_stream.hpp"
+#include "table_function_common.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_open_flags.hpp"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <unistd.h>
+
+namespace miint {
+
+PerRunReader::PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspera, bool trim, std::mutex &open_mutex,
+                           const AsperaConfig *aspera_config)
+    : fs_(fs), run_(std::move(run)), use_aspera_(use_aspera), trim_(trim), open_mutex_(open_mutex),
+      aspera_config_(aspera_config) {
+}
+
+PerRunReader::~PerRunReader() {
+	// Readers / processes are auto-released by their unique_ptrs.
+	// Temp files: best-effort cleanup on the way out.
+	if (!sff_temp_path_.empty()) {
+		std::remove(sff_temp_path_.c_str());
+		sff_temp_path_.clear();
+	}
+#if MIINT_ASPERA_SUPPORTED
+	if (!aspera_temp_path_.empty()) {
+		std::remove(aspera_temp_path_.c_str());
+		aspera_temp_path_.clear();
+	}
+	// AsperaProcess destructor handles SIGTERM → SIGKILL → waitpid
+#endif
+}
+
+void PerRunReader::Open() {
+	if (opened_) {
+		return;
+	}
+	if (run_.format == ENASequenceFormat::SFF) {
+		OpenSFF();
+	} else {
+#if MIINT_ASPERA_SUPPORTED
+		if (use_aspera_) {
+			OpenAspera();
+		} else {
+			OpenHTTP();
+		}
+#else
+		OpenHTTP();
+#endif
+	}
+	opened_ = true;
+}
+
+SequenceRecordBatch PerRunReader::ReadBatch(size_t max_size) {
+	if (exhausted_) {
+		return SequenceRecordBatch {};
+	}
+	SequenceRecordBatch batch;
+	if (run_.format == ENASequenceFormat::SFF) {
+		batch = sff_reader_->read(max_size);
+	} else {
+		batch = fastx_reader_->read(max_size);
+	}
+	if (batch.empty()) {
+		exhausted_ = true;
+	}
+	return batch;
+}
+
+void PerRunReader::Finish() {
+	if (finished_) {
+		return;
+	}
+	finished_ = true;
+#if MIINT_ASPERA_SUPPORTED
+	if (use_aspera_ && aspera_process_) {
+		int exit_code = aspera_process_->WaitForExit();
+		aspera_process_.reset();
+		if (exit_code != 0 && exit_code != -1) {
+			throw duckdb::IOException("read_ena_sequences: ascp exited with code %d for run '%s'", exit_code,
+			                          run_.run_accession);
+		}
+	}
+#endif
+}
+
+void PerRunReader::OpenHTTP() {
+	if (run_.fastq_urls.empty()) {
+		throw duckdb::IOException("read_ena_sequences: no FASTQ URLs available for run '%s'", run_.run_accession);
+	}
+
+	// Serialize file opens to avoid overwhelming remote servers with simultaneous
+	// HTTP HEAD requests. Reads still proceed in parallel.
+	std::lock_guard<std::mutex> open_guard(open_mutex_);
+
+	// CreateDuckDBSeqStream returns a raw `new`'d pointer. Ownership transfers
+	// to SequenceReader only on successful construction. Until that call
+	// succeeds, we own the streams and MUST clean them up on any throw path —
+	// SequenceReader's constructor does not deallocate on failure, so without
+	// these RAII guards any exception (not just std::runtime_error) leaks.
+	auto stream_deleter = [](DuckDBSeqStream *p) {
+		if (p) {
+			duckdb_seq_close(p);
+		}
+	};
+	std::unique_ptr<DuckDBSeqStream, decltype(stream_deleter)> s1(
+	    duckdb::CreateDuckDBSeqStream(fs_, run_.fastq_urls[0]), stream_deleter);
+	std::unique_ptr<DuckDBSeqStream, decltype(stream_deleter)> s2(nullptr, stream_deleter);
+	if (run_.is_paired && run_.fastq_urls.size() >= 2) {
+		s2.reset(duckdb::CreateDuckDBSeqStream(fs_, run_.fastq_urls[1]));
+	}
+
+	try {
+		fastx_reader_ = std::make_unique<SequenceReader>(s1.get(), s2.get(), true);
+		// SequenceReader took ownership — stop tracking here.
+		s1.release();
+		s2.release();
+	} catch (const std::runtime_error &e) {
+		if (s2 && std::string(e.what()) == "Empty stream (sequence2)") {
+			// ENA metadata may report PAIRED layout but the second FASTQ file
+			// is actually empty (single-end deposited with PAIRED metadata).
+			// The failed constructor may have consumed the streams; regardless,
+			// our RAII guards will release whichever ones aren't owned by it.
+			// Reopen just the first file and retry as single-end.
+			s1.reset();
+			s2.reset();
+			std::unique_ptr<DuckDBSeqStream, decltype(stream_deleter)> s1_retry(
+			    duckdb::CreateDuckDBSeqStream(fs_, run_.fastq_urls[0]), stream_deleter);
+			fastx_reader_ =
+			    std::make_unique<SequenceReader>(s1_retry.get(), static_cast<DuckDBSeqStream *>(nullptr), true);
+			s1_retry.release();
+		} else {
+			// s1 / s2 guards clean up automatically on the rethrow.
+			throw;
+		}
+	}
+	// Any other exception type (e.g., IOException) propagates and RAII cleans up.
+}
+
+void PerRunReader::OpenSFF() {
+	if (run_.sff_url.empty()) {
+		throw duckdb::IOException("read_ena_sequences: no SFF URL available for run '%s'", run_.run_accession);
+	}
+
+	auto temp_dir = GetTempDir();
+	auto temp_path = temp_dir + "/miint_ena_sff_XXXXXX";
+	std::vector<char> tmpl_buf(temp_path.begin(), temp_path.end());
+	tmpl_buf.push_back('\0');
+	int fd = mkstemp(tmpl_buf.data());
+	if (fd == -1) {
+		throw duckdb::IOException("read_ena_sequences: failed to create temp file for SFF download");
+	}
+	temp_path = std::string(tmpl_buf.data());
+	sff_temp_path_ = temp_path;
+
+	bool fd_closed = false;
+	auto cleanup_on_error = [&]() {
+		if (!fd_closed) {
+			close(fd);
+			fd_closed = true;
+		}
+		std::remove(temp_path.c_str());
+		sff_temp_path_.clear();
+	};
+
+	try {
+		duckdb::unique_ptr<duckdb::FileHandle> source;
+		{
+			// Serialize only the HTTP connection setup, not the full download.
+			std::lock_guard<std::mutex> open_guard(open_mutex_);
+			source = fs_.OpenFile(run_.sff_url, duckdb::FileOpenFlags(duckdb::FileOpenFlags::FILE_FLAGS_READ));
+		}
+
+		static constexpr size_t DOWNLOAD_BUF_SIZE = 1048576; // 1 MB
+		std::vector<char> buf(DOWNLOAD_BUF_SIZE);
+		while (true) {
+			auto bytes_read = source->Read(buf.data(), DOWNLOAD_BUF_SIZE);
+			if (bytes_read == 0) {
+				break;
+			}
+			size_t written = 0;
+			while (written < bytes_read) {
+				ssize_t w = write(fd, buf.data() + written, bytes_read - written);
+				if (w < 0) {
+					if (errno == EINTR) {
+						continue;
+					}
+					int saved_errno = errno;
+					cleanup_on_error();
+					throw duckdb::IOException(
+					    "read_ena_sequences: failed writing SFF temp file for run '%s' (errno=%d: %s)",
+					    run_.run_accession, saved_errno, strerror(saved_errno));
+				}
+				written += static_cast<size_t>(w);
+			}
+		}
+		close(fd);
+		fd_closed = true;
+	} catch (...) {
+		cleanup_on_error();
+		throw;
+	}
+
+	sff_reader_ = std::make_unique<SFFReader>(temp_path, trim_);
+}
+
+#if MIINT_ASPERA_SUPPORTED
+
+void PerRunReader::OpenAspera() {
+	std::vector<std::string> remote_paths;
+	for (const auto &ap : run_.aspera_paths) {
+		remote_paths.push_back(ap.remote_path);
+	}
+
+	AsperaConfig config = aspera_config_ ? *aspera_config_ : AsperaConfig {};
+	if (!run_.aspera_paths.empty()) {
+		config.host = run_.aspera_paths[0].host;
+	}
+
+	// Serialize ascp launches (fork/exec); pipe reads use thread-owned descriptors.
+	{
+		std::lock_guard<std::mutex> open_guard(open_mutex_);
+		aspera_process_ = std::make_unique<AsperaProcess>(config, remote_paths);
+	}
+	auto *proc = aspera_process_.get();
+
+	std::string filename;
+	size_t file_size;
+	if (!proc->NextFile(filename, file_size)) {
+		throw duckdb::IOException("read_ena_sequences: Aspera stream ended unexpectedly (expected files for run '%s')",
+		                          run_.run_accession);
+	}
+
+	std::string gz_hint = filename;
+	if (gz_hint.empty() && !run_.aspera_paths.empty()) {
+		gz_hint = run_.aspera_paths[0].remote_path;
+	}
+	bool is_gz = duckdb::IsGzipped(gz_hint);
+
+	if (!run_.is_paired) {
+		auto *s1 = CreateAsperaSeqStream(proc, is_gz);
+		try {
+			fastx_reader_ = std::make_unique<SequenceReader>(s1, static_cast<AsperaSeqStream *>(nullptr), true);
+		} catch (...) {
+			delete s1;
+			throw;
+		}
+		return;
+	}
+
+	// Paired-end: stream R1 from pipe to temp file, then stream R2 live.
+	static constexpr size_t COPY_BUF_SIZE = 1024 * 1024; // 1 MB
+
+	std::string tmpl = GetTempDir() + "/miint_aspera_r1_XXXXXX";
+	std::vector<char> tmpl_buf(tmpl.begin(), tmpl.end());
+	tmpl_buf.push_back('\0');
+	int fd = mkstemp(tmpl_buf.data());
+	if (fd == -1) {
+		throw duckdb::IOException("read_ena_sequences: failed to create temp file for paired-end Aspera buffering");
+	}
+	aspera_temp_path_ = std::string(tmpl_buf.data());
+
+	std::vector<char> copy_buf(COPY_BUF_SIZE);
+	while (true) {
+		int n = proc->ReadBounded(copy_buf.data(), COPY_BUF_SIZE);
+		if (n == 0) {
+			break;
+		}
+		if (n < 0) {
+			close(fd);
+			std::remove(aspera_temp_path_.c_str());
+			aspera_temp_path_.clear();
+			throw duckdb::IOException("read_ena_sequences: pipe read error while buffering R1 for run '%s'",
+			                          run_.run_accession);
+		}
+		size_t written = 0;
+		while (written < static_cast<size_t>(n)) {
+			ssize_t w = write(fd, copy_buf.data() + written, static_cast<size_t>(n) - written);
+			if (w < 0) {
+				if (errno == EINTR) {
+					continue;
+				}
+				int err = errno;
+				close(fd);
+				std::remove(aspera_temp_path_.c_str());
+				aspera_temp_path_.clear();
+				throw duckdb::IOException(
+				    "read_ena_sequences: failed to write temp file for paired-end Aspera buffering "
+				    "(run '%s', errno=%d: %s)",
+				    run_.run_accession, err, strerror(err));
+			}
+			written += static_cast<size_t>(w);
+		}
+	}
+	close(fd);
+
+	std::string filename2;
+	size_t file_size2;
+	if (!proc->NextFile(filename2, file_size2)) {
+		std::remove(aspera_temp_path_.c_str());
+		aspera_temp_path_.clear();
+		throw duckdb::IOException("read_ena_sequences: Aspera stream ended unexpectedly (expected R2 for run '%s')",
+		                          run_.run_accession);
+	}
+
+	std::string gz_hint2 = filename2;
+	if (gz_hint2.empty() && run_.aspera_paths.size() >= 2) {
+		gz_hint2 = run_.aspera_paths[1].remote_path;
+	}
+	bool is_gz2 = duckdb::IsGzipped(gz_hint2);
+
+	auto *s1 = duckdb::CreateDuckDBSeqStream(fs_, aspera_temp_path_, is_gz);
+	AsperaSeqStream *s2 = nullptr;
+	try {
+		s2 = CreateAsperaSeqStream(proc, is_gz2);
+		fastx_reader_ = std::make_unique<SequenceReader>(s1, s2, true);
+	} catch (...) {
+		delete s2;
+		delete s1;
+		// On throw here the SequenceReader never took ownership of s1, so the
+		// R1 temp file we already wrote will be removed by the destructor via
+		// aspera_temp_path_. Clear it only after Unix-level `std::remove` runs
+		// from ~PerRunReader to keep the cleanup path in one place.
+		throw;
+	}
+}
+
+#endif // MIINT_ASPERA_SUPPORTED
+
+} // namespace miint

--- a/src/per_run_reader.cpp
+++ b/src/per_run_reader.cpp
@@ -22,14 +22,12 @@ PerRunReader::PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspe
 PerRunReader::~PerRunReader() {
 	// Readers / processes are auto-released by their unique_ptrs.
 	// Temp files: best-effort cleanup on the way out.
+	// (Aspera: AsperaProcess dtor handles SIGTERM → SIGKILL → waitpid for
+	// both aspera_process_ and aspera_process_paired_, no explicit work here.)
 	if (!sff_temp_path_.empty()) {
 		std::remove(sff_temp_path_.c_str());
 		sff_temp_path_.clear();
 	}
-#if MIINT_ASPERA_SUPPORTED
-	// AsperaProcess destructor handles SIGTERM → SIGKILL → waitpid for both
-	// single-end (aspera_process_) and paired-end (aspera_process_paired_).
-#endif
 }
 
 void PerRunReader::Open() {

--- a/src/read_ena_attributes.cpp
+++ b/src/read_ena_attributes.cpp
@@ -1,7 +1,159 @@
 #include "read_ena_attributes.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
+#include "duckdb/planner/expression/bound_comparison_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/planner/expression/bound_constant_expression.hpp"
+#include "duckdb/planner/expression/bound_operator_expression.hpp"
 
 namespace duckdb {
+
+namespace {
+
+// Walk a DuckDB bound filter expression into an ENAFilterNode. Unknown shapes
+// map to ENAFilterNode::Kind::UNSUPPORTED, which the extractor then rejects
+// (forcing XML fallback).
+//
+// Column-name resolution invariant (relied upon here):
+//   When DuckDB calls `pushdown_complex_filter`, every
+//   `BoundColumnRefExpression::binding.column_index` in the supplied filter
+//   tree is a LOCAL index into `LogicalGet::GetColumnIds()` — i.e. an index
+//   into the projected-columns subset, not into the full schema `names`.
+//   To recover a name we do: `names[GetColumnIds()[local_idx].GetPrimaryIndex()]`.
+//
+//   Source of truth: `duckdb/src/common/multi_file/multi_file_list.cpp:68-69`,
+//   where DuckDB itself constructs filter column-refs with exactly this
+//   binding shape (`ColumnBinding(table_index, entry.first)` where `entry.first`
+//   is the local index into column_ids). If a future DuckDB version breaks
+//   this invariant, the out-of-bounds checks below cause us to emit
+//   `MakeUnsupported` and silently fall back to the XML path — degraded but
+//   still correct.
+std::string ResolveColumnName(const BoundColumnRefExpression &ref, const LogicalGet &get) {
+	const auto &col_ids = get.GetColumnIds();
+	idx_t local_idx = ref.binding.column_index;
+	if (local_idx >= col_ids.size()) {
+		return "";
+	}
+	idx_t actual_col = col_ids[local_idx].GetPrimaryIndex();
+	if (actual_col >= get.names.size()) {
+		return "";
+	}
+	return get.names[actual_col];
+}
+
+std::unique_ptr<miint::ENAFilterNode> ExpressionToFilterNode(const Expression &expr, const LogicalGet &get);
+
+// Handle `col = const` or `const = col`. Only VARCHAR constants are mapped;
+// anything else (NULL, non-string) => unsupported.
+std::unique_ptr<miint::ENAFilterNode> TranslateEqual(const BoundComparisonExpression &cmp, const LogicalGet &get) {
+	const Expression *col_side = nullptr;
+	const Expression *const_side = nullptr;
+	if (cmp.left->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+	    cmp.right->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		col_side = cmp.left.get();
+		const_side = cmp.right.get();
+	} else if (cmp.right->GetExpressionClass() == ExpressionClass::BOUND_COLUMN_REF &&
+	           cmp.left->GetExpressionClass() == ExpressionClass::BOUND_CONSTANT) {
+		col_side = cmp.right.get();
+		const_side = cmp.left.get();
+	} else {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+
+	const auto &col_ref = col_side->Cast<BoundColumnRefExpression>();
+	const auto &const_expr = const_side->Cast<BoundConstantExpression>();
+	if (const_expr.value.IsNull()) {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	if (const_expr.return_type.id() != LogicalTypeId::VARCHAR) {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	auto col_name = ResolveColumnName(col_ref, get);
+	if (col_name.empty()) {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	return miint::ENAFilterNode::MakeEqual(col_name, const_expr.value.ToString());
+}
+
+// Handle `col IN (c1, c2, ...)`. Children[0] is the column ref; remaining
+// children are the values. Anything else in the IN list (NULL, non-string
+// constant, subexpression) => unsupported.
+std::unique_ptr<miint::ENAFilterNode> TranslateIn(const BoundOperatorExpression &op, const LogicalGet &get) {
+	if (op.children.size() < 2) {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	if (op.children[0]->GetExpressionClass() != ExpressionClass::BOUND_COLUMN_REF) {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	const auto &col_ref = op.children[0]->Cast<BoundColumnRefExpression>();
+	auto col_name = ResolveColumnName(col_ref, get);
+	if (col_name.empty()) {
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	std::vector<std::string> values;
+	values.reserve(op.children.size() - 1);
+	for (idx_t i = 1; i < op.children.size(); i++) {
+		if (op.children[i]->GetExpressionClass() != ExpressionClass::BOUND_CONSTANT) {
+			return miint::ENAFilterNode::MakeUnsupported();
+		}
+		const auto &c = op.children[i]->Cast<BoundConstantExpression>();
+		if (c.value.IsNull() || c.return_type.id() != LogicalTypeId::VARCHAR) {
+			return miint::ENAFilterNode::MakeUnsupported();
+		}
+		values.push_back(c.value.ToString());
+	}
+	return miint::ENAFilterNode::MakeIn(col_name, values);
+}
+
+std::unique_ptr<miint::ENAFilterNode> TranslateConjunction(const BoundConjunctionExpression &conj,
+                                                           const LogicalGet &get, bool is_and) {
+	std::vector<std::unique_ptr<miint::ENAFilterNode>> children;
+	children.reserve(conj.children.size());
+	for (const auto &child : conj.children) {
+		children.push_back(ExpressionToFilterNode(*child, get));
+	}
+	return is_and ? miint::ENAFilterNode::MakeAnd(std::move(children))
+	              : miint::ENAFilterNode::MakeOr(std::move(children));
+}
+
+std::unique_ptr<miint::ENAFilterNode> ExpressionToFilterNode(const Expression &expr, const LogicalGet &get) {
+	switch (expr.GetExpressionClass()) {
+	case ExpressionClass::BOUND_COMPARISON: {
+		const auto &cmp = expr.Cast<BoundComparisonExpression>();
+		if (cmp.GetExpressionType() != ExpressionType::COMPARE_EQUAL) {
+			return miint::ENAFilterNode::MakeUnsupported();
+		}
+		return TranslateEqual(cmp, get);
+	}
+	case ExpressionClass::BOUND_OPERATOR: {
+		const auto &op = expr.Cast<BoundOperatorExpression>();
+		// COMPARE_NOT_IN is a distinct expression type and correctly lands
+		// here as UNSUPPORTED. BOUND_OPERATOR also covers other operators
+		// (IS NULL, IS NOT NULL, COALESCE, ...) that we reject uniformly.
+		if (op.GetExpressionType() != ExpressionType::COMPARE_IN) {
+			return miint::ENAFilterNode::MakeUnsupported();
+		}
+		// `COMPARE_IN` with a non-constant RHS (e.g., a correlated subquery
+		// that hasn't been decorrelated yet) is handled inside TranslateIn:
+		// any non-`BOUND_CONSTANT` child returns UNSUPPORTED.
+		return TranslateIn(op, get);
+	}
+	case ExpressionClass::BOUND_CONJUNCTION: {
+		const auto &conj = expr.Cast<BoundConjunctionExpression>();
+		if (conj.GetExpressionType() == ExpressionType::CONJUNCTION_AND) {
+			return TranslateConjunction(conj, get, /*is_and=*/true);
+		}
+		if (conj.GetExpressionType() == ExpressionType::CONJUNCTION_OR) {
+			return TranslateConjunction(conj, get, /*is_and=*/false);
+		}
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+	default:
+		return miint::ENAFilterNode::MakeUnsupported();
+	}
+}
+
+} // namespace
 
 // ---- Data ----
 
@@ -70,15 +222,37 @@ void ReadENAAttributesTableFunction::GlobalState::ResolveAccessions(const std::v
 }
 
 bool ReadENAAttributesTableFunction::GlobalState::FetchNextBatch() {
-	if (pending_sample_accs.empty()) {
+	if (pending_sample_offset >= pending_sample_accs.size()) {
 		return false;
 	}
-	size_t n = std::min<size_t>(BATCH_SIZE, pending_sample_accs.size());
-	std::vector<std::string> batch(pending_sample_accs.begin(), pending_sample_accs.begin() + n);
-	pending_sample_accs.erase(pending_sample_accs.begin(), pending_sample_accs.begin() + n);
+	size_t remaining = pending_sample_accs.size() - pending_sample_offset;
+	size_t n = std::min<size_t>(BATCH_SIZE, remaining);
+	std::vector<std::string> batch(pending_sample_accs.begin() + pending_sample_offset,
+	                               pending_sample_accs.begin() + pending_sample_offset + n);
+	pending_sample_offset += n;
 
 	auto xml = client->FetchXML(batch);
 	current_batch = miint::ENAParser::ParseSampleAttributesXML(xml);
+	current_batch_offset = 0;
+	samples_fetched.fetch_add(n, std::memory_order_relaxed);
+	return true;
+}
+
+bool ReadENAAttributesTableFunction::GlobalState::FetchNextStructuredBatch(
+    const miint::ENAAttributePushdown &pushdown) {
+	if (pending_sample_offset >= pending_sample_accs.size()) {
+		return false;
+	}
+	size_t remaining = pending_sample_accs.size() - pending_sample_offset;
+	size_t n = std::min<size_t>(BATCH_SIZE, remaining);
+	std::vector<std::string> batch(pending_sample_accs.begin() + pending_sample_offset,
+	                               pending_sample_accs.begin() + pending_sample_offset + n);
+	pending_sample_offset += n;
+
+	auto url = miint::BuildStructuredSearchURL(batch, pushdown.tags, pushdown.tag_value_pairs);
+	auto tsv = client->FetchURL(url);
+	auto parsed = miint::ENAParser::ParseTSV(tsv);
+	current_batch = miint::UnpivotStructuredTSV(parsed, pushdown.tags);
 	current_batch_offset = 0;
 	samples_fetched.fetch_add(n, std::memory_order_relaxed);
 	return true;
@@ -159,9 +333,14 @@ void ReadENAAttributesTableFunction::Execute(ClientContext &context, TableFuncti
 
 	// Advance to the next fetched batch if we've drained the current one.
 	// Loop to skip empty batches (a 50-sample batch whose XML has no sample
-	// with any attributes would otherwise end the scan prematurely).
+	// with any attributes would otherwise end the scan prematurely). When
+	// pushdown_complex_filter extracted a structured predicate, use the TSV
+	// search path; otherwise fall back to per-sample XML.
+	const bool use_structured = !bind_data.pushdown.tags.empty();
 	while (global_state.current_batch_offset >= global_state.current_batch.size()) {
-		if (!global_state.FetchNextBatch()) {
+		bool ok =
+		    use_structured ? global_state.FetchNextStructuredBatch(bind_data.pushdown) : global_state.FetchNextBatch();
+		if (!ok) {
 			output.SetCardinality(0);
 			return;
 		}
@@ -200,6 +379,27 @@ void ReadENAAttributesTableFunction::Execute(ClientContext &context, TableFuncti
 	output.SetCardinality(count);
 }
 
+// ---- Pushdown complex filter ----
+
+void ReadENAAttributesTableFunction::PushdownComplexFilter(ClientContext &context, LogicalGet &get,
+                                                           FunctionData *bind_data_p,
+                                                           vector<unique_ptr<Expression>> &filters) {
+	auto &bind_data = bind_data_p->Cast<Data>();
+
+	std::vector<std::unique_ptr<miint::ENAFilterNode>> ast;
+	ast.reserve(filters.size());
+	for (const auto &expr : filters) {
+		ast.push_back(ExpressionToFilterNode(*expr, get));
+	}
+	bind_data.pushdown = miint::ExtractPushdownPredicates(ast);
+
+	// Per plan decision #5 (localdocs/PLAN-ena-predicate-maxseqs.md): we do
+	// NOT erase any entries from `filters`. DuckDB re-applies the predicates
+	// as a LogicalFilter above the scan, so any semantic divergence between
+	// ENA's /search matcher and SQL equality degrades to a mild inefficiency,
+	// not a correctness bug.
+}
+
 // ---- Progress ----
 
 double ReadENAAttributesTableFunction::Progress(ClientContext &context, const FunctionData *bind_data,
@@ -226,6 +426,7 @@ double ReadENAAttributesTableFunction::Progress(ClientContext &context, const Fu
 TableFunction ReadENAAttributesTableFunction::GetFunction() {
 	auto tf = TableFunction("read_ena_attributes", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
 	tf.table_scan_progress = Progress;
+	tf.pushdown_complex_filter = PushdownComplexFilter;
 	return tf;
 }
 

--- a/src/read_ena_attributes.cpp
+++ b/src/read_ena_attributes.cpp
@@ -13,7 +13,7 @@ ReadENAAttributesTableFunction::Data::Data(std::vector<std::string> accessions)
 // ---- GlobalState ----
 
 ReadENAAttributesTableFunction::GlobalState::GlobalState(DatabaseInstance &db)
-    : client(make_uniq<miint::ENAClient>(db)), row_offset(0), fetched(false) {
+    : client(make_uniq<miint::ENAClient>(db)) {
 }
 
 std::vector<std::string>
@@ -59,32 +59,29 @@ ReadENAAttributesTableFunction::GlobalState::ResolveSampleAccessions(const std::
 	return sample_accs;
 }
 
-void ReadENAAttributesTableFunction::GlobalState::FetchAttributes(const std::vector<std::string> &accessions) {
-	// Mark as fetched immediately to avoid infinite retry loops on network errors
-	fetched = true;
+void ReadENAAttributesTableFunction::GlobalState::ResolveAccessions(const std::vector<std::string> &accessions) {
+	// Mark as resolved immediately so that a network error during the
+	// Search call below doesn't cause successive Execute callbacks to keep
+	// retrying the same failing request in a loop.
+	resolved = true;
+	pending_sample_accs = ResolveSampleAccessions(accessions);
+	total_samples_expected.store(pending_sample_accs.size(), std::memory_order_relaxed);
+	samples_fetched.store(0, std::memory_order_relaxed);
+}
 
-	auto sample_accs = ResolveSampleAccessions(accessions);
-
-	if (sample_accs.empty()) {
-		return;
+bool ReadENAAttributesTableFunction::GlobalState::FetchNextBatch() {
+	if (pending_sample_accs.empty()) {
+		return false;
 	}
+	size_t n = std::min<size_t>(BATCH_SIZE, pending_sample_accs.size());
+	std::vector<std::string> batch(pending_sample_accs.begin(), pending_sample_accs.begin() + n);
+	pending_sample_accs.erase(pending_sample_accs.begin(), pending_sample_accs.begin() + n);
 
-	// NOTE: This materializes all attributes before returning any rows.
-	// For large studies (thousands of samples), this may use significant memory
-	// and block until all XML batches are fetched. A streaming approach would
-	// be better for very large studies.
-	static constexpr size_t BATCH_SIZE = 50;
-	for (size_t start = 0; start < sample_accs.size(); start += BATCH_SIZE) {
-		size_t end = std::min(start + BATCH_SIZE, sample_accs.size());
-		std::vector<std::string> batch(sample_accs.begin() + start, sample_accs.begin() + end);
-
-		auto xml = client->FetchXML(batch);
-		auto batch_attrs = miint::ENAParser::ParseSampleAttributesXML(xml);
-
-		for (auto &attr : batch_attrs) {
-			attributes.push_back(std::move(attr));
-		}
-	}
+	auto xml = client->FetchXML(batch);
+	current_batch = miint::ENAParser::ParseSampleAttributesXML(xml);
+	current_batch_offset = 0;
+	samples_fetched.fetch_add(n, std::memory_order_relaxed);
+	return true;
 }
 
 // ---- Bind ----
@@ -154,21 +151,26 @@ void ReadENAAttributesTableFunction::Execute(ClientContext &context, TableFuncti
 
 	lock_guard<mutex> guard(global_state.lock);
 
-	// Fetch all attributes on first call
-	if (!global_state.fetched) {
-		global_state.FetchAttributes(bind_data.accessions);
+	// First call: resolve input accessions to a list of sample accessions.
+	// Subsequent fetches happen lazily one batch at a time below.
+	if (!global_state.resolved) {
+		global_state.ResolveAccessions(bind_data.accessions);
 	}
 
-	if (global_state.row_offset >= global_state.attributes.size()) {
-		output.SetCardinality(0);
-		return;
+	// Advance to the next fetched batch if we've drained the current one.
+	// Loop to skip empty batches (a 50-sample batch whose XML has no sample
+	// with any attributes would otherwise end the scan prematurely).
+	while (global_state.current_batch_offset >= global_state.current_batch.size()) {
+		if (!global_state.FetchNextBatch()) {
+			output.SetCardinality(0);
+			return;
+		}
 	}
 
-	idx_t remaining = global_state.attributes.size() - global_state.row_offset;
+	auto &attrs = global_state.current_batch;
+	size_t offset = global_state.current_batch_offset;
+	idx_t remaining = attrs.size() - offset;
 	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
-
-	auto &attrs = global_state.attributes;
-	size_t offset = global_state.row_offset;
 
 	// sample_accession (column 0)
 	auto acc_data = FlatVector::GetData<string_t>(output.data[0]);
@@ -194,14 +196,36 @@ void ReadENAAttributesTableFunction::Execute(ClientContext &context, TableFuncti
 		}
 	}
 
-	global_state.row_offset += count;
+	global_state.current_batch_offset += count;
 	output.SetCardinality(count);
+}
+
+// ---- Progress ----
+
+double ReadENAAttributesTableFunction::Progress(ClientContext &context, const FunctionData *bind_data,
+                                                const GlobalTableFunctionState *global_state) {
+	if (!global_state) {
+		return -1.0;
+	}
+	auto &state = global_state->Cast<GlobalState>();
+	// Before ResolveAccessions runs we don't know the scale of the work. Once
+	// resolved, report samples-fetched / total. This gives users visible
+	// progress for large studies like PRJEB11419 (33k+ samples) where a full
+	// scan is long-running by nature.
+	size_t total = state.total_samples_expected.load(std::memory_order_relaxed);
+	if (total == 0) {
+		return -1.0;
+	}
+	size_t fetched = state.samples_fetched.load(std::memory_order_relaxed);
+	double pct = 100.0 * static_cast<double>(fetched) / static_cast<double>(total);
+	return std::min(100.0, pct);
 }
 
 // ---- Registration ----
 
 TableFunction ReadENAAttributesTableFunction::GetFunction() {
 	auto tf = TableFunction("read_ena_attributes", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
+	tf.table_scan_progress = Progress;
 	return tf;
 }
 

--- a/src/read_ena_searchable_fields.cpp
+++ b/src/read_ena_searchable_fields.cpp
@@ -1,0 +1,168 @@
+#include "read_ena_searchable_fields.hpp"
+
+#include "duckdb/common/vector_size.hpp"
+
+#include <sstream>
+
+namespace duckdb {
+
+// ---- Data / GlobalState ----
+
+ReadENASearchableFieldsTableFunction::Data::Data(std::string result_type) : result_type(std::move(result_type)) {
+}
+
+ReadENASearchableFieldsTableFunction::GlobalState::GlobalState(DatabaseInstance &db)
+    : client(make_uniq<miint::ENAClient>(db)) {
+}
+
+// ---- Bind ----
+
+unique_ptr<FunctionData> ReadENASearchableFieldsTableFunction::Bind(ClientContext &context,
+                                                                    TableFunctionBindInput &input,
+                                                                    vector<LogicalType> &return_types,
+                                                                    vector<std::string> &names) {
+	if (input.inputs.empty() || input.inputs[0].IsNull()) {
+		throw InvalidInputException(
+		    "ena_searchable_fields: result_type is required (e.g., 'sample', 'read_run', 'study', 'experiment')");
+	}
+	if (input.inputs[0].type().id() != LogicalTypeId::VARCHAR) {
+		throw InvalidInputException("ena_searchable_fields: result_type must be VARCHAR");
+	}
+	std::string result_type = input.inputs[0].ToString();
+
+	// Trim whitespace and reject empty.
+	auto first = result_type.find_first_not_of(" \t\n\r");
+	if (first == std::string::npos) {
+		throw InvalidInputException("ena_searchable_fields: result_type cannot be empty");
+	}
+	auto last = result_type.find_last_not_of(" \t\n\r");
+	result_type = result_type.substr(first, last - first + 1);
+
+	// Validate: ENA's /returnFields endpoint accepts a result-type identifier.
+	// Apply the same charset policy as `ENAParser::ValidateAccession` (alnum +
+	// _-.) to prevent URL injection.
+	for (char c : result_type) {
+		if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_' && c != '-' && c != '.') {
+			throw InvalidInputException(
+			    "ena_searchable_fields: result_type contains invalid characters (allowed: alphanumeric, _ - .)");
+		}
+	}
+
+	names.emplace_back("field_name");
+	names.emplace_back("type");
+	names.emplace_back("description");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::VARCHAR);
+
+	return make_uniq<Data>(std::move(result_type));
+}
+
+// ---- InitGlobal / InitLocal ----
+
+unique_ptr<GlobalTableFunctionState> ReadENASearchableFieldsTableFunction::InitGlobal(ClientContext &context,
+                                                                                      TableFunctionInitInput &input) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	return make_uniq<GlobalState>(db);
+}
+
+unique_ptr<LocalTableFunctionState>
+ReadENASearchableFieldsTableFunction::InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                GlobalTableFunctionState *global_state) {
+	return make_uniq<LocalState>();
+}
+
+// ---- Execute ----
+
+void ReadENASearchableFieldsTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p,
+                                                   DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &global = data_p.global_state->Cast<GlobalState>();
+	lock_guard<mutex> guard(global.lock);
+
+	// One-shot fetch on first call. Set `fetched` before making the request so
+	// that a network error doesn't trap us in a per-chunk retry loop.
+	if (!global.fetched) {
+		global.fetched = true;
+		std::ostringstream url;
+		url << miint::ENAParser::PORTAL_BASE << "/returnFields?result=" << bind_data.result_type << "&format=tsv";
+		auto tsv = global.client->FetchURL(url.str());
+		auto parsed = miint::ENAParser::ParseTSV(tsv);
+
+		// Locate the columns by header name so we're robust to ENA reordering.
+		int col_id = -1;
+		int col_type = -1;
+		int col_desc = -1;
+		for (size_t i = 0; i < parsed.column_names.size(); i++) {
+			const auto &name = parsed.column_names[i];
+			if (name == "columnId" || name == "field_name") {
+				col_id = static_cast<int>(i);
+			} else if (name == "type") {
+				col_type = static_cast<int>(i);
+			} else if (name == "description") {
+				col_desc = static_cast<int>(i);
+			}
+		}
+		if (col_id < 0) {
+			throw IOException(
+			    "ena_searchable_fields: /returnFields response missing expected 'columnId' header (result_type='%s')",
+			    bind_data.result_type);
+		}
+		for (const auto &row : parsed.rows) {
+			std::array<std::string, 3> out {};
+			if (col_id >= 0 && static_cast<size_t>(col_id) < row.size()) {
+				out[0] = row[col_id];
+			}
+			if (col_type >= 0 && static_cast<size_t>(col_type) < row.size()) {
+				out[1] = row[col_type];
+			}
+			if (col_desc >= 0 && static_cast<size_t>(col_desc) < row.size()) {
+				out[2] = row[col_desc];
+			}
+			if (out[0].empty()) {
+				// Skip rows with no field name — unlikely but a corrupt TSV
+				// row shouldn't show up as a blank in the output.
+				continue;
+			}
+			global.rows.push_back(std::move(out));
+		}
+	}
+
+	idx_t remaining = global.rows.size() - global.offset;
+	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+	if (count == 0) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	auto name_data = FlatVector::GetData<string_t>(output.data[0]);
+	auto type_data = FlatVector::GetData<string_t>(output.data[1]);
+	auto desc_data = FlatVector::GetData<string_t>(output.data[2]);
+	auto &desc_validity = FlatVector::Validity(output.data[2]);
+
+	for (idx_t i = 0; i < count; i++) {
+		const auto &row = global.rows[global.offset + i];
+		name_data[i] = StringVector::AddString(output.data[0], row[0]);
+		type_data[i] = StringVector::AddString(output.data[1], row[1]);
+		if (row[2].empty()) {
+			desc_validity.SetInvalid(i);
+		} else {
+			desc_data[i] = StringVector::AddString(output.data[2], row[2]);
+		}
+	}
+
+	global.offset += count;
+	output.SetCardinality(count);
+}
+
+// ---- Registration ----
+
+TableFunction ReadENASearchableFieldsTableFunction::GetFunction() {
+	return TableFunction("ena_searchable_fields", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal, InitLocal);
+}
+
+void ReadENASearchableFieldsTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/read_ena_sequences.cpp
+++ b/src/read_ena_sequences.cpp
@@ -148,8 +148,14 @@ unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &cont
 		}
 	}
 
+	// Named as `trim_sff` rather than `trim` to avoid a parser/binder clash: TRIM
+	// is a SQL function keyword, and read_ena_sequences is a dual-path function
+	// (`function` + `in_out_function`) where DuckDB's binder routes any non-
+	// scalar argument — including `name=value` syntax — through the in-out path,
+	// which skips named-parameter extraction. `trim_sff => false` survives both
+	// issues. Internal identifiers keep the shorter `trim` name.
 	bool trim = true;
-	auto trim_param = input.named_parameters.find("trim");
+	auto trim_param = input.named_parameters.find("trim_sff");
 	if (trim_param != input.named_parameters.end() && !trim_param->second.IsNull()) {
 		trim = trim_param->second.GetValue<bool>();
 	}
@@ -748,7 +754,7 @@ TableFunction ReadENASequencesTableFunction::GetFunction() {
 	tf.named_parameters["qual_offset"] = LogicalType::BIGINT;
 	tf.named_parameters["download_method"] = LogicalType::VARCHAR;
 	tf.named_parameters["prefer_format"] = LogicalType::VARCHAR;
-	tf.named_parameters["trim"] = LogicalType::BOOLEAN;
+	tf.named_parameters["trim_sff"] = LogicalType::BOOLEAN;
 	tf.named_parameters["max_sequences"] = LogicalType::BIGINT;
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	tf.table_scan_progress = Progress;

--- a/src/read_ena_sequences.cpp
+++ b/src/read_ena_sequences.cpp
@@ -1,5 +1,6 @@
 #include "read_ena_sequences.hpp"
 #include "SequenceRecord.hpp"
+#include "ena_resolver_cache.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include <cerrno>
@@ -9,8 +10,8 @@ namespace duckdb {
 
 // ---- Data ----
 
-ReadENASequencesTableFunction::Data::Data(std::vector<RunInfo> runs, bool include_fp, uint8_t offset, bool trim,
-                                          const std::string &prefer_format)
+ReadENASequencesTableFunction::Data::Data(std::vector<miint::ENARunInfo> runs, bool include_fp, uint8_t offset,
+                                          bool trim, const std::string &prefer_format)
     : runs(std::move(runs)), include_filepath(include_fp), qual_offset(offset), use_aspera(false), trim(trim),
       prefer_format(prefer_format), names({"sequence_index", "read_id", "comment", "sequence1", "sequence2", "qual1",
                                            "qual2", "run_accession", "sample_accession", "experiment_accession"}),
@@ -25,7 +26,7 @@ ReadENASequencesTableFunction::Data::Data(std::vector<RunInfo> runs, bool includ
 
 // ---- GlobalState ----
 
-ReadENASequencesTableFunction::GlobalState::GlobalState(FileSystem &fs, const std::vector<RunInfo> &runs,
+ReadENASequencesTableFunction::GlobalState::GlobalState(FileSystem &fs, const std::vector<miint::ENARunInfo> &runs,
                                                         bool use_aspera, bool trim)
     : runs(runs), next_run_idx(0), fs(fs), use_aspera(use_aspera), trim(trim), runs_completed(0),
       total_runs(runs.size()), bytes_completed(0), skipped_warned(false) {
@@ -303,169 +304,32 @@ void ReadENASequencesTableFunction::GlobalState::OpenReaderAspera(size_t run_idx
 
 // ---- Bind ----
 
-// Helper: get column value from a TSV row, or empty string if not present
-static std::string GetCol(const std::vector<std::string> &row, int col) {
-	return (col >= 0 && col < static_cast<int>(row.size())) ? row[col] : "";
-}
+// Resolve accessions to run info via ENA Portal API (batched + cached).
+// Preserves input order: multi-run accessions (e.g., studies) are flattened in the
+// order ENA returns them; across distinct accessions the caller's input order is kept.
+//
+// Cache lifetime: the cache is constructed locally and lives only for this call.
+// For Phase B (lateral / in_out_function) we need the cache to survive across
+// per-outer-row ExecuteInOut invocations — promote ownership to the bind Data
+// (or GlobalState) at that point.
+static std::vector<miint::ENARunInfo> ResolveRuns(miint::ENAClient &client, const std::vector<std::string> &accessions,
+                                                  const std::string &prefer_format) {
+	miint::ENAResolverCache cache(256);
+	miint::ENAFetcher fetcher = [&client](const std::string &url) {
+		return client.FetchURL(url);
+	};
+	auto resolved = miint::ResolveRunsBatch(fetcher, cache, accessions, prefer_format);
 
-// Resolve accessions to run info via ENA Portal API
-static std::vector<ReadENASequencesTableFunction::RunInfo>
-ResolveRuns(miint::ENAClient &client, const std::vector<std::string> &accessions, const std::string &prefer_format) {
-	std::vector<ReadENASequencesTableFunction::RunInfo> runs;
-
+	std::vector<miint::ENARunInfo> runs;
 	for (const auto &acc : accessions) {
-		auto tsv = client.Search(acc, "read_run",
-		                         "run_accession,sample_accession,experiment_accession,"
-		                         "fastq_ftp,fastq_aspera,fastq_bytes,library_layout,"
-		                         "submitted_ftp,submitted_aspera,submitted_bytes,submitted_format");
-		auto parsed = miint::ENAParser::ParseTSV(tsv);
-
-		// Find column indices by name
-		int run_col = -1, sample_col = -1, exp_col = -1, ftp_col = -1, aspera_col = -1, bytes_col = -1, layout_col = -1;
-		int sub_ftp_col = -1, sub_aspera_col = -1, sub_bytes_col = -1, sub_format_col = -1;
-		for (size_t i = 0; i < parsed.column_names.size(); i++) {
-			const auto &name = parsed.column_names[i];
-			if (name == "run_accession")
-				run_col = static_cast<int>(i);
-			else if (name == "sample_accession")
-				sample_col = static_cast<int>(i);
-			else if (name == "experiment_accession")
-				exp_col = static_cast<int>(i);
-			else if (name == "fastq_ftp")
-				ftp_col = static_cast<int>(i);
-			else if (name == "fastq_aspera")
-				aspera_col = static_cast<int>(i);
-			else if (name == "fastq_bytes")
-				bytes_col = static_cast<int>(i);
-			else if (name == "library_layout")
-				layout_col = static_cast<int>(i);
-			else if (name == "submitted_ftp")
-				sub_ftp_col = static_cast<int>(i);
-			else if (name == "submitted_aspera")
-				sub_aspera_col = static_cast<int>(i);
-			else if (name == "submitted_bytes")
-				sub_bytes_col = static_cast<int>(i);
-			else if (name == "submitted_format")
-				sub_format_col = static_cast<int>(i);
+		auto it = resolved.find(acc);
+		if (it == resolved.end()) {
+			continue;
 		}
-
-		for (const auto &row : parsed.rows) {
-			std::string run_accession = GetCol(row, run_col);
-			std::string sample_accession = GetCol(row, sample_col);
-			std::string experiment_accession = GetCol(row, exp_col);
-			std::string ftp_field = GetCol(row, ftp_col);
-			std::string aspera_field = GetCol(row, aspera_col);
-			std::string bytes_field = GetCol(row, bytes_col);
-			std::string layout = GetCol(row, layout_col);
-
-			auto fastq_urls = miint::ENAParser::FTPtoHTTPS(ftp_field);
-			bool has_fastq = !fastq_urls.empty();
-
-			// Check for submitted SFF files
-			std::string sub_ftp = GetCol(row, sub_ftp_col);
-			std::string sub_aspera = GetCol(row, sub_aspera_col);
-			std::string sub_bytes = GetCol(row, sub_bytes_col);
-			std::string sub_format = GetCol(row, sub_format_col);
-			auto sff_filter =
-			    miint::ENAParser::FilterSubmittedByFormat(sub_ftp, sub_aspera, sub_format, sub_bytes, "SFF");
-			bool has_sff = !sff_filter.urls.empty();
-
-			// Format selection:
-			// - 'sff':   use SFF if available, otherwise fall back to FASTQ silently
-			// - 'auto':  use FASTQ if available, otherwise fall back to SFF
-			// - 'fastq': FASTQ only, skip runs that lack FASTQ
-			bool use_sff = false;
-			if (prefer_format == "sff") {
-				use_sff = has_sff;
-			} else if (prefer_format == "auto") {
-				use_sff = !has_fastq && has_sff;
-			}
-
-			if (use_sff) {
-				// Flatten: one RunInfo per SFF file, all sharing the same accession metadata
-				for (size_t si = 0; si < sff_filter.urls.size(); si++) {
-					ReadENASequencesTableFunction::RunInfo info;
-					info.run_accession = run_accession;
-					info.sample_accession = sample_accession;
-					info.experiment_accession = experiment_accession;
-					info.format = ENASequenceFormat::SFF;
-					info.sff_url = sff_filter.urls[si];
-					info.is_paired = false; // SFF is always single-end
-					info.total_bytes = sff_filter.total_bytes / sff_filter.urls.size();
-					runs.push_back(std::move(info));
-				}
-			} else if (has_fastq) {
-				// Standard FASTQ path (existing behavior)
-				ReadENASequencesTableFunction::RunInfo info;
-				info.run_accession = run_accession;
-				info.sample_accession = sample_accession;
-				info.experiment_accession = experiment_accession;
-				info.fastq_urls = std::move(fastq_urls);
-				info.aspera_paths = miint::AsperaUtils::ParseAsperaPaths(aspera_field);
-				info.is_paired = (layout == "PAIRED");
-
-				// Parse fastq_bytes
-				std::vector<uint64_t> file_bytes;
-				if (!bytes_field.empty()) {
-					std::string::size_type bstart = 0;
-					while (true) {
-						auto bsemi = bytes_field.find(';', bstart);
-						std::string bs = (bsemi == std::string::npos) ? bytes_field.substr(bstart)
-						                                              : bytes_field.substr(bstart, bsemi - bstart);
-						try {
-							file_bytes.push_back(std::stoull(bs));
-						} catch (...) {
-							file_bytes.push_back(0);
-						}
-						if (bsemi == std::string::npos) {
-							break;
-						}
-						bstart = bsemi + 1;
-					}
-				}
-
-				// ENA 3-file paired-end filtering (existing logic)
-				if (info.is_paired && info.fastq_urls.size() > 2) {
-					std::vector<std::string> filtered;
-					std::vector<uint64_t> filtered_bytes;
-					for (size_t fi = 0; fi < info.fastq_urls.size(); fi++) {
-						if (info.fastq_urls[fi].find("_1.fast") != std::string::npos ||
-						    info.fastq_urls[fi].find("_2.fast") != std::string::npos) {
-							filtered.push_back(info.fastq_urls[fi]);
-							if (fi < file_bytes.size()) {
-								filtered_bytes.push_back(file_bytes[fi]);
-							}
-						}
-					}
-					if (filtered.size() == 2) {
-						info.fastq_urls = std::move(filtered);
-						file_bytes = std::move(filtered_bytes);
-					}
-				}
-				if (info.is_paired && info.aspera_paths.size() > 2) {
-					std::vector<miint::AsperaPath> filtered;
-					for (const auto &ap : info.aspera_paths) {
-						if (ap.remote_path.find("_1.fast") != std::string::npos ||
-						    ap.remote_path.find("_2.fast") != std::string::npos) {
-							filtered.push_back(ap);
-						}
-					}
-					if (filtered.size() == 2) {
-						info.aspera_paths = std::move(filtered);
-					}
-				}
-
-				info.total_bytes = 0;
-				for (auto b : file_bytes) {
-					info.total_bytes += b;
-				}
-
-				runs.push_back(std::move(info));
-			}
-			// else: no FASTQ and no SFF (or prefer_format='fastq' with no FASTQ) — skip run
+		for (const auto &info : it->second) {
+			runs.push_back(info);
 		}
 	}
-
 	return runs;
 }
 
@@ -555,7 +419,7 @@ unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &cont
 	// Check if there are any FASTX runs that could benefit from Aspera
 	bool has_fastx_runs = false;
 	for (const auto &run : data->runs) {
-		if (run.format == ENASequenceFormat::FASTX) {
+		if (run.format == miint::ENASequenceFormat::FASTX) {
 			has_fastx_runs = true;
 			break;
 		}
@@ -570,7 +434,7 @@ unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &cont
 			// Check that all FASTX runs have aspera paths
 			bool all_have_aspera = true;
 			for (const auto &run : data->runs) {
-				if (run.format == ENASequenceFormat::FASTX && run.aspera_paths.empty()) {
+				if (run.format == miint::ENASequenceFormat::FASTX && run.aspera_paths.empty()) {
 					all_have_aspera = false;
 					break;
 				}
@@ -640,7 +504,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 	// Helper: tear down a failed run's reader and process
 	auto cleanup_run = [&](size_t idx) {
 		auto &run = global_state.runs[idx];
-		if (run.format == ENASequenceFormat::SFF) {
+		if (run.format == miint::ENASequenceFormat::SFF) {
 			global_state.sff_readers[idx].reset();
 			if (!global_state.sff_temp_paths[idx].empty()) {
 				std::remove(global_state.sff_temp_paths[idx].c_str());
@@ -663,7 +527,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 	// Helper: open reader for the current run
 	auto open_run = [&](size_t idx) {
 		auto &run = global_state.runs[idx];
-		if (run.format == ENASequenceFormat::SFF) {
+		if (run.format == miint::ENASequenceFormat::SFF) {
 			global_state.OpenReaderSFF(idx);
 		} else {
 #if MIINT_ASPERA_SUPPORTED
@@ -743,7 +607,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 		// Read batch — dispatch based on format
 		auto read_batch = [&]() -> miint::SequenceRecordBatch {
 			auto &run = global_state.runs[current_run_idx];
-			if (run.format == ENASequenceFormat::SFF) {
+			if (run.format == miint::ENASequenceFormat::SFF) {
 				return global_state.sff_readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
 			} else {
 				return global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
@@ -780,7 +644,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 		if (batch.empty()) {
 			// Run completed successfully — release resources
 			auto &completed_run = global_state.runs[current_run_idx];
-			if (completed_run.format == ENASequenceFormat::SFF) {
+			if (completed_run.format == miint::ENASequenceFormat::SFF) {
 				global_state.sff_readers[current_run_idx].reset();
 				if (!global_state.sff_temp_paths[current_run_idx].empty()) {
 					std::remove(global_state.sff_temp_paths[current_run_idx].c_str());
@@ -841,7 +705,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 
 	// qual1 (column 5)
 	// SFF stores raw Phred internally with offset 33; user's qual_offset only applies to FASTQ
-	uint8_t effective_qual_offset = (run.format == ENASequenceFormat::SFF) ? 33 : bind_data.qual_offset;
+	uint8_t effective_qual_offset = (run.format == miint::ENASequenceFormat::SFF) ? 33 : bind_data.qual_offset;
 	SetResultVectorListUInt8(output.data[field_idx++], batch.quals1, effective_qual_offset);
 
 	// qual2 (column 6)
@@ -863,7 +727,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 	// filepath (column 10) - optional
 	if (bind_data.include_filepath) {
 		std::string filepath;
-		if (run.format == ENASequenceFormat::SFF) {
+		if (run.format == miint::ENASequenceFormat::SFF) {
 			filepath = run.sff_url;
 		} else if (bind_data.use_aspera && !run.aspera_paths.empty()) {
 			filepath = run.aspera_paths[0].host + ":" + run.aspera_paths[0].remote_path;

--- a/src/read_ena_sequences.cpp
+++ b/src/read_ena_sequences.cpp
@@ -154,6 +154,22 @@ unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &cont
 		trim = trim_param->second.GetValue<bool>();
 	}
 
+	// `max_sequences`: 0 / NULL / absent = unlimited. Negative values are a
+	// user error caught here rather than silently coerced, matching the
+	// one-named-parameter-rejects-garbage precedent of qual_offset /
+	// download_method / prefer_format above.
+	uint64_t max_sequences = 0;
+	auto ms_param = input.named_parameters.find("max_sequences");
+	if (ms_param != input.named_parameters.end() && !ms_param->second.IsNull()) {
+		int64_t raw = ms_param->second.GetValue<int64_t>();
+		if (raw < 0) {
+			throw InvalidInputException(
+			    "read_ena_sequences: max_sequences must be >= 0 (got %lld; use 0 for unlimited)",
+			    static_cast<long long>(raw));
+		}
+		max_sequences = static_cast<uint64_t>(raw);
+	}
+
 	auto &db = DatabaseInstance::GetDatabase(context);
 
 	std::vector<miint::ENARunInfo> runs;
@@ -170,6 +186,7 @@ unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &cont
 	auto data = make_uniq<Data>(std::move(runs), include_filepath, qual_offset, trim, prefer_format);
 	data->deferred_resolution = deferred;
 	data->db_ptr = &db;
+	data->max_sequences = max_sequences;
 	if (deferred) {
 		// Per-bind cache + ENAClient: metadata lookups across outer rows dedupe
 		// and the ENAClient's rate limiter (~3 req/sec) throttles globally.
@@ -286,7 +303,8 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 		}
 #endif
 		return std::make_unique<miint::PerRunReader>(global_state.fs, global_state.runs[idx], global_state.use_aspera,
-		                                             global_state.trim, global_state.open_mutex, cfg);
+		                                             global_state.trim, global_state.open_mutex, cfg,
+		                                             bind_data.max_sequences);
 	};
 
 	miint::SequenceRecordBatch batch;
@@ -544,9 +562,9 @@ OperatorResultType ReadENASequencesTableFunction::ExecuteInOut(ExecutionContext 
 	// and for retry-after-failure. Lateral path always uses HTTP (Bind rejects
 	// download_method='aspera' in deferred mode).
 	auto make_reader_for = [&](const miint::ENARunInfo &run) {
-		return std::make_unique<miint::PerRunReader>(global.fs, run, /*use_aspera=*/false, bind_data.trim,
-		                                             global.open_mutex,
-		                                             static_cast<const miint::AsperaConfig *>(nullptr));
+		return std::make_unique<miint::PerRunReader>(
+		    global.fs, run, /*use_aspera=*/false, bind_data.trim, global.open_mutex,
+		    static_cast<const miint::AsperaConfig *>(nullptr), bind_data.max_sequences);
 	};
 
 	// Phase 1: need a fresh outer row → pull and resolve.
@@ -731,6 +749,7 @@ TableFunction ReadENASequencesTableFunction::GetFunction() {
 	tf.named_parameters["download_method"] = LogicalType::VARCHAR;
 	tf.named_parameters["prefer_format"] = LogicalType::VARCHAR;
 	tf.named_parameters["trim"] = LogicalType::BOOLEAN;
+	tf.named_parameters["max_sequences"] = LogicalType::BIGINT;
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	tf.table_scan_progress = Progress;
 	return tf;

--- a/src/read_ena_sequences.cpp
+++ b/src/read_ena_sequences.cpp
@@ -36,271 +36,8 @@ ReadENASequencesTableFunction::GlobalState::GlobalState(FileSystem &fs, const st
 	}
 	total_bytes = sum_bytes;
 	readers.resize(runs.size());
-	sff_readers.resize(runs.size());
-	sff_temp_paths.resize(runs.size());
 	run_sequence_counters.resize(runs.size(), 1);
-#if MIINT_ASPERA_SUPPORTED
-	aspera_processes.resize(runs.size());
-	temp_file_paths.resize(runs.size());
-#endif
 }
-
-ReadENASequencesTableFunction::GlobalState::~GlobalState() {
-	// Clean up SFF temp files
-	for (auto &path : sff_temp_paths) {
-		if (!path.empty()) {
-			std::remove(path.c_str());
-			path.clear();
-		}
-	}
-#if MIINT_ASPERA_SUPPORTED
-	for (auto &path : temp_file_paths) {
-		if (!path.empty()) {
-			std::remove(path.c_str());
-			path.clear();
-		}
-	}
-	// AsperaProcess destructors handle killing children + closing pipes
-#endif
-}
-
-void ReadENASequencesTableFunction::GlobalState::OpenReader(size_t run_idx) {
-	if (readers[run_idx]) {
-		return;
-	}
-	const auto &run = runs[run_idx];
-	if (run.fastq_urls.empty()) {
-		throw IOException("read_ena_sequences: no FASTQ URLs available for run '%s'", run.run_accession);
-	}
-
-	// Serialize file opens to avoid overwhelming remote servers with
-	// simultaneous HTTP HEAD requests (e.g., EBI rejects concurrent connections).
-	// Reading from opened files is still fully parallel — only the open is serialized.
-	lock_guard<mutex> open_guard(open_mutex);
-
-	auto *s1 = CreateDuckDBSeqStream(fs, run.fastq_urls[0]);
-	miint::DuckDBSeqStream *s2 = nullptr;
-	if (run.is_paired && run.fastq_urls.size() >= 2) {
-		s2 = CreateDuckDBSeqStream(fs, run.fastq_urls[1]);
-	}
-
-	try {
-		readers[run_idx] = std::make_unique<miint::SequenceReader>(s1, static_cast<miint::DuckDBSeqStream *>(s2), true);
-	} catch (const std::runtime_error &e) {
-		if (s2 && std::string(e.what()) == "Empty stream (sequence2)") {
-			// ENA metadata may report PAIRED layout but the second FASTQ file
-			// can be empty (e.g., single-end data deposited with PAIRED metadata).
-			// The failed constructor consumed the original streams, so re-open
-			// just the first file and fall back to single-end for this run.
-			auto *s1_retry = CreateDuckDBSeqStream(fs, run.fastq_urls[0]);
-			readers[run_idx] =
-			    std::make_unique<miint::SequenceReader>(s1_retry, static_cast<miint::DuckDBSeqStream *>(nullptr), true);
-		} else {
-			throw;
-		}
-	}
-}
-
-void ReadENASequencesTableFunction::GlobalState::OpenReaderSFF(size_t run_idx) {
-	if (sff_readers[run_idx]) {
-		return;
-	}
-	const auto &run = runs[run_idx];
-	if (run.sff_url.empty()) {
-		throw IOException("read_ena_sequences: no SFF URL available for run '%s'", run.run_accession);
-	}
-
-	// Create temp file for the SFF download
-	auto temp_dir = miint::GetTempDir();
-	auto temp_path = temp_dir + "/miint_ena_sff_XXXXXX";
-	std::vector<char> tmpl_buf(temp_path.begin(), temp_path.end());
-	tmpl_buf.push_back('\0');
-	int fd = mkstemp(tmpl_buf.data());
-	if (fd == -1) {
-		throw IOException("read_ena_sequences: failed to create temp file for SFF download");
-	}
-	temp_path = std::string(tmpl_buf.data());
-	sff_temp_paths[run_idx] = temp_path;
-
-	// RAII guard: ensures fd is closed exactly once and temp file is removed on error
-	bool fd_closed = false;
-	auto cleanup_on_error = [&]() {
-		if (!fd_closed) {
-			close(fd);
-			fd_closed = true;
-		}
-		std::remove(temp_path.c_str());
-		sff_temp_paths[run_idx].clear();
-	};
-
-	try {
-		// Serialize only the HTTP connection setup, not the full download.
-		// This avoids blocking all threads for the duration of multi-MB downloads
-		// while still rate-limiting simultaneous connection opens to remote servers.
-		unique_ptr<FileHandle> source;
-		{
-			lock_guard<mutex> open_guard(open_mutex);
-			source = fs.OpenFile(run.sff_url, FileOpenFlags(FileOpenFlags::FILE_FLAGS_READ));
-		}
-
-		static constexpr size_t DOWNLOAD_BUF_SIZE = 1048576; // 1MB
-		std::vector<char> buf(DOWNLOAD_BUF_SIZE);
-		while (true) {
-			auto bytes_read = source->Read(buf.data(), DOWNLOAD_BUF_SIZE);
-			if (bytes_read == 0) {
-				break;
-			}
-			size_t written = 0;
-			while (written < bytes_read) {
-				ssize_t w = write(fd, buf.data() + written, bytes_read - written);
-				if (w < 0) {
-					if (errno == EINTR) {
-						continue;
-					}
-					int saved_errno = errno;
-					cleanup_on_error();
-					throw IOException("read_ena_sequences: failed writing SFF temp file for run '%s' (errno=%d: %s)",
-					                  run.run_accession, saved_errno, strerror(saved_errno));
-				}
-				written += static_cast<size_t>(w);
-			}
-		}
-		close(fd);
-		fd_closed = true;
-	} catch (...) {
-		cleanup_on_error();
-		throw;
-	}
-
-	sff_readers[run_idx] = std::make_unique<miint::SFFReader>(temp_path, trim);
-}
-
-#if MIINT_ASPERA_SUPPORTED
-
-void ReadENASequencesTableFunction::GlobalState::OpenReaderAspera(size_t run_idx) {
-	if (readers[run_idx]) {
-		return;
-	}
-	const auto &run = runs[run_idx];
-
-	// Collect remote paths for this run only
-	std::vector<std::string> remote_paths;
-	for (const auto &ap : run.aspera_paths) {
-		remote_paths.push_back(ap.remote_path);
-	}
-
-	auto config = aspera_config;
-	if (!run.aspera_paths.empty()) {
-		config.host = run.aspera_paths[0].host;
-	}
-
-	// Serialize ascp launches (fork/exec) — pipe reads happen on each thread's own pipe
-	{
-		lock_guard<mutex> open_guard(open_mutex);
-		aspera_processes[run_idx] = std::make_unique<miint::AsperaProcess>(config, remote_paths);
-	}
-	auto *proc = aspera_processes[run_idx].get();
-
-	std::string filename;
-	size_t file_size;
-
-	if (!proc->NextFile(filename, file_size)) {
-		throw IOException("read_ena_sequences: Aspera stream ended unexpectedly (expected files for run '%s')",
-		                  run.run_accession);
-	}
-
-	// Determine gzip from tar filename, fall back to aspera path if available
-	std::string gz_hint = filename;
-	if (gz_hint.empty() && !run.aspera_paths.empty()) {
-		gz_hint = run.aspera_paths[0].remote_path;
-	}
-	bool is_gz = IsGzipped(gz_hint);
-
-	if (!run.is_paired) {
-		auto *s1 = miint::CreateAsperaSeqStream(proc, is_gz);
-		try {
-			readers[run_idx] =
-			    std::make_unique<miint::SequenceReader>(s1, static_cast<miint::AsperaSeqStream *>(nullptr), true);
-		} catch (...) {
-			delete s1;
-			throw;
-		}
-	} else {
-		// Paired-end: stream R1 from pipe to temp file in chunks, then stream R2 live
-		static constexpr size_t COPY_BUF_SIZE = 1024 * 1024; // 1 MB
-
-		std::string tmpl = miint::GetTempDir() + "/miint_aspera_r1_XXXXXX";
-		std::vector<char> tmpl_buf(tmpl.begin(), tmpl.end());
-		tmpl_buf.push_back('\0');
-		int fd = mkstemp(tmpl_buf.data());
-		if (fd == -1) {
-			throw IOException("read_ena_sequences: failed to create temp file for paired-end Aspera buffering");
-		}
-		temp_file_paths[run_idx] = std::string(tmpl_buf.data());
-
-		// Stream-copy R1 from pipe to temp file in 1MB chunks (no full-file buffering)
-		std::vector<char> copy_buf(COPY_BUF_SIZE);
-		while (true) {
-			int n = proc->ReadBounded(copy_buf.data(), COPY_BUF_SIZE);
-			if (n == 0) {
-				break;
-			}
-			if (n < 0) {
-				close(fd);
-				std::remove(temp_file_paths[run_idx].c_str());
-				temp_file_paths[run_idx].clear();
-				throw IOException("read_ena_sequences: pipe read error while buffering R1 for run '%s'",
-				                  run.run_accession);
-			}
-			size_t written = 0;
-			while (written < static_cast<size_t>(n)) {
-				ssize_t w = write(fd, copy_buf.data() + written, static_cast<size_t>(n) - written);
-				if (w < 0) {
-					if (errno == EINTR) {
-						continue;
-					}
-					int err = errno;
-					close(fd);
-					std::remove(temp_file_paths[run_idx].c_str());
-					temp_file_paths[run_idx].clear();
-					throw IOException("read_ena_sequences: failed to write temp file for paired-end Aspera buffering "
-					                  "(run '%s', errno=%d: %s)",
-					                  run.run_accession, err, strerror(err));
-				}
-				written += static_cast<size_t>(w);
-			}
-		}
-		close(fd);
-
-		// Advance tar stream to R2
-		std::string filename2;
-		size_t file_size2;
-		if (!proc->NextFile(filename2, file_size2)) {
-			std::remove(temp_file_paths[run_idx].c_str());
-			temp_file_paths[run_idx].clear();
-			throw IOException("read_ena_sequences: Aspera stream ended unexpectedly (expected R2 for run '%s')",
-			                  run.run_accession);
-		}
-
-		std::string gz_hint2 = filename2;
-		if (gz_hint2.empty() && run.aspera_paths.size() >= 2) {
-			gz_hint2 = run.aspera_paths[1].remote_path;
-		}
-		bool is_gz2 = IsGzipped(gz_hint2);
-
-		auto *s1 = CreateDuckDBSeqStream(fs, temp_file_paths[run_idx], is_gz);
-		miint::AsperaSeqStream *s2 = nullptr;
-		try {
-			s2 = miint::CreateAsperaSeqStream(proc, is_gz2);
-			readers[run_idx] = std::make_unique<miint::SequenceReader>(s1, s2, true);
-		} catch (...) {
-			delete s2;
-			delete s1;
-			throw;
-		}
-	}
-}
-#endif // MIINT_ASPERA_SUPPORTED
 
 // ---- Bind ----
 
@@ -336,31 +73,46 @@ static std::vector<miint::ENARunInfo> ResolveRuns(miint::ENAClient &client, cons
 unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
                                                              vector<LogicalType> &return_types,
                                                              vector<std::string> &names) {
-	std::vector<std::string> accessions;
-	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
-		accessions.push_back(input.inputs[0].ToString());
-	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
-		auto &list_children = ListValue::GetChildren(input.inputs[0]);
-		for (const auto &child : list_children) {
-			accessions.push_back(child.ToString());
-		}
-	} else {
-		throw InvalidInputException("read_ena_sequences: first argument must be VARCHAR or VARCHAR[]");
-	}
+	// Lateral / subquery dispatch: DuckDB's BindTableInTableOutFunction binds
+	// the expressions into a subquery and leaves `input.inputs` empty. An empty
+	// inputs vector is therefore the authoritative signal — it does not mean
+	// the user called read_ena_sequences() with no args (the function binder
+	// rejects that earlier because the overload has exactly one positional
+	// argument). A literal NULL is caught separately below with a clear error.
+	const bool deferred = input.inputs.empty();
 
-	if (accessions.empty()) {
-		throw InvalidInputException("read_ena_sequences: at least one accession must be provided");
-	}
-	for (auto &acc : accessions) {
-		// Trim whitespace
-		auto start = acc.find_first_not_of(" \t\n\r");
-		if (start == std::string::npos) {
-			acc.clear();
-		} else {
-			acc = acc.substr(start, acc.find_last_not_of(" \t\n\r") - start + 1);
+	std::vector<std::string> accessions;
+	if (!deferred) {
+		if (input.inputs[0].IsNull()) {
+			throw InvalidInputException(
+			    "read_ena_sequences: accession cannot be NULL (use a VARCHAR literal, VARCHAR[] list, "
+			    "or a correlated column / subquery for lateral mode)");
 		}
-		if (acc.empty()) {
-			throw InvalidInputException("read_ena_sequences: accession cannot be empty");
+		if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
+			accessions.push_back(input.inputs[0].ToString());
+		} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
+			auto &list_children = ListValue::GetChildren(input.inputs[0]);
+			for (const auto &child : list_children) {
+				accessions.push_back(child.ToString());
+			}
+		} else {
+			throw InvalidInputException("read_ena_sequences: first argument must be VARCHAR or VARCHAR[]");
+		}
+
+		if (accessions.empty()) {
+			throw InvalidInputException("read_ena_sequences: at least one accession must be provided");
+		}
+		for (auto &acc : accessions) {
+			// Trim whitespace
+			auto start = acc.find_first_not_of(" \t\n\r");
+			if (start == std::string::npos) {
+				acc.clear();
+			} else {
+				acc = acc.substr(start, acc.find_last_not_of(" \t\n\r") - start + 1);
+			}
+			if (acc.empty()) {
+				throw InvalidInputException("read_ena_sequences: accession cannot be empty");
+			}
 		}
 	}
 
@@ -402,52 +154,77 @@ unique_ptr<FunctionData> ReadENASequencesTableFunction::Bind(ClientContext &cont
 		trim = trim_param->second.GetValue<bool>();
 	}
 
-	// Resolve accessions to run info via ENA Portal API
 	auto &db = DatabaseInstance::GetDatabase(context);
-	miint::ENAClient client(db);
-	auto runs = ResolveRuns(client, accessions, prefer_format);
 
-	if (runs.empty()) {
-		throw IOException("read_ena_sequences: no sequence data found for the provided accession(s)");
+	std::vector<miint::ENARunInfo> runs;
+	if (!deferred) {
+		// Resolve accessions to run info via ENA Portal API (batched + cached)
+		miint::ENAClient client(db);
+		runs = ResolveRuns(client, accessions, prefer_format);
+
+		if (runs.empty()) {
+			throw IOException("read_ena_sequences: no sequence data found for the provided accession(s)");
+		}
 	}
 
 	auto data = make_uniq<Data>(std::move(runs), include_filepath, qual_offset, trim, prefer_format);
+	data->deferred_resolution = deferred;
+	data->db_ptr = &db;
+	if (deferred) {
+		// Per-bind cache + ENAClient: metadata lookups across outer rows dedupe
+		// and the ENAClient's rate limiter (~3 req/sec) throttles globally.
+		// Capacity 256 matches the eager-resolve ResolveRuns helper.
+		data->resolver_cache = std::make_unique<miint::ENAResolverCache>(256);
+		data->lateral_client = std::make_unique<miint::ENAClient>(db);
+	}
 
 	// Determine whether to use Aspera (only relevant for FASTX runs; SFF uses HTTP only)
 	data->use_aspera = false;
 #if MIINT_ASPERA_SUPPORTED
-	// Check if there are any FASTX runs that could benefit from Aspera
-	bool has_fastx_runs = false;
-	for (const auto &run : data->runs) {
-		if (run.format == miint::ENASequenceFormat::FASTX) {
-			has_fastx_runs = true;
-			break;
+	if (deferred) {
+		// Lateral path: runs are resolved per outer row, so we can't pre-validate
+		// that every run has aspera paths. Fall back to HTTP streaming regardless
+		// of download_method; the lateral use case (LIMIT-inside-LATERAL) benefits
+		// from short-circuiting, not throughput. Explicit aspera request errors.
+		if (download_method == "aspera") {
+			throw IOException("read_ena_sequences: download_method='aspera' is not supported with lateral / "
+			                  "correlated arguments; use 'http' or omit the parameter");
 		}
-	}
-	if (has_fastx_runs && (download_method == "aspera" || download_method == "auto")) {
-		bool aspera_available = miint::AsperaUtils::IsAvailable();
-		if (download_method == "aspera" && !aspera_available) {
-			throw IOException("read_ena_sequences: download_method='aspera' but ascp not found in PATH. "
-			                  "Install IBM Aspera CLI or use download_method='http'");
+	} else {
+		// Check if there are any FASTX runs that could benefit from Aspera
+		bool has_fastx_runs = false;
+		for (const auto &run : data->runs) {
+			if (run.format == miint::ENASequenceFormat::FASTX) {
+				has_fastx_runs = true;
+				break;
+			}
 		}
-		if (aspera_available) {
-			// Check that all FASTX runs have aspera paths
-			bool all_have_aspera = true;
-			for (const auto &run : data->runs) {
-				if (run.format == miint::ENASequenceFormat::FASTX && run.aspera_paths.empty()) {
-					all_have_aspera = false;
-					break;
+		if (has_fastx_runs && (download_method == "aspera" || download_method == "auto")) {
+			bool aspera_available = miint::AsperaUtils::IsAvailable();
+			if (download_method == "aspera" && !aspera_available) {
+				throw IOException("read_ena_sequences: download_method='aspera' but ascp not found in PATH. "
+				                  "Install IBM Aspera CLI or use download_method='http'");
+			}
+			if (aspera_available) {
+				// Check that all FASTX runs have aspera paths
+				bool all_have_aspera = true;
+				for (const auto &run : data->runs) {
+					if (run.format == miint::ENASequenceFormat::FASTX && run.aspera_paths.empty()) {
+						all_have_aspera = false;
+						break;
+					}
 				}
-			}
-			if (download_method == "aspera" && !all_have_aspera) {
-				throw IOException("read_ena_sequences: download_method='aspera' but not all runs have Aspera paths");
-			}
-			if (all_have_aspera) {
-				std::string ascp_path = miint::AsperaUtils::FindAscp();
-				std::string key_path = miint::AsperaUtils::ResolveKey(db, ascp_path, download_method == "aspera");
-				if (!key_path.empty()) {
-					data->use_aspera = true;
-					data->aspera_config = miint::AsperaUtils::BuildConfig(ascp_path, key_path);
+				if (download_method == "aspera" && !all_have_aspera) {
+					throw IOException(
+					    "read_ena_sequences: download_method='aspera' but not all runs have Aspera paths");
+				}
+				if (all_have_aspera) {
+					std::string ascp_path = miint::AsperaUtils::FindAscp();
+					std::string key_path = miint::AsperaUtils::ResolveKey(db, ascp_path, download_method == "aspera");
+					if (!key_path.empty()) {
+						data->use_aspera = true;
+						data->aspera_config = miint::AsperaUtils::BuildConfig(ascp_path, key_path);
+					}
 				}
 			}
 		}
@@ -498,49 +275,22 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 	auto &global_state = data_p.global_state->Cast<GlobalState>();
 	auto &local_state = data_p.local_state->Cast<LocalState>();
 
+	// Helper: construct a fresh PerRunReader for a given run index.
+	// All per-run state (temp files, ascp process, FASTX/SFF reader) lives on
+	// the PerRunReader; the GlobalState holds only the run metadata + counters.
+	auto make_reader = [&](size_t idx) {
+		const miint::AsperaConfig *cfg = nullptr;
+#if MIINT_ASPERA_SUPPORTED
+		if (global_state.use_aspera) {
+			cfg = &global_state.aspera_config;
+		}
+#endif
+		return std::make_unique<miint::PerRunReader>(global_state.fs, global_state.runs[idx], global_state.use_aspera,
+		                                             global_state.trim, global_state.open_mutex, cfg);
+	};
+
 	miint::SequenceRecordBatch batch;
-	size_t current_run_idx;
-
-	// Helper: tear down a failed run's reader and process
-	auto cleanup_run = [&](size_t idx) {
-		auto &run = global_state.runs[idx];
-		if (run.format == miint::ENASequenceFormat::SFF) {
-			global_state.sff_readers[idx].reset();
-			if (!global_state.sff_temp_paths[idx].empty()) {
-				std::remove(global_state.sff_temp_paths[idx].c_str());
-				global_state.sff_temp_paths[idx].clear();
-			}
-		} else {
-			global_state.readers[idx].reset();
-		}
-#if MIINT_ASPERA_SUPPORTED
-		if (global_state.use_aspera && global_state.aspera_processes[idx]) {
-			global_state.aspera_processes[idx].reset();
-		}
-		if (!global_state.temp_file_paths[idx].empty()) {
-			std::remove(global_state.temp_file_paths[idx].c_str());
-			global_state.temp_file_paths[idx].clear();
-		}
-#endif
-	};
-
-	// Helper: open reader for the current run
-	auto open_run = [&](size_t idx) {
-		auto &run = global_state.runs[idx];
-		if (run.format == miint::ENASequenceFormat::SFF) {
-			global_state.OpenReaderSFF(idx);
-		} else {
-#if MIINT_ASPERA_SUPPORTED
-			if (global_state.use_aspera) {
-				global_state.OpenReaderAspera(idx);
-			} else {
-				global_state.OpenReader(idx);
-			}
-#else
-			global_state.OpenReader(idx);
-#endif
-		}
-	};
+	size_t current_run_idx = 0;
 
 	// Claim-read-release loop (same pattern as read_fastx)
 	while (true) {
@@ -575,21 +325,26 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 				return;
 			}
 
-			// Open reader — retry once on failure before skipping
+			// Open reader — retry once on failure before skipping.
+			// On retry, destroy the partially-initialized reader (its dtor runs
+			// any teardown) and recreate from scratch. Reset the run's
+			// sequence counter so the retry starts numbering from 1.
 			try {
-				open_run(local_state.current_run_idx);
+				global_state.readers[local_state.current_run_idx] = make_reader(local_state.current_run_idx);
+				global_state.readers[local_state.current_run_idx]->Open();
 			} catch (const std::exception &e) {
 				auto &run = global_state.runs[local_state.current_run_idx];
 				Printer::PrintF("read_ena_sequences: warning: run '%s' failed to open (%s), retrying...",
 				                run.run_accession, e.what());
-				cleanup_run(local_state.current_run_idx);
+				global_state.readers[local_state.current_run_idx].reset();
 				global_state.run_sequence_counters[local_state.current_run_idx] = 1;
 				try {
-					open_run(local_state.current_run_idx);
+					global_state.readers[local_state.current_run_idx] = make_reader(local_state.current_run_idx);
+					global_state.readers[local_state.current_run_idx]->Open();
 				} catch (const std::exception &e2) {
 					Printer::PrintF("read_ena_sequences: warning: run '%s' failed on retry (%s), skipping",
 					                run.run_accession, e2.what());
-					cleanup_run(local_state.current_run_idx);
+					global_state.readers[local_state.current_run_idx].reset();
 					{
 						lock_guard<mutex> skip_guard(global_state.skipped_lock);
 						global_state.skipped_runs.push_back(run.run_accession);
@@ -604,69 +359,52 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 
 		current_run_idx = local_state.current_run_idx;
 
-		// Read batch — dispatch based on format
-		auto read_batch = [&]() -> miint::SequenceRecordBatch {
-			auto &run = global_state.runs[current_run_idx];
-			if (run.format == miint::ENASequenceFormat::SFF) {
-				return global_state.sff_readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
-			} else {
-				return global_state.readers[current_run_idx]->read(STANDARD_VECTOR_SIZE);
-			}
-		};
-
 		try {
-			batch = read_batch();
+			batch = global_state.readers[current_run_idx]->ReadBatch(STANDARD_VECTOR_SIZE);
 		} catch (const std::exception &e) {
-			// Mid-stream read failure. Tear down and retry from scratch.
+			// Mid-stream read failure.
+			//
+			// We intentionally do NOT retry from scratch here. The previous
+			// iterations of Execute already emitted rows from the first attempt
+			// into downstream chunks (DuckDB consumes the output chunk before
+			// the next Execute call). Reopening and re-reading would emit the
+			// SAME underlying reads a second time, and with the counter reset
+			// would give them duplicate sequence_index values too.
+			//
+			// Instead: skip the remainder of this run with a loud warning. The
+			// user gets partial data up to the failure point, plus the run is
+			// recorded in skipped_runs so the end-of-scan summary tells them
+			// exactly which sample was truncated.
 			auto &run = global_state.runs[current_run_idx];
-			Printer::PrintF("read_ena_sequences: warning: run '%s' failed mid-stream (%s), retrying...",
-			                run.run_accession, e.what());
-			cleanup_run(current_run_idx);
-			global_state.run_sequence_counters[current_run_idx] = 1;
-			try {
-				open_run(current_run_idx);
-				batch = read_batch();
-			} catch (const std::exception &e2) {
-				Printer::PrintF("read_ena_sequences: warning: run '%s' failed on retry (%s), skipping",
-				                run.run_accession, e2.what());
-				cleanup_run(current_run_idx);
-				{
-					lock_guard<mutex> skip_guard(global_state.skipped_lock);
-					global_state.skipped_runs.push_back(run.run_accession);
-				}
-				global_state.bytes_completed.fetch_add(run.total_bytes, std::memory_order_relaxed);
-				global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
-				local_state.has_run = false;
-				continue;
+			uint64_t emitted = global_state.run_sequence_counters[current_run_idx] > 0
+			                       ? global_state.run_sequence_counters[current_run_idx] - 1
+			                       : 0;
+			Printer::PrintF("read_ena_sequences: WARNING: run '%s' failed mid-stream after emitting %llu read(s) "
+			                "(%s); skipping remainder — downstream sees partial data for this run",
+			                run.run_accession, static_cast<unsigned long long>(emitted), e.what());
+			global_state.readers[current_run_idx].reset();
+			{
+				lock_guard<mutex> skip_guard(global_state.skipped_lock);
+				global_state.skipped_runs.push_back(run.run_accession);
 			}
+			global_state.bytes_completed.fetch_add(run.total_bytes, std::memory_order_relaxed);
+			global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
+			local_state.has_run = false;
+			continue;
 		}
 
 		if (batch.empty()) {
-			// Run completed successfully — release resources
-			auto &completed_run = global_state.runs[current_run_idx];
-			if (completed_run.format == miint::ENASequenceFormat::SFF) {
-				global_state.sff_readers[current_run_idx].reset();
-				if (!global_state.sff_temp_paths[current_run_idx].empty()) {
-					std::remove(global_state.sff_temp_paths[current_run_idx].c_str());
-					global_state.sff_temp_paths[current_run_idx].clear();
-				}
-			} else {
+			// Run completed successfully — wait for ascp (if any) and release.
+			// Finish() may throw on ascp non-zero exit; clean up the reader first
+			// so the throw doesn't leave dangling state behind.
+			auto &reader = *global_state.readers[current_run_idx];
+			try {
+				reader.Finish();
+			} catch (...) {
 				global_state.readers[current_run_idx].reset();
+				throw;
 			}
-#if MIINT_ASPERA_SUPPORTED
-			if (global_state.use_aspera && global_state.aspera_processes[current_run_idx]) {
-				int exit_code = global_state.aspera_processes[current_run_idx]->WaitForExit();
-				global_state.aspera_processes[current_run_idx].reset();
-				if (exit_code != 0 && exit_code != -1) {
-					throw IOException("read_ena_sequences: ascp exited with code %d for run '%s'", exit_code,
-					                  completed_run.run_accession);
-				}
-			}
-			if (!global_state.temp_file_paths[current_run_idx].empty()) {
-				std::remove(global_state.temp_file_paths[current_run_idx].c_str());
-				global_state.temp_file_paths[current_run_idx].clear();
-			}
-#endif
+			global_state.readers[current_run_idx].reset();
 			global_state.bytes_completed.fetch_add(global_state.runs[current_run_idx].total_bytes,
 			                                       std::memory_order_relaxed);
 			global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
@@ -676,10 +414,22 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 		break;
 	}
 
-	idx_t count = batch.size();
-	idx_t field_idx = 0;
 	const auto &run = global_state.runs[current_run_idx];
 	auto &seq_counter = global_state.run_sequence_counters[current_run_idx];
+	FillOutputFromBatch(output, batch, bind_data, run, seq_counter);
+}
+
+// ---- FillOutputFromBatch (shared by Execute + ExecuteInOut) ----
+//
+// Writes one DuckDB DataChunk from one SequenceRecordBatch. Caller owns the
+// sequence counter (it lives on GlobalState for literal-path runs and on
+// LocalState for in-out runs), so we take it by reference and post-increment
+// one id per row.
+void ReadENASequencesTableFunction::FillOutputFromBatch(DataChunk &output, const miint::SequenceRecordBatch &batch,
+                                                        const Data &bind_data, const miint::ENARunInfo &run,
+                                                        uint64_t &seq_counter) {
+	idx_t count = batch.size();
+	idx_t field_idx = 0;
 
 	// sequence_index (column 0)
 	auto seq_idx_data = FlatVector::GetData<int64_t>(output.data[field_idx++]);
@@ -746,10 +496,206 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 	output.SetCardinality(count);
 }
 
+// ---- ExecuteInOut ----
+//
+// State machine for the lateral / in-out path. Mirrors the literal path's
+// retry policy (Execute): one-shot retry on open failure, one-shot retry on
+// mid-stream read failure, skip-with-warning on second failure. Returning
+// `HAVE_MORE_OUTPUT` with cardinality=0 is safe because internal state
+// (current_reader reset, pending_runs popped, lateral_sequence_counter reset)
+// advances between callbacks — the dispatcher loops until state progresses to
+// a data-emitting call or a NEED_MORE_INPUT / terminal return.
+//
+// CRITICAL user-facing invariant: every skip path prints a loud Printer
+// warning via record_skip(). Silent skips in lateral mode are dangerous — the
+// outer query just sees zero rows for the failed accession, indistinguishable
+// from "no matches". The user depends on these warnings to notice lost
+// samples. Both per-attempt retry messages AND final skip notices are emitted.
+//
+// `lateral_sequence_counter` is reset to 1 when a new outer row is consumed
+// (Phase 1) AND on open-retry / mid-stream retry (matching the literal path's
+// counter reset invariant #4 in localdocs/PLAN-ena-lateral.md). Within a
+// single outer row, the counter increments monotonically across pending_runs
+// so sequence_index is globally unique per outer row.
+OperatorResultType ReadENASequencesTableFunction::ExecuteInOut(ExecutionContext &context, TableFunctionInput &data_p,
+                                                               DataChunk &input, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &local = data_p.local_state->Cast<LocalState>();
+	auto &global = data_p.global_state->Cast<GlobalState>();
+
+	// Record a skipped accession and emit a loud warning. Both pieces are
+	// user-critical: the user must know which samples they did not get data
+	// for, so they can decide whether to retry manually or investigate.
+	auto record_skip = [&bind_data](const std::string &outer_accession, const std::string &run_accession,
+	                                const std::string &reason) {
+		{
+			std::lock_guard<std::mutex> guard(bind_data.lateral_skipped_lock);
+			bind_data.lateral_skipped_accessions.push_back(run_accession.empty() ? outer_accession : run_accession);
+		}
+		if (run_accession.empty()) {
+			Printer::PrintF("read_ena_sequences: WARNING: skipped outer accession '%s' — %s", outer_accession, reason);
+		} else {
+			Printer::PrintF("read_ena_sequences: WARNING: skipped run '%s' (from outer accession '%s') — %s",
+			                run_accession, outer_accession, reason);
+		}
+	};
+
+	// Construct a fresh PerRunReader for a given run. Used for initial open
+	// and for retry-after-failure. Lateral path always uses HTTP (Bind rejects
+	// download_method='aspera' in deferred mode).
+	auto make_reader_for = [&](const miint::ENARunInfo &run) {
+		return std::make_unique<miint::PerRunReader>(global.fs, run, /*use_aspera=*/false, bind_data.trim,
+		                                             global.open_mutex,
+		                                             static_cast<const miint::AsperaConfig *>(nullptr));
+	};
+
+	// Phase 1: need a fresh outer row → pull and resolve.
+	if (local.row_consumed && local.pending_runs.empty()) {
+		if (input.size() == 0) {
+			output.SetCardinality(0);
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		auto acc_val = input.data[0].GetValue(0);
+		if (acc_val.IsNull()) {
+			// NULL accession → no rows for this outer row. Not a failure
+			// (outer emitted NULL intentionally); skip quietly.
+			output.SetCardinality(0);
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		local.current_accession = acc_val.ToString();
+		local.lateral_sequence_counter = 1;
+
+		// Resolve against the bind-owned cache using the bind-owned ENAClient.
+		// Sharing the client across outer rows means its ~3 req/sec rate
+		// limiter actually throttles globally (not per-row), and parallel
+		// LocalStates serialize on the client's internal mutex.
+		miint::ENAFetcher fetcher = [&bind_data](const std::string &url) {
+			return bind_data.lateral_client->FetchURL(url);
+		};
+		try {
+			auto resolved = miint::ResolveRunsBatch(fetcher, *bind_data.resolver_cache, {local.current_accession},
+			                                        bind_data.prefer_format);
+			auto it = resolved.find(local.current_accession);
+			if (it == resolved.end() || it->second.empty()) {
+				record_skip(local.current_accession, "",
+				            "ENA returned no runs for this accession (may not exist, may have no sequence data)");
+				local.row_consumed = true;
+				output.SetCardinality(0);
+				return OperatorResultType::NEED_MORE_INPUT;
+			}
+			for (const auto &run : it->second) {
+				local.pending_runs.push_back(run);
+			}
+		} catch (const std::exception &e) {
+			record_skip(local.current_accession, "", std::string("metadata resolution failed: ") + e.what());
+			local.row_consumed = true;
+			output.SetCardinality(0);
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		local.row_consumed = false;
+	}
+
+	// Phase 2: ensure we have an open reader on the current pending run.
+	// Retry-once-on-open mirrors Execute (literal path, invariant #3).
+	if (!local.current_reader) {
+		if (local.pending_runs.empty()) {
+			local.row_consumed = true;
+			output.SetCardinality(0);
+			return OperatorResultType::NEED_MORE_INPUT;
+		}
+		auto run = local.pending_runs.front();
+		local.pending_runs.pop_front();
+		local.current_reader = make_reader_for(run);
+		try {
+			local.current_reader->Open();
+		} catch (const std::exception &e) {
+			Printer::PrintF("read_ena_sequences: warning: run '%s' failed to open (%s), retrying...", run.run_accession,
+			                e.what());
+			local.current_reader.reset();
+			local.lateral_sequence_counter = 1; // No rows emitted yet; keep counter consistent.
+			local.current_reader = make_reader_for(run);
+			try {
+				local.current_reader->Open();
+			} catch (const std::exception &e2) {
+				record_skip(local.current_accession, run.run_accession,
+				            std::string("open failed on retry: ") + e2.what());
+				local.current_reader.reset();
+				// State advanced (run popped, reader reset); the dispatcher
+				// will call us back to handle the next pending run or yield
+				// NEED_MORE_INPUT. This is why HAVE_MORE_OUTPUT + cardinality=0
+				// is safe here — forward progress is guaranteed.
+				output.SetCardinality(0);
+				return OperatorResultType::HAVE_MORE_OUTPUT;
+			}
+		}
+	}
+
+	// Phase 3: read a batch.
+	//
+	// IMPORTANT: we do NOT retry from scratch on a mid-stream failure. Previous
+	// ExecuteInOut calls already streamed rows from this run downstream (the
+	// output chunks are consumed between calls), and re-reading from the top
+	// would emit the same reads again with the sequence_index counter reset.
+	// Downstream would see duplicate (run_accession, sequence_index) pairs with
+	// identical — or worse, subtly different — read_id content. That's a data
+	// integrity hazard the user can't easily dedupe without guessing which
+	// rows were doubled.
+	//
+	// Instead: skip the rest of this run and report LOUDLY exactly how much
+	// was emitted before the failure. The user can decide to re-run the query
+	// (which will hit the metadata cache) or accept the partial data.
+	miint::SequenceRecordBatch batch;
+	try {
+		batch = local.current_reader->ReadBatch(STANDARD_VECTOR_SIZE);
+	} catch (const std::exception &e) {
+		const uint64_t emitted = local.lateral_sequence_counter > 0 ? local.lateral_sequence_counter - 1 : 0;
+		const std::string failed_run = local.current_reader->Run().run_accession;
+		record_skip(local.current_accession, failed_run,
+		            "failed mid-stream after emitting " + std::to_string(emitted) +
+		                " read(s); downstream sees partial data for this run (error: " + e.what() + ")");
+		local.current_reader.reset();
+		output.SetCardinality(0);
+		return OperatorResultType::HAVE_MORE_OUTPUT;
+	}
+
+	if (batch.empty()) {
+		// Reader exhausted — Finish() waits for ascp (no-op for HTTP) and may
+		// throw on non-zero exit. In lateral mode we warn but do not abort:
+		// the user already has whatever rows we emitted, and killing the
+		// entire outer query because one run's completion code was non-zero
+		// is overkill. The warning ensures the user still sees the problem.
+		try {
+			local.current_reader->Finish();
+		} catch (const std::exception &e) {
+			record_skip(local.current_accession, local.current_reader->Run().run_accession,
+			            std::string("finish/transfer completion failed: ") + e.what());
+		}
+		local.current_reader.reset();
+		if (!local.pending_runs.empty()) {
+			output.SetCardinality(0);
+			return OperatorResultType::HAVE_MORE_OUTPUT;
+		}
+		local.row_consumed = true;
+		output.SetCardinality(0);
+		return OperatorResultType::NEED_MORE_INPUT;
+	}
+
+	// Phase 4: emit the batch.
+	FillOutputFromBatch(output, batch, bind_data, local.current_reader->Run(), local.lateral_sequence_counter);
+	return OperatorResultType::HAVE_MORE_OUTPUT;
+}
+
 // ---- Progress ----
 
 double ReadENASequencesTableFunction::Progress(ClientContext &context, const FunctionData *bind_data,
                                                const GlobalTableFunctionState *global_state) {
+	if (bind_data) {
+		auto &bd = bind_data->Cast<Data>();
+		if (bd.deferred_resolution) {
+			// Lateral mode: total work is unknown (driven by outer side).
+			return -1.0;
+		}
+	}
 	if (!global_state) {
 		return -1.0;
 	}
@@ -776,6 +722,10 @@ double ReadENASequencesTableFunction::Progress(ClientContext &context, const Fun
 
 TableFunction ReadENASequencesTableFunction::GetFunction() {
 	auto tf = TableFunction("read_ena_sequences", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
+	// Dual-path: literal / scalar args take `Execute` (parallel, byte-based
+	// progress); correlated / subquery args take `ExecuteInOut` (one outer row
+	// at a time, LIMIT-inside-LATERAL short-circuits via LocalState dtor).
+	tf.in_out_function = ExecuteInOut;
 	tf.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
 	tf.named_parameters["qual_offset"] = LogicalType::BIGINT;
 	tf.named_parameters["download_method"] = LogicalType::VARCHAR;

--- a/test/cpp/test_ENAClient.cpp
+++ b/test/cpp/test_ENAClient.cpp
@@ -1,5 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include "ena_parser.hpp"
+#include "ena_resolver_cache.hpp"
+#include "ena_run_info_extractor.hpp"
 
 // ---- Step 1.1: Accession type detection ----
 
@@ -394,5 +396,533 @@ TEST_CASE("FilterSubmittedByFormat extracts matching files", "[ena]") {
 		    miint::ENAParser::FilterSubmittedByFormat("ftp.example.com/a.sff", "", "SFF", "notanumber", "SFF");
 		REQUIRE(result.urls.size() == 1);
 		CHECK(result.total_bytes == 0);
+	}
+}
+
+// ---- BuildSearchURLBatch ----
+
+TEST_CASE("BuildSearchURLBatch with single run accession uses IN clause", "[ena]") {
+	auto url = miint::ENAParser::BuildSearchURLBatch({"ERR1074767"}, miint::ENAAccessionType::RUN, "read_run",
+	                                                 "run_accession,fastq_ftp");
+	// Single-element: query=run_accession IN ("ERR1074767")
+	CHECK(url.find("run_accession%20IN%20%28%22ERR1074767%22%29") != std::string::npos);
+	CHECK(url.find("result=read_run") != std::string::npos);
+	CHECK(url.find("fields=run_accession,fastq_ftp") != std::string::npos);
+}
+
+TEST_CASE("BuildSearchURLBatch with multiple run accessions", "[ena]") {
+	auto url = miint::ENAParser::BuildSearchURLBatch({"ERR1074767", "ERR1074768"}, miint::ENAAccessionType::RUN,
+	                                                 "read_run", "run_accession,fastq_ftp");
+	// query=run_accession IN ("ERR1074767","ERR1074768")
+	CHECK(url.find("run_accession%20IN%20%28%22ERR1074767%22%2C%22ERR1074768%22%29") != std::string::npos);
+}
+
+TEST_CASE("BuildSearchURLBatch with study accessions uses study_accession column", "[ena]") {
+	auto url = miint::ENAParser::BuildSearchURLBatch({"PRJEB5291", "PRJNA555783"}, miint::ENAAccessionType::STUDY,
+	                                                 "read_run", "run_accession,study_accession");
+	CHECK(url.find("study_accession%20IN%20%28%22PRJEB5291%22%2C%22PRJNA555783%22%29") != std::string::npos);
+}
+
+TEST_CASE("BuildSearchURLBatch URL-encodes parens, quotes, commas", "[ena]") {
+	auto url = miint::ENAParser::BuildSearchURLBatch({"ERR1", "ERR2", "ERR3"}, miint::ENAAccessionType::RUN, "read_run",
+	                                                 "run_accession");
+	// %20 (space), %28 '(', %22 '"', %2C ',', %29 ')'
+	CHECK(url.find("%20IN%20%28") != std::string::npos); // IN (
+	CHECK(url.find("%22ERR1%22%2C%22ERR2%22%2C%22ERR3%22") != std::string::npos);
+	CHECK(url.find("%29&fields=") != std::string::npos); // ) before fields
+}
+
+TEST_CASE("BuildSearchURLBatch throws on empty accession vector", "[ena]") {
+	CHECK_THROWS(miint::ENAParser::BuildSearchURLBatch({}, miint::ENAAccessionType::RUN, "read_run", "run_accession"));
+}
+
+TEST_CASE("BuildSearchURLBatch throws on UNKNOWN accession type", "[ena]") {
+	CHECK_THROWS(miint::ENAParser::BuildSearchURLBatch({"ERR1074767"}, miint::ENAAccessionType::UNKNOWN, "read_run",
+	                                                   "run_accession"));
+}
+
+TEST_CASE("BuildSearchURLBatch validates every accession", "[ena]") {
+	CHECK_THROWS(miint::ENAParser::BuildSearchURLBatch({"ERR1", "bad accession"}, miint::ENAAccessionType::RUN,
+	                                                   "read_run", "run_accession"));
+	CHECK_THROWS(miint::ENAParser::BuildSearchURLBatch({"ERR1", "ERR2&limit=1"}, miint::ENAAccessionType::RUN,
+	                                                   "read_run", "run_accession"));
+}
+
+TEST_CASE("BuildSearchURLBatch starts with portal base", "[ena]") {
+	auto url = miint::ENAParser::BuildSearchURLBatch({"ERR1074767"}, miint::ENAAccessionType::RUN, "read_run",
+	                                                 "run_accession");
+	CHECK(url.rfind("https://www.ebi.ac.uk/ena/portal/api/search?", 0) == 0);
+	CHECK(url.find("&limit=0&format=tsv") != std::string::npos);
+}
+
+// ---- ENAColumnIndexMap ----
+
+TEST_CASE("ENAColumnIndexMap maps column names to indices", "[ena]") {
+	SECTION("All known columns are mapped") {
+		std::vector<std::string> header = {"run_accession",    "sample_accession", "experiment_accession",
+		                                   "study_accession",  "fastq_ftp",        "fastq_aspera",
+		                                   "fastq_bytes",      "library_layout",   "submitted_ftp",
+		                                   "submitted_aspera", "submitted_bytes",  "submitted_format"};
+		auto cols = miint::ENAColumnIndexMap::FromHeader(header);
+		CHECK(cols.run_accession == 0);
+		CHECK(cols.sample_accession == 1);
+		CHECK(cols.experiment_accession == 2);
+		CHECK(cols.study_accession == 3);
+		CHECK(cols.fastq_ftp == 4);
+		CHECK(cols.fastq_aspera == 5);
+		CHECK(cols.fastq_bytes == 6);
+		CHECK(cols.library_layout == 7);
+		CHECK(cols.submitted_ftp == 8);
+		CHECK(cols.submitted_aspera == 9);
+		CHECK(cols.submitted_bytes == 10);
+		CHECK(cols.submitted_format == 11);
+	}
+
+	SECTION("Missing columns remain -1") {
+		std::vector<std::string> header = {"run_accession", "fastq_ftp"};
+		auto cols = miint::ENAColumnIndexMap::FromHeader(header);
+		CHECK(cols.run_accession == 0);
+		CHECK(cols.fastq_ftp == 1);
+		CHECK(cols.sample_accession == -1);
+		CHECK(cols.library_layout == -1);
+	}
+
+	SECTION("Unknown column names are ignored") {
+		std::vector<std::string> header = {"run_accession", "irrelevant", "fastq_ftp"};
+		auto cols = miint::ENAColumnIndexMap::FromHeader(header);
+		CHECK(cols.run_accession == 0);
+		CHECK(cols.fastq_ftp == 2);
+	}
+
+	SECTION("Get returns empty string for missing column") {
+		std::vector<std::string> row = {"ERR1", "SAM1"};
+		CHECK(miint::ENAColumnIndexMap::Get(row, -1) == "");
+		CHECK(miint::ENAColumnIndexMap::Get(row, 99) == "");
+		CHECK(miint::ENAColumnIndexMap::Get(row, 0) == "ERR1");
+	}
+}
+
+// ---- ENARunInfoExtractor ----
+
+static miint::ENAColumnIndexMap StandardCols() {
+	std::vector<std::string> header = {"run_accession",    "sample_accession", "experiment_accession", "fastq_ftp",
+	                                   "fastq_aspera",     "fastq_bytes",      "library_layout",       "submitted_ftp",
+	                                   "submitted_aspera", "submitted_bytes",  "submitted_format"};
+	return miint::ENAColumnIndexMap::FromHeader(header);
+}
+
+TEST_CASE("ENARunInfoExtractor extracts single-end FASTQ", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR1074767",
+	                                "SAMEA3271045",
+	                                "ERX1106717",
+	                                "ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767.fastq.gz",
+	                                "fasp.sra.ebi.ac.uk:/vol1/fastq/ERR107/007/ERR1074767/ERR1074767.fastq.gz",
+	                                "12345",
+	                                "SINGLE",
+	                                "",
+	                                "",
+	                                "",
+	                                ""};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].run_accession == "ERR1074767");
+	CHECK(runs[0].sample_accession == "SAMEA3271045");
+	CHECK(runs[0].experiment_accession == "ERX1106717");
+	CHECK(runs[0].is_paired == false);
+	REQUIRE(runs[0].fastq_urls.size() == 1);
+	CHECK(runs[0].fastq_urls[0] == "https://ftp.sra.ebi.ac.uk/vol1/fastq/ERR107/007/ERR1074767/ERR1074767.fastq.gz");
+	CHECK(runs[0].total_bytes == 12345);
+	CHECK(runs[0].format == miint::ENASequenceFormat::FASTX);
+	CHECK(runs[0].sff_url.empty());
+	REQUIRE(runs[0].aspera_paths.size() == 1);
+	CHECK(runs[0].aspera_paths[0].host == "fasp.sra.ebi.ac.uk");
+}
+
+TEST_CASE("ENARunInfoExtractor extracts paired-end FASTQ with 2 files", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR1000",
+	                                "SAM1",
+	                                "EXP1",
+	                                "ftp.example.com/ERR1000_1.fastq.gz;ftp.example.com/ERR1000_2.fastq.gz",
+	                                "fasp.example.com:/a_1.fastq.gz;fasp.example.com:/a_2.fastq.gz",
+	                                "100;200",
+	                                "PAIRED",
+	                                "",
+	                                "",
+	                                "",
+	                                ""};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].is_paired == true);
+	REQUIRE(runs[0].fastq_urls.size() == 2);
+	CHECK(runs[0].total_bytes == 300);
+	REQUIRE(runs[0].aspera_paths.size() == 2);
+}
+
+TEST_CASE("ENARunInfoExtractor filters 3-file paired-end to _1/_2", "[ena]") {
+	auto cols = StandardCols();
+	// ENA sometimes returns 3 files for PAIRED layout: an orphan single plus _1 and _2.
+	// The extractor must drop the orphan.
+	std::vector<std::string> row = {
+	    "ERR2000",
+	    "SAM2",
+	    "EXP2",
+	    "ftp.example.com/ERR2000.fastq.gz;ftp.example.com/ERR2000_1.fastq.gz;ftp.example.com/ERR2000_2.fastq.gz",
+	    "fasp.example.com:/ERR2000.fastq.gz;fasp.example.com:/ERR2000_1.fastq.gz;fasp.example.com:/ERR2000_2.fastq.gz",
+	    "50;100;200",
+	    "PAIRED",
+	    "",
+	    "",
+	    "",
+	    ""};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].is_paired == true);
+	REQUIRE(runs[0].fastq_urls.size() == 2);
+	CHECK(runs[0].fastq_urls[0].find("_1.fast") != std::string::npos);
+	CHECK(runs[0].fastq_urls[1].find("_2.fast") != std::string::npos);
+	// Total bytes should reflect only the _1/_2 files (100+200), not the orphan
+	CHECK(runs[0].total_bytes == 300);
+	REQUIRE(runs[0].aspera_paths.size() == 2);
+	CHECK(runs[0].aspera_paths[0].remote_path.find("_1.fast") != std::string::npos);
+	CHECK(runs[0].aspera_paths[1].remote_path.find("_2.fast") != std::string::npos);
+}
+
+TEST_CASE("ENARunInfoExtractor picks SFF when prefer_format='sff' and SFF available", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR3000",
+	                                "SAM3",
+	                                "EXP3",
+	                                "ftp.example.com/ERR3000.fastq.gz", // FASTQ also present
+	                                "",
+	                                "500",
+	                                "SINGLE",
+	                                "ftp.example.com/a.sff",
+	                                "",
+	                                "1000",
+	                                "SFF"};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "sff");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].format == miint::ENASequenceFormat::SFF);
+	CHECK(runs[0].sff_url == "https://ftp.example.com/a.sff");
+	CHECK(runs[0].total_bytes == 1000);
+	CHECK(runs[0].fastq_urls.empty());
+}
+
+TEST_CASE("ENARunInfoExtractor prefer_format='sff' falls back to FASTQ when no SFF", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {
+	    "ERR3001", "SAM3", "EXP3", "ftp.example.com/ERR3001.fastq.gz", "", "500", "SINGLE", "", "", "", ""};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "sff");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].format == miint::ENASequenceFormat::FASTX);
+	REQUIRE(runs[0].fastq_urls.size() == 1);
+}
+
+TEST_CASE("ENARunInfoExtractor prefer_format='fastq' skips SFF-only row", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR3002", "SAM3", "EXP3", "", "", "", "SINGLE", "ftp.example.com/a.sff",
+	                                "",        "1000", "SFF"};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "fastq");
+	CHECK(runs.empty());
+}
+
+TEST_CASE("ENARunInfoExtractor prefer_format='auto' picks FASTQ when both present", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR3003", "SAM3", "EXP3",   "ftp.example.com/ERR3003.fastq.gz",
+	                                "",        "500",  "SINGLE", "ftp.example.com/a.sff",
+	                                "",        "1000", "SFF"};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].format == miint::ENASequenceFormat::FASTX);
+}
+
+TEST_CASE("ENARunInfoExtractor flattens multiple SFF URLs into one RunInfo each", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR4000", "SAM4",    "EXP4",   "",
+	                                "",        "",        "SINGLE", "ftp.example.com/a.sff;ftp.example.com/b.sff",
+	                                "",        "400;600", "SFF;SFF"};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	REQUIRE(runs.size() == 2);
+	CHECK(runs[0].format == miint::ENASequenceFormat::SFF);
+	CHECK(runs[0].sff_url == "https://ftp.example.com/a.sff");
+	CHECK(runs[1].format == miint::ENASequenceFormat::SFF);
+	CHECK(runs[1].sff_url == "https://ftp.example.com/b.sff");
+	// Total SFF bytes (1000) split equally across files
+	CHECK(runs[0].total_bytes == 500);
+	CHECK(runs[1].total_bytes == 500);
+	// SFF uses same metadata for all flattened entries
+	CHECK(runs[0].run_accession == "ERR4000");
+	CHECK(runs[1].run_accession == "ERR4000");
+}
+
+TEST_CASE("ENARunInfoExtractor returns empty for row with no usable format", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {"ERR5000", "SAM5", "EXP5", "", "", "", "SINGLE", "", "", "", ""};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	CHECK(runs.empty());
+}
+
+TEST_CASE("ENARunInfoExtractor bytes field with invalid number treated as 0", "[ena]") {
+	auto cols = StandardCols();
+	std::vector<std::string> row = {
+	    "ERR6000", "SAM6", "EXP6", "ftp.example.com/ERR6000.fastq.gz", "", "notanumber", "SINGLE", "", "", "", ""};
+
+	auto runs = miint::ENARunInfoExtractor::FromTSVRow(row, cols, "auto");
+	REQUIRE(runs.size() == 1);
+	CHECK(runs[0].total_bytes == 0);
+}
+
+// ---- ResolveRunsBatch ----
+//
+// MockFetcher records every URL it receives and returns TSV bodies keyed by
+// substring match. Lets tests assert which URLs were fetched and how many times.
+// State lives in a std::shared_ptr so that std::function's copy-on-wrap still
+// mutates the same state the test harness inspects.
+struct MockFetcher {
+	struct State {
+		std::vector<std::string> urls;
+		std::vector<std::pair<std::string, std::string>> responses;
+	};
+	std::shared_ptr<State> state {std::make_shared<State>()};
+
+	std::string operator()(const std::string &url) const {
+		state->urls.push_back(url);
+		for (const auto &p : state->responses) {
+			if (url.find(p.first) != std::string::npos) {
+				return p.second;
+			}
+		}
+		return "run_accession\tstudy_accession\tfastq_ftp\n";
+	}
+
+	void AddResponse(const std::string &needle, const std::string &body) {
+		state->responses.push_back({needle, body});
+	}
+
+	const std::vector<std::string> &urls() const {
+		return state->urls;
+	}
+
+	int CountContaining(const std::string &needle) const {
+		int n = 0;
+		for (const auto &u : state->urls) {
+			if (u.find(needle) != std::string::npos) {
+				n++;
+			}
+		}
+		return n;
+	}
+};
+
+// Build a minimal single-row TSV response matching BATCH_FIELDS.
+// Columns (12): run_accession,sample_accession,experiment_accession,study_accession,
+//               fastq_ftp,fastq_aspera,fastq_bytes,library_layout,
+//               submitted_ftp,submitted_aspera,submitted_bytes,submitted_format
+static std::string RunRowTSV(const std::string &run_accession, const std::string &study_accession = "") {
+	std::string header = "run_accession\tsample_accession\texperiment_accession\tstudy_accession\t"
+	                     "fastq_ftp\tfastq_aspera\tfastq_bytes\tlibrary_layout\t"
+	                     "submitted_ftp\tsubmitted_aspera\tsubmitted_bytes\tsubmitted_format\n";
+	std::string ftp = "ftp.sra.ebi.ac.uk/vol1/fastq/" + run_accession + "/" + run_accession + ".fastq.gz";
+	return header + run_accession + "\tSAM1\tEXP1\t" + study_accession + "\t" + ftp + "\t\t100\tSINGLE\t\t\t\t\n";
+}
+
+TEST_CASE("ResolveRunsBatch groups by accession type", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+	fetch.AddResponse("run_accession%20IN", RunRowTSV("ERR1") + "ERR2\tSAM1\tEXP1\t\t" +
+	                                            "ftp.example.com/ERR2.fastq.gz\t\t200\tSINGLE\t\t\t\t\n");
+	// For study query, return a row that has study_accession so grouping works
+	fetch.AddResponse("study_accession%20IN",
+	                  "run_accession\tsample_accession\texperiment_accession\tstudy_accession\tfastq_ftp\t"
+	                  "fastq_aspera\tfastq_bytes\tlibrary_layout\tsubmitted_ftp\tsubmitted_aspera\t"
+	                  "submitted_bytes\tsubmitted_format\n"
+	                  "ERR9\tSAM9\tEXP9\tPRJNA3\tftp.example.com/ERR9.fastq.gz\t\t300\tSINGLE\t\t\t\t\n");
+
+	auto result = miint::ResolveRunsBatch(fetch, cache, {"ERR1", "ERR2", "PRJNA3"}, "auto");
+
+	// Exactly two fetches: one run batch, one study batch.
+	CHECK(fetch.urls().size() == 2);
+	CHECK(fetch.CountContaining("run_accession%20IN") == 1);
+	CHECK(fetch.CountContaining("study_accession%20IN") == 1);
+
+	REQUIRE(result.count("ERR1") == 1);
+	REQUIRE(result.count("ERR2") == 1);
+	REQUIRE(result.count("PRJNA3") == 1);
+	CHECK(result["ERR1"].size() == 1);
+	CHECK(result["ERR2"].size() == 1);
+	CHECK(result["PRJNA3"].size() == 1);
+	CHECK(result["PRJNA3"][0].run_accession == "ERR9");
+}
+
+TEST_CASE("ResolveRunsBatch respects max_batch_size", "[ena]") {
+	miint::ENAResolverCache cache(256);
+	MockFetcher fetch;
+
+	std::vector<std::string> inputs;
+	for (int i = 0; i < 75; i++) {
+		inputs.push_back("ERR" + std::to_string(1000 + i));
+	}
+
+	miint::ENAFetcher fetcher = [&fetch](const std::string &url) {
+		return fetch(url);
+	};
+	miint::ResolveRunsBatch(fetcher, cache, inputs, "auto", 50);
+
+	// 75 accessions / 50 per batch = 2 fetches
+	CHECK(fetch.urls().size() == 2);
+	CHECK(fetch.CountContaining("run_accession%20IN") == 2);
+}
+
+TEST_CASE("ResolveRunsBatch populates cache for all input accessions", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+	fetch.AddResponse("run_accession%20IN", RunRowTSV("ERR1"));
+
+	miint::ENAFetcher fetcher = [&fetch](const std::string &url) {
+		return fetch(url);
+	};
+	miint::ResolveRunsBatch(fetcher, cache, {"ERR1", "ERR2"}, "auto");
+
+	// Both should be cached (ERR1 with data, ERR2 as negative cache entry)
+	std::vector<miint::ENARunInfo> tmp;
+	CHECK(cache.Get({"ERR1", "auto"}, tmp));
+	CHECK(tmp.size() == 1);
+	CHECK(cache.Get({"ERR2", "auto"}, tmp));
+	CHECK(tmp.empty());
+}
+
+TEST_CASE("ResolveRunsBatch serves from cache without calling fetcher", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	miint::ENARunInfo pre;
+	pre.run_accession = "ERR1";
+	cache.Put({"ERR1", "auto"}, {pre});
+
+	MockFetcher fetch;
+	auto result = miint::ResolveRunsBatch(fetch, cache, {"ERR1"}, "auto");
+
+	CHECK(fetch.urls().empty()); // no HTTP fetch
+	REQUIRE(result.count("ERR1") == 1);
+	CHECK(result["ERR1"].size() == 1);
+}
+
+TEST_CASE("ResolveRunsBatch mixes cached + uncached accessions", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	miint::ENARunInfo pre;
+	pre.run_accession = "ERR1";
+	cache.Put({"ERR1", "auto"}, {pre});
+
+	MockFetcher fetch;
+	fetch.AddResponse("run_accession%20IN", RunRowTSV("ERR2"));
+
+	auto result = miint::ResolveRunsBatch(fetch, cache, {"ERR1", "ERR2"}, "auto");
+
+	// Only one fetch for ERR2
+	CHECK(fetch.urls().size() == 1);
+	// Fetch URL should contain ERR2 but not ERR1
+	CHECK(fetch.urls()[0].find("ERR2") != std::string::npos);
+	CHECK(fetch.urls()[0].find("ERR1") == std::string::npos);
+	CHECK(result["ERR1"].size() == 1);
+	CHECK(result["ERR2"].size() == 1);
+}
+
+TEST_CASE("ResolveRunsBatch negative-caches empty results", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+	// Fetcher returns header-only TSV → no rows → empty
+
+	miint::ResolveRunsBatch(fetch, cache, {"ERR_MISSING"}, "auto");
+	CHECK(fetch.urls().size() == 1);
+
+	// Second call should hit cache, not fetch
+	miint::ResolveRunsBatch(fetch, cache, {"ERR_MISSING"}, "auto");
+	CHECK(fetch.urls().size() == 1);
+}
+
+TEST_CASE("ResolveRunsBatch deduplicates input accessions", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+	fetch.AddResponse("run_accession%20IN", RunRowTSV("ERR1"));
+
+	auto result = miint::ResolveRunsBatch(fetch, cache, {"ERR1", "ERR1", "ERR1"}, "auto");
+
+	CHECK(fetch.urls().size() == 1);
+	// URL should include ERR1 only once in the IN clause
+	size_t n = 0;
+	const auto &url = fetch.urls()[0];
+	auto pos = url.find("%22ERR1%22");
+	while (pos != std::string::npos) {
+		n++;
+		pos = url.find("%22ERR1%22", pos + 1);
+	}
+	CHECK(n == 1);
+	REQUIRE(result.count("ERR1") == 1);
+}
+
+TEST_CASE("ResolveRunsBatch drops rows whose grouping key matches no input", "[ena]") {
+	// ENA sometimes returns extra rows (e.g., alternative run accessions under the same
+	// sample or study). FetchBatch must NOT cache those under their grouping keys, because
+	// doing so would pollute the cache with entries the caller never asked for and could
+	// create false-positive hits in future queries.
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+
+	// Batch query for ERR1 — server returns an extra row for ERR_UNEXPECTED.
+	std::string tsv = "run_accession\tsample_accession\texperiment_accession\tstudy_accession\t"
+	                  "fastq_ftp\tfastq_aspera\tfastq_bytes\tlibrary_layout\t"
+	                  "submitted_ftp\tsubmitted_aspera\tsubmitted_bytes\tsubmitted_format\n"
+	                  "ERR1\tSAM1\tEXP1\t\tftp.example.com/ERR1.fastq.gz\t\t100\tSINGLE\t\t\t\t\n"
+	                  "ERR_UNEXPECTED\tSAM2\tEXP2\t\tftp.example.com/ERR_UNEXPECTED.fastq.gz\t\t200\tSINGLE\t\t\t\t\n";
+	fetch.AddResponse("run_accession%20IN", tsv);
+
+	auto result = miint::ResolveRunsBatch(fetch, cache, {"ERR1"}, "auto");
+
+	// Only ERR1 should be in the result
+	CHECK(result.count("ERR1") == 1);
+	CHECK(result["ERR1"].size() == 1);
+	CHECK(result.count("ERR_UNEXPECTED") == 0);
+
+	// Cache must not hold an entry for ERR_UNEXPECTED
+	std::vector<miint::ENARunInfo> tmp;
+	CHECK_FALSE(cache.Get({"ERR_UNEXPECTED", "auto"}, tmp));
+	CHECK(cache.Get({"ERR1", "auto"}, tmp));
+}
+
+TEST_CASE("ResolveRunsBatch throws when batch response is missing grouping column", "[ena]") {
+	// If ENA returns a TSV that doesn't include the column we grouped by (e.g., an API
+	// change or server error), we must throw rather than silently report no results.
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+	// Response with columns but none that match run_accession (the grouping column for RUN type)
+	fetch.AddResponse("run_accession%20IN", "sample_accession\tfastq_ftp\nSAM1\tftp.example.com/a.fastq.gz\n");
+
+	CHECK_THROWS(miint::ResolveRunsBatch(fetch, cache, {"ERR1"}, "auto"));
+}
+
+TEST_CASE("ResolveRunsBatch: UNKNOWN-type falls back to per-accession fetch", "[ena]") {
+	miint::ENAResolverCache cache(16);
+	MockFetcher fetch;
+	// Unknown-type accessions go through BuildSearchURL (single-accession path), which
+	// uses %3D%22 (equals) rather than %20IN%20%28 (compound).
+
+	miint::ENAFetcher fetcher = [&fetch](const std::string &url) {
+		return fetch(url);
+	};
+	miint::ResolveRunsBatch(fetcher, cache, {"unknown-acc1", "unknown-acc2"}, "auto");
+
+	CHECK(fetch.urls().size() == 2); // one fetch per accession
+	for (const auto &u : fetch.urls()) {
+		CHECK(u.find("%3D%22") != std::string::npos);      // equality query
+		CHECK(u.find("%20IN%20%28") == std::string::npos); // NOT a batched query
 	}
 }

--- a/test/cpp/test_ENAResolverCache.cpp
+++ b/test/cpp/test_ENAResolverCache.cpp
@@ -1,0 +1,164 @@
+#include <catch2/catch_test_macros.hpp>
+#include "ena_resolver_cache.hpp"
+#include <atomic>
+#include <thread>
+#include <vector>
+
+static miint::ENARunInfo MakeRun(const std::string &acc) {
+	miint::ENARunInfo r;
+	r.run_accession = acc;
+	return r;
+}
+
+TEST_CASE("ENAResolverCache: miss then hit", "[ena][cache]") {
+	miint::ENAResolverCache cache(4);
+	miint::ENAResolverCache::Key key {"ERR1", "auto"};
+
+	std::vector<miint::ENARunInfo> out;
+	CHECK_FALSE(cache.Get(key, out));
+
+	std::vector<miint::ENARunInfo> value;
+	value.push_back(MakeRun("ERR1"));
+	cache.Put(key, value);
+
+	CHECK(cache.Get(key, out));
+	REQUIRE(out.size() == 1);
+	CHECK(out[0].run_accession == "ERR1");
+}
+
+TEST_CASE("ENAResolverCache: LRU eviction at capacity", "[ena][cache]") {
+	miint::ENAResolverCache cache(2);
+
+	cache.Put({"ERR1", "auto"}, {MakeRun("ERR1")});
+	cache.Put({"ERR2", "auto"}, {MakeRun("ERR2")});
+	CHECK(cache.Size() == 2);
+
+	// Touch ERR1 to make it MRU; ERR2 becomes LRU
+	std::vector<miint::ENARunInfo> out;
+	CHECK(cache.Get({"ERR1", "auto"}, out));
+
+	// Insert ERR3 → ERR2 should be evicted
+	cache.Put({"ERR3", "auto"}, {MakeRun("ERR3")});
+	CHECK(cache.Size() == 2);
+	CHECK(cache.Get({"ERR1", "auto"}, out));
+	CHECK(cache.Get({"ERR3", "auto"}, out));
+	CHECK_FALSE(cache.Get({"ERR2", "auto"}, out));
+}
+
+TEST_CASE("ENAResolverCache: key includes prefer_format", "[ena][cache]") {
+	miint::ENAResolverCache cache(4);
+	cache.Put({"ERR1", "auto"}, {MakeRun("ERR1-auto")});
+	cache.Put({"ERR1", "sff"}, {MakeRun("ERR1-sff")});
+
+	std::vector<miint::ENARunInfo> out;
+	REQUIRE(cache.Get({"ERR1", "auto"}, out));
+	CHECK(out[0].run_accession == "ERR1-auto");
+
+	REQUIRE(cache.Get({"ERR1", "sff"}, out));
+	CHECK(out[0].run_accession == "ERR1-sff");
+
+	CHECK_FALSE(cache.Get({"ERR1", "fastq"}, out));
+}
+
+TEST_CASE("ENAResolverCache: negative caching (empty vector) returns hit", "[ena][cache]") {
+	miint::ENAResolverCache cache(4);
+	miint::ENAResolverCache::Key key {"ERR_MISSING", "auto"};
+
+	cache.Put(key, std::vector<miint::ENARunInfo> {}); // negative cache entry
+
+	std::vector<miint::ENARunInfo> out;
+	out.push_back(MakeRun("stale")); // ensure Get overwrites
+	CHECK(cache.Get(key, out));
+	CHECK(out.empty());
+}
+
+TEST_CASE("ENAResolverCache: replace existing key updates value and bumps MRU", "[ena][cache]") {
+	miint::ENAResolverCache cache(2);
+	cache.Put({"ERR1", "auto"}, {MakeRun("v1")});
+	cache.Put({"ERR2", "auto"}, {MakeRun("ERR2")});
+
+	// Overwrite ERR1 with v2; this bumps ERR1 to MRU (so ERR2 is LRU)
+	cache.Put({"ERR1", "auto"}, {MakeRun("v2")});
+
+	// Evict ERR2 by inserting ERR3
+	cache.Put({"ERR3", "auto"}, {MakeRun("ERR3")});
+
+	std::vector<miint::ENARunInfo> out;
+	REQUIRE(cache.Get({"ERR1", "auto"}, out));
+	CHECK(out[0].run_accession == "v2");
+	CHECK(cache.Get({"ERR3", "auto"}, out));
+	CHECK_FALSE(cache.Get({"ERR2", "auto"}, out));
+}
+
+TEST_CASE("ENAResolverCache: capacity=0 disables caching", "[ena][cache]") {
+	miint::ENAResolverCache cache(0);
+	cache.Put({"ERR1", "auto"}, {MakeRun("ERR1")});
+	CHECK(cache.Size() == 0);
+	std::vector<miint::ENARunInfo> out;
+	CHECK_FALSE(cache.Get({"ERR1", "auto"}, out));
+}
+
+TEST_CASE("ENAResolverCache: concurrent Put/Get (thread safety sanity)", "[ena][cache]") {
+	miint::ENAResolverCache cache(128);
+	constexpr int kThreads = 8;
+	constexpr int kIters = 2000;
+
+	std::atomic<int> failures {0};
+	std::vector<std::thread> ts;
+	for (int t = 0; t < kThreads; t++) {
+		ts.emplace_back([&, t]() {
+			for (int i = 0; i < kIters; i++) {
+				std::string acc = "ERR" + std::to_string((t * kIters + i) % 50); // 50 distinct keys
+				miint::ENAResolverCache::Key key {acc, "auto"};
+				std::vector<miint::ENARunInfo> out;
+				if (cache.Get(key, out)) {
+					if (!out.empty() && out[0].run_accession != acc) {
+						failures.fetch_add(1);
+					}
+				} else {
+					cache.Put(key, {MakeRun(acc)});
+				}
+			}
+		});
+	}
+	for (auto &th : ts) {
+		th.join();
+	}
+	CHECK(failures.load() == 0);
+}
+
+TEST_CASE("ENAResolverCache: adversarial eviction under contention", "[ena][cache]") {
+	// Capacity < live-key count forces constant eviction. 8 threads hammering 8 keys
+	// against a 4-slot cache stresses the Put eviction path (order.pop_back +
+	// map.erase + order.push_front + map.emplace) under concurrent access.
+	miint::ENAResolverCache cache(4);
+	constexpr int kThreads = 8;
+	constexpr int kKeys = 8;
+	constexpr int kIters = 5000;
+
+	std::atomic<int> corruption {0};
+	std::vector<std::thread> ts;
+	for (int t = 0; t < kThreads; t++) {
+		ts.emplace_back([&, t]() {
+			for (int i = 0; i < kIters; i++) {
+				std::string acc = "ACC" + std::to_string((t + i) % kKeys);
+				miint::ENAResolverCache::Key key {acc, "auto"};
+				std::vector<miint::ENARunInfo> out;
+				if (cache.Get(key, out)) {
+					// A hit must return a value matching its key (no cross-key contamination).
+					if (!out.empty() && out[0].run_accession != acc) {
+						corruption.fetch_add(1);
+					}
+				} else {
+					cache.Put(key, {MakeRun(acc)});
+				}
+			}
+		});
+	}
+	for (auto &th : ts) {
+		th.join();
+	}
+	CHECK(corruption.load() == 0);
+	// Cache must remain within capacity regardless of the race pattern.
+	CHECK(cache.Size() <= 4);
+}

--- a/test/cpp/test_ena_attributes_filter.cpp
+++ b/test/cpp/test_ena_attributes_filter.cpp
@@ -1,0 +1,186 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "ena_attributes_filter.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using miint::ENAAttributePushdown;
+using miint::ENAFilterNode;
+using miint::ExtractPushdownPredicates;
+
+// Helper: wrap a single ENAFilterNode as the conjunct-list that
+// ExtractPushdownPredicates expects (DuckDB already splits top-level AND).
+static std::vector<std::unique_ptr<ENAFilterNode>> SingleConjunct(std::unique_ptr<ENAFilterNode> node) {
+	std::vector<std::unique_ptr<ENAFilterNode>> out;
+	out.push_back(std::move(node));
+	return out;
+}
+
+TEST_CASE("ExtractPushdownPredicates detects tag = 'X'", "[ena][pushdown]") {
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeEqual("tag", "host_body_site"));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	REQUIRE(result.tags.size() == 1);
+	CHECK(result.tags[0] == "host_body_site");
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates detects tag IN (...) when all in allowlist", "[ena][pushdown]") {
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeIn("tag", {"host_body_site", "collection_date"}));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	REQUIRE(result.tags.size() == 2);
+	CHECK(result.tags[0] == "host_body_site");
+	CHECK(result.tags[1] == "collection_date");
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates detects tag = X AND value = Y", "[ena][pushdown]") {
+	// DuckDB splits top-level AND into two conjuncts.
+	std::vector<std::unique_ptr<ENAFilterNode>> conjuncts;
+	conjuncts.push_back(ENAFilterNode::MakeEqual("tag", "host_body_site"));
+	conjuncts.push_back(ENAFilterNode::MakeEqual("value", "UBERON:feces"));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	REQUIRE(result.tags.size() == 1);
+	CHECK(result.tags[0] == "host_body_site");
+	REQUIRE(result.tag_value_pairs.size() == 1);
+	CHECK(result.tag_value_pairs[0].first == "host_body_site");
+	CHECK(result.tag_value_pairs[0].second == "UBERON:feces");
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back when any tag is unknown (IN list)", "[ena][pushdown]") {
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeIn("tag", {"host_body_site", "some_custom_tag"}));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back on OR across valid+unknown tags", "[ena][pushdown]") {
+	std::vector<std::unique_ptr<ENAFilterNode>> or_children;
+	or_children.push_back(ENAFilterNode::MakeEqual("tag", "host_body_site"));
+	or_children.push_back(ENAFilterNode::MakeEqual("tag", "some_custom_tag"));
+
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeOr(std::move(or_children)));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back on non-equality operator on tag", "[ena][pushdown]") {
+	// tag LIKE 'host_%' — ENAFilterNode::MakeUnsupported() represents an
+	// expression the DuckDB→AST translator couldn't map onto EQ/IN/AND/OR.
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeUnsupported());
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back on non-equality operator on value", "[ena][pushdown]") {
+	// tag='host_body_site' AND value LIKE 'UBERON:%' — the tag conjunct maps
+	// cleanly, but the value conjunct is unsupported. Any unsupported conjunct
+	// forces fallback (not a partial push).
+	std::vector<std::unique_ptr<ENAFilterNode>> conjuncts;
+	conjuncts.push_back(ENAFilterNode::MakeEqual("tag", "host_body_site"));
+	conjuncts.push_back(ENAFilterNode::MakeUnsupported());
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back when value is constrained without a pinned tag", "[ena][pushdown]") {
+	// value='UBERON:feces' alone is ambiguous (which tag?). Fallback required.
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeEqual("value", "UBERON:feces"));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back when sample_accession is constrained", "[ena][pushdown]") {
+	// tag='host_body_site' AND sample_accession='SAMN...' — we can't translate
+	// the sample_accession predicate through the /search endpoint with the same
+	// semantics as the XML path's output, so we reject the whole thing for
+	// safety.
+	std::vector<std::unique_ptr<ENAFilterNode>> conjuncts;
+	conjuncts.push_back(ENAFilterNode::MakeEqual("tag", "host_body_site"));
+	conjuncts.push_back(ENAFilterNode::MakeEqual("sample_accession", "SAMN12345"));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates is case-insensitive for tag values", "[ena][pushdown]") {
+	// WHERE tag='HOST_BODY_SITE' — user-typed uppercase must still match the
+	// registry and be stored lowercase in the output.
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeEqual("tag", "HOST_BODY_SITE"));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	REQUIRE(result.tags.size() == 1);
+	CHECK(result.tags[0] == "host_body_site");
+}
+
+TEST_CASE("ExtractPushdownPredicates deduplicates repeated tags", "[ena][pushdown]") {
+	// WHERE tag IN ('host_body_site','HOST_BODY_SITE') — two spellings of the
+	// same canonical tag should collapse.
+	auto conjuncts = SingleConjunct(ENAFilterNode::MakeIn("tag", {"host_body_site", "HOST_BODY_SITE"}));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	REQUIRE(result.tags.size() == 1);
+	CHECK(result.tags[0] == "host_body_site");
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back on multiple tag IN conjuncts", "[ena][pushdown]") {
+	// `tag IN ('a','b') AND tag IN ('c','d')` has SQL INTERSECTION semantics
+	// (tag must be in both sets). Emitting the union to ENA would broaden the
+	// wire query; reject for strict correctness.
+	std::vector<std::unique_ptr<ENAFilterNode>> conjuncts;
+	conjuncts.push_back(ENAFilterNode::MakeIn("tag", {"host_body_site", "collection_date"}));
+	conjuncts.push_back(ENAFilterNode::MakeIn("tag", {"collection_date", "scientific_name"}));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates falls back on tag IN (...) AND value=Y", "[ena][pushdown]") {
+	// value= pin requires a single-tag EQ pin (one row → one tag → unambiguous
+	// column to constrain). With tag IN, the column to constrain is ambiguous.
+	std::vector<std::unique_ptr<ENAFilterNode>> conjuncts;
+	conjuncts.push_back(ENAFilterNode::MakeIn("tag", {"host_body_site", "collection_date"}));
+	conjuncts.push_back(ENAFilterNode::MakeEqual("value", "UBERON:feces"));
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}
+
+TEST_CASE("ExtractPushdownPredicates on empty input returns empty (no pushdown)", "[ena][pushdown]") {
+	std::vector<std::unique_ptr<ENAFilterNode>> conjuncts;
+
+	auto result = ExtractPushdownPredicates(conjuncts);
+
+	CHECK(result.tags.empty());
+	CHECK(result.tag_value_pairs.empty());
+}

--- a/test/cpp/test_ena_attributes_pushdown.cpp
+++ b/test/cpp/test_ena_attributes_pushdown.cpp
@@ -1,0 +1,213 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "ena_attributes_filter.hpp"
+#include "ena_parser.hpp"
+
+#include <string>
+#include <vector>
+
+using miint::BuildStructuredSearchURL;
+using miint::ENAParser;
+using miint::ENATSVResult;
+using miint::SampleAttribute;
+using miint::UnpivotStructuredTSV;
+
+TEST_CASE("BuildStructuredSearchURL emits tag-only query when no pinned values", "[ena][pushdown]") {
+	std::vector<std::string> sample_accs = {"SAMN111", "SAMN222"};
+	std::vector<std::string> tags = {"host_body_site", "collection_date"};
+	std::vector<std::pair<std::string, std::string>> pairs;
+
+	auto url = BuildStructuredSearchURL(sample_accs, tags, pairs);
+
+	CHECK(url.find("https://www.ebi.ac.uk/ena/portal/api/search?") == 0);
+	CHECK(url.find("result=sample") != std::string::npos);
+	CHECK(url.find("fields=sample_accession,host_body_site,collection_date") != std::string::npos);
+	// Accession IN-filter, URL-encoded.
+	CHECK(url.find("sample_accession%20IN%20%28%22SAMN111%22%2C%22SAMN222%22%29") != std::string::npos);
+	// No AND clauses — no tag_value_pairs were supplied.
+	CHECK(url.find("%20AND%20") == std::string::npos);
+	CHECK(url.find("format=tsv") != std::string::npos);
+}
+
+TEST_CASE("BuildStructuredSearchURL appends AND tag=value for each pinned pair", "[ena][pushdown]") {
+	std::vector<std::string> sample_accs = {"SAMN111"};
+	std::vector<std::string> tags = {"host_body_site"};
+	std::vector<std::pair<std::string, std::string>> pairs = {{"host_body_site", "UBERON:feces"}};
+
+	auto url = BuildStructuredSearchURL(sample_accs, tags, pairs);
+
+	// The `:` in "UBERON:feces" must be percent-encoded as %3A.
+	CHECK(url.find("%20AND%20host_body_site%3D%22UBERON%3Afeces%22") != std::string::npos);
+	CHECK(url.find("fields=sample_accession,host_body_site") != std::string::npos);
+}
+
+TEST_CASE("BuildStructuredSearchURL deduplicates fields while preserving order", "[ena][pushdown]") {
+	// Caller may pass the same tag twice (e.g., from a weirdly-canonicalized
+	// filter). `sample_accession` must stay first; duplicates drop.
+	std::vector<std::string> sample_accs = {"SAMN111"};
+	std::vector<std::string> tags = {"host_body_site", "host_body_site"};
+	std::vector<std::pair<std::string, std::string>> pairs;
+
+	auto url = BuildStructuredSearchURL(sample_accs, tags, pairs);
+
+	CHECK(url.find("fields=sample_accession,host_body_site") != std::string::npos);
+	// No double host_body_site.
+	CHECK(url.find("host_body_site,host_body_site") == std::string::npos);
+}
+
+TEST_CASE("BuildStructuredSearchURL rejects empty sample_accessions", "[ena][pushdown]") {
+	std::vector<std::string> tags = {"host_body_site"};
+	std::vector<std::pair<std::string, std::string>> pairs;
+
+	CHECK_THROWS(BuildStructuredSearchURL({}, tags, pairs));
+}
+
+TEST_CASE("BuildStructuredSearchURL rejects empty tags", "[ena][pushdown]") {
+	std::vector<std::string> sample_accs = {"SAMN111"};
+	std::vector<std::pair<std::string, std::string>> pairs;
+
+	CHECK_THROWS(BuildStructuredSearchURL(sample_accs, {}, pairs));
+}
+
+TEST_CASE("BuildStructuredSearchURL rejects pinned tag not in tags", "[ena][pushdown]") {
+	// Callers that hand-build a pushdown (rather than going through
+	// ExtractPushdownPredicates) could supply a tag_value_pair whose tag is
+	// absent from `tags`. The resulting URL would carry a query clause for a
+	// field we didn't ask ENA to return. Reject to prevent this mismatch.
+	std::vector<std::string> sample_accs = {"SAMN111"};
+	std::vector<std::string> tags = {"host_body_site"};
+	std::vector<std::pair<std::string, std::string>> pairs = {{"collection_date", "2020-03-14"}};
+
+	CHECK_THROWS(BuildStructuredSearchURL(sample_accs, tags, pairs));
+}
+
+TEST_CASE("BuildStructuredSearchURL percent-encodes control chars in values", "[ena][pushdown]") {
+	// Values come from user-supplied SQL literals; a malformed or hostile
+	// value shouldn't be able to break out of the quoted `field="..."`
+	// context. Exercise CR / LF / NUL / tab / quote / ampersand / space
+	// specifically.
+	std::vector<std::string> sample_accs = {"SAMN111"};
+	std::vector<std::string> tags = {"host_body_site"};
+
+	std::string value_with_controls;
+	value_with_controls.push_back('\r');
+	value_with_controls.push_back('\n');
+	value_with_controls.push_back('\t');
+	value_with_controls.push_back('\0');
+	value_with_controls.push_back(' ');
+	value_with_controls.push_back('&');
+	value_with_controls.push_back('"');
+	value_with_controls.push_back('a');
+
+	std::vector<std::pair<std::string, std::string>> pairs = {{"host_body_site", value_with_controls}};
+
+	auto url = BuildStructuredSearchURL(sample_accs, tags, pairs);
+
+	// Each control char must appear as its upper-case hex %XX escape.
+	CHECK(url.find("%0D") != std::string::npos); // CR
+	CHECK(url.find("%0A") != std::string::npos); // LF
+	CHECK(url.find("%09") != std::string::npos); // TAB
+	CHECK(url.find("%00") != std::string::npos); // NUL
+	CHECK(url.find("%20") != std::string::npos); // space
+	CHECK(url.find("%26") != std::string::npos); // &
+	CHECK(url.find("%22") != std::string::npos); // " (also closes the field="" pair, so appears 2x)
+	// Literal plaintext char stays unescaped.
+	CHECK(url.find("a%22") != std::string::npos);
+	// No raw CR/LF/NUL survived.
+	CHECK(url.find('\r') == std::string::npos);
+	CHECK(url.find('\n') == std::string::npos);
+	CHECK(url.find('\0') == std::string::npos);
+}
+
+TEST_CASE("BuildStructuredSearchURL rejects injection via accession", "[ena][pushdown]") {
+	// Accession validation is delegated to ENAParser::ValidateAccession,
+	// which rejects non-alphanumeric (modulo _ - .). Confirm upstream
+	// validation fires.
+	std::vector<std::string> sample_accs = {"SAMN\"; DROP TABLE"};
+	std::vector<std::string> tags = {"host_body_site"};
+	std::vector<std::pair<std::string, std::string>> pairs;
+
+	CHECK_THROWS(BuildStructuredSearchURL(sample_accs, tags, pairs));
+}
+
+TEST_CASE("UnpivotStructuredTSV emits one row per non-empty tag column", "[ena][pushdown]") {
+	ENATSVResult parsed;
+	parsed.column_names = {"sample_accession", "host_body_site", "collection_date"};
+	parsed.rows = {
+	    {"SAMN111", "UBERON:feces", "2020-03-14"},
+	    {"SAMN222", "UBERON:saliva", "2021-06-02"},
+	};
+
+	auto rows = UnpivotStructuredTSV(parsed, {"host_body_site", "collection_date"});
+
+	REQUIRE(rows.size() == 4);
+	CHECK(rows[0].sample_accession == "SAMN111");
+	CHECK(rows[0].tag == "host_body_site");
+	CHECK(rows[0].value == "UBERON:feces");
+	CHECK(rows[1].sample_accession == "SAMN111");
+	CHECK(rows[1].tag == "collection_date");
+	CHECK(rows[1].value == "2020-03-14");
+	CHECK(rows[2].sample_accession == "SAMN222");
+	CHECK(rows[2].tag == "host_body_site");
+	CHECK(rows[2].value == "UBERON:saliva");
+	CHECK(rows[3].sample_accession == "SAMN222");
+	CHECK(rows[3].tag == "collection_date");
+	CHECK(rows[3].value == "2021-06-02");
+}
+
+TEST_CASE("UnpivotStructuredTSV skips empty cells", "[ena][pushdown]") {
+	// Matches XML-path behavior: samples without a given attribute produce no
+	// row for that (sample, tag) pair.
+	ENATSVResult parsed;
+	parsed.column_names = {"sample_accession", "host_body_site", "collection_date"};
+	parsed.rows = {
+	    {"SAMN111", "", "2020-03-14"},    // missing host_body_site
+	    {"SAMN222", "UBERON:saliva", ""}, // missing collection_date
+	};
+
+	auto rows = UnpivotStructuredTSV(parsed, {"host_body_site", "collection_date"});
+
+	REQUIRE(rows.size() == 2);
+	CHECK(rows[0].sample_accession == "SAMN111");
+	CHECK(rows[0].tag == "collection_date");
+	CHECK(rows[1].sample_accession == "SAMN222");
+	CHECK(rows[1].tag == "host_body_site");
+}
+
+TEST_CASE("UnpivotStructuredTSV handles short rows (missing trailing columns)", "[ena][pushdown]") {
+	// ENA sometimes returns rows shorter than the header row when all trailing
+	// columns are empty. Treat out-of-bounds cells as empty.
+	ENATSVResult parsed;
+	parsed.column_names = {"sample_accession", "host_body_site", "collection_date"};
+	parsed.rows = {
+	    {"SAMN111", "UBERON:feces"}, // collection_date column absent in row
+	};
+
+	auto rows = UnpivotStructuredTSV(parsed, {"host_body_site", "collection_date"});
+
+	REQUIRE(rows.size() == 1);
+	CHECK(rows[0].tag == "host_body_site");
+}
+
+TEST_CASE("UnpivotStructuredTSV returns empty when sample_accession column is missing", "[ena][pushdown]") {
+	ENATSVResult parsed;
+	parsed.column_names = {"host_body_site"};
+	parsed.rows = {{"UBERON:feces"}};
+
+	auto rows = UnpivotStructuredTSV(parsed, {"host_body_site"});
+
+	CHECK(rows.empty());
+}
+
+TEST_CASE("UnpivotStructuredTSV case-insensitive column matching", "[ena][pushdown]") {
+	ENATSVResult parsed;
+	parsed.column_names = {"SAMPLE_ACCESSION", "HOST_BODY_SITE"};
+	parsed.rows = {{"SAMN111", "UBERON:feces"}};
+
+	auto rows = UnpivotStructuredTSV(parsed, {"host_body_site"});
+
+	REQUIRE(rows.size() == 1);
+	CHECK(rows[0].sample_accession == "SAMN111");
+	CHECK(rows[0].tag == "host_body_site");
+	CHECK(rows[0].value == "UBERON:feces");
+}

--- a/test/cpp/test_ena_search_field_registry.cpp
+++ b/test/cpp/test_ena_search_field_registry.cpp
@@ -1,0 +1,40 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "ena_search_field_registry.hpp"
+
+TEST_CASE("ENASearchFieldRegistry recognizes host_body_site", "[ena][registry]") {
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("host_body_site"));
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("collection_date"));
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("scientific_name"));
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("sample_accession"));
+}
+
+TEST_CASE("ENASearchFieldRegistry rejects unknown tag", "[ena][registry]") {
+	CHECK_FALSE(miint::ENASearchFieldRegistry::IsSearchableSampleField("some_custom_tag"));
+	CHECK_FALSE(miint::ENASearchFieldRegistry::IsSearchableSampleField("ENV_FEATURE"));
+	// Typo in a real field: still not in the set.
+	CHECK_FALSE(miint::ENASearchFieldRegistry::IsSearchableSampleField("host_bodysite"));
+}
+
+TEST_CASE("ENASearchFieldRegistry is case-insensitive", "[ena][registry]") {
+	// Real filters may come from users typing WHERE tag='HOST_BODY_SITE'.
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("HOST_BODY_SITE"));
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("Host_Body_Site"));
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("COLLECTION_DATE"));
+}
+
+TEST_CASE("ENASearchFieldRegistry trims whitespace", "[ena][registry]") {
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("  host_body_site  "));
+	CHECK(miint::ENASearchFieldRegistry::IsSearchableSampleField("\tcollection_date\n"));
+	CHECK_FALSE(miint::ENASearchFieldRegistry::IsSearchableSampleField(""));
+	CHECK_FALSE(miint::ENASearchFieldRegistry::IsSearchableSampleField("   "));
+}
+
+TEST_CASE("ENASearchFieldRegistry set is non-empty and sorted", "[ena][registry]") {
+	const auto &fields = miint::ENASearchFieldRegistry::SearchableSampleFields();
+	// Sanity check: the curated list should have at least a few dozen entries.
+	// Drops from regeneration will trip this and force an update to the test.
+	REQUIRE(fields.size() >= 40);
+	REQUIRE(fields.count("host_body_site") == 1);
+	REQUIRE(fields.count("environment_biome") == 1);
+}

--- a/test/sql/ena_searchable_fields.test
+++ b/test/sql/ena_searchable_fields.test
@@ -1,0 +1,57 @@
+# name: test/sql/ena_searchable_fields.test
+# description: Test ena_searchable_fields discovery table function
+# group: [sql]
+
+# NOTE: This test requires network access to EBI/ENA servers.
+
+require httpfs
+
+require miint
+
+require-env ENA_AVAILABLE
+
+# ---- Schema ----
+
+query III
+DESCRIBE SELECT * FROM ena_searchable_fields('sample');
+----
+field_name	VARCHAR	YES	NULL	NULL	NULL
+type	VARCHAR	YES	NULL	NULL	NULL
+description	VARCHAR	YES	NULL	NULL	NULL
+
+# ---- At least a reasonable number of sample fields are returned ----
+
+query I
+SELECT COUNT(*) > 20 AS has_many FROM ena_searchable_fields('sample');
+----
+true
+
+# ---- Core MIxS fields present for sample result type ----
+
+query I
+SELECT COUNT(*) = 2
+FROM ena_searchable_fields('sample')
+WHERE field_name IN ('host_body_site', 'collection_date');
+----
+true
+
+# ---- read_run is also a valid result type ----
+
+query I
+SELECT COUNT(*) > 0 FROM ena_searchable_fields('read_run');
+----
+true
+
+# ---- Invalid result_type: empty ----
+
+statement error
+SELECT * FROM ena_searchable_fields('');
+----
+result_type cannot be empty
+
+# ---- Invalid result_type: URL injection attempt rejected at bind ----
+
+statement error
+SELECT * FROM ena_searchable_fields('sample&query=evil');
+----
+result_type contains invalid characters

--- a/test/sql/read_ena.test
+++ b/test/sql/read_ena.test
@@ -9,6 +9,9 @@ require httpfs
 
 require miint
 
+# Skip when ENA Portal API is not reachable (offline CI, blocked network).
+require-env ENA_AVAILABLE
+
 # ---- Error handling (no network needed) ----
 
 statement error

--- a/test/sql/read_ena_attributes.test
+++ b/test/sql/read_ena_attributes.test
@@ -8,6 +8,9 @@ require httpfs
 
 require miint
 
+# Skip when ENA Portal API is not reachable (offline CI, blocked network).
+require-env ENA_AVAILABLE
+
 # ---- Error handling ----
 
 statement error

--- a/test/sql/read_ena_attributes_pushdown.test
+++ b/test/sql/read_ena_attributes_pushdown.test
@@ -1,0 +1,92 @@
+# name: test/sql/read_ena_attributes_pushdown.test
+# description: Predicate pushdown for read_ena_attributes (WHERE tag=... / tag IN ...)
+# group: [sql]
+
+# NOTE: Requires network access to EBI/ENA. Gated via ENA_AVAILABLE.
+
+require httpfs
+
+require miint
+
+require-env ENA_AVAILABLE
+
+# ---- Output shape is unchanged whether or not pushdown fires ----
+
+query IIIIII
+DESCRIBE SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='collection_date';
+----
+sample_accession	VARCHAR	YES	NULL	NULL	NULL
+tag	VARCHAR	YES	NULL	NULL	NULL
+value	VARCHAR	YES	NULL	NULL	NULL
+
+# ---- Pushdown on a tag known to be present on this sample ----
+# ERR1074767 → sample SAMEA3610311, which has a `collection_date` attribute.
+# `collection_date` is in the search-field allowlist, so the structured path
+# fires. DuckDB re-applies the filter above the scan (plan decision #5), so
+# even if ENA's structured matcher disagreed with the XML path we'd still be
+# correct — the count here is a sanity check.
+
+query I
+SELECT COUNT(*) > 0
+FROM read_ena_attributes('ERR1074767') WHERE tag='collection_date';
+----
+true
+
+# ---- Pushdown equivalence: structured path must agree with XML fallback ----
+# For a tag present on the sample, the two paths should return the same row
+# count. We force XML by including an unknown tag in the IN list (per plan
+# decision #4, any unknown tag disables pushdown for the whole filter).
+
+query I
+SELECT (
+  SELECT COUNT(*) FROM read_ena_attributes('ERR1074767') WHERE tag='collection_date'
+) = (
+  SELECT COUNT(*) FROM read_ena_attributes('ERR1074767')
+  WHERE tag IN ('collection_date','some_custom_unknown_tag')
+);
+----
+true
+
+# ---- tag IN (...) with all fields in the allowlist ----
+
+query I
+SELECT COUNT(*) > 0
+FROM read_ena_attributes('ERR1074767')
+WHERE tag IN ('collection_date','scientific_name');
+----
+true
+
+# ---- Unknown tag alone falls back to XML path ----
+# The XML path sees zero matches for 'some_custom_unknown_tag' on this
+# sample; we only assert it runs without error.
+
+query I
+SELECT COUNT(*) >= 0
+FROM read_ena_attributes('ERR1074767') WHERE tag='some_custom_unknown_tag';
+----
+true
+
+# ---- Case-insensitive pushdown ----
+# User-typed uppercase must canonicalize through the registry and return the
+# same count as the lowercase form.
+
+query I
+SELECT (
+  SELECT COUNT(*) FROM read_ena_attributes('ERR1074767') WHERE tag='COLLECTION_DATE'
+) = (
+  SELECT COUNT(*) FROM read_ena_attributes('ERR1074767') WHERE tag='collection_date'
+);
+----
+true
+
+# ---- tag + value pinning (structured `field="value"` query) ----
+# Sanity: when the pinned value doesn't match, the structured path returns
+# zero, and DuckDB's re-applied filter on top would filter out any XML-path
+# mismatches too. Result: zero rows, no error.
+
+query I
+SELECT COUNT(*) = 0
+FROM read_ena_attributes('ERR1074767')
+WHERE tag='collection_date' AND value='this_value_does_not_exist_anywhere';
+----
+true

--- a/test/sql/read_ena_attributes_pushdown_translator.test
+++ b/test/sql/read_ena_attributes_pushdown_translator.test
@@ -1,0 +1,77 @@
+# name: test/sql/read_ena_attributes_pushdown_translator.test
+# description: Exercise the DuckDB-Expression -> ENAFilterNode translator via EXPLAIN. EXPLAIN triggers Bind + optimizer (which calls PushdownComplexFilter) without executing the scan, so these tests run without network access.
+# group: [sql]
+
+require miint
+
+# ---- Pushable shapes ----
+# Translator must accept these without crashing. Correctness of the produced
+# AST is validated separately by the [pushdown]-tagged C++ tests over the
+# pure ExtractPushdownPredicates helper.
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='host_body_site';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag IN ('host_body_site','collection_date');
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='HOST_BODY_SITE' AND value='UBERON:feces';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE value='UBERON:feces' AND tag='host_body_site';
+
+# ---- Shapes that must map to UNSUPPORTED (fallback to XML) without crashing ----
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag LIKE 'host_%';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag!='host_body_site';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag IS NULL;
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE value='UBERON:feces';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE sample_accession='SAMEA3610311';
+
+# ---- Conjunctions (top-level AND) with mixed accept/reject atoms ----
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='host_body_site' AND tag LIKE 'host_%';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='host_body_site' AND sample_accession='SAMEA3610311';
+
+# ---- Disjunctions (OR) — whole-tree reject ----
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='host_body_site' OR tag='scientific_name';
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag='host_body_site' OR sample_accession='SAMEA3610311';
+
+# ---- Multiple tag IN conjuncts (reject: semantic intersection, not union) ----
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767')
+WHERE tag IN ('host_body_site','collection_date') AND tag IN ('collection_date','scientific_name');
+
+# ---- No WHERE — callback is never called; sanity baseline ----
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767');
+
+# ---- IN with a NULL element (runtime NULL handling) ----
+# DuckDB may rewrite this; the translator must not crash regardless.
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag IN ('host_body_site', NULL);
+
+# ---- Non-constant side (column vs column) — must fall through to UNSUPPORTED ----
+
+statement ok
+EXPLAIN SELECT * FROM read_ena_attributes('ERR1074767') WHERE tag=value;

--- a/test/sql/read_ena_sequences.test
+++ b/test/sql/read_ena_sequences.test
@@ -129,3 +129,37 @@ query II
 EXPLAIN SELECT * FROM read_ena_sequences('ERR1074767') LIMIT 1;
 ----
 physical_plan	<!REGEX>:.*INOUT_FUNCTION.*
+
+# ---- max_sequences ----
+
+statement ok
+PRAGMA explain_output = DEFAULT;
+
+# max_sequences caps row count per run. ERR1074767 has thousands of reads,
+# so an exact-match assertion proves the cap actually fired (as opposed to
+# EOF returning fewer rows for some unrelated reason).
+query I
+SELECT COUNT(*) = 10 AS capped_exact
+FROM read_ena_sequences('ERR1074767', max_sequences=10);
+----
+true
+
+# Same run, default (uncapped) cardinality is much larger than 10.
+query I
+SELECT COUNT(*) > 10 AS uncapped
+FROM (SELECT * FROM read_ena_sequences('ERR1074767') LIMIT 20);
+----
+true
+
+# max_sequences=0 is the explicit sentinel for "unlimited".
+query I
+SELECT COUNT(*) > 10 AS uncapped
+FROM (SELECT * FROM read_ena_sequences('ERR1074767', max_sequences=0) LIMIT 20);
+----
+true
+
+# Negative max_sequences rejected at Bind time.
+statement error
+SELECT * FROM read_ena_sequences('ERR1074767', max_sequences=-5);
+----
+max_sequences must be >= 0

--- a/test/sql/read_ena_sequences.test
+++ b/test/sql/read_ena_sequences.test
@@ -101,3 +101,13 @@ query I
 SELECT filepath LIKE '%ebi.ac.uk%' AS has_ebi FROM read_ena_sequences('ERR1074767', include_filepath=true) LIMIT 1;
 ----
 true
+
+# ---- Batched resolver: duplicate accession in list exercises the LRU cache ----
+
+# A list containing the same accession twice resolves via the batched path.
+# Dedup inside ResolveRunsBatch + negative cache prevents duplicate HTTP work.
+# Output should still reflect a single distinct run_accession.
+query I
+SELECT COUNT(DISTINCT run_accession) FROM read_ena_sequences(['ERR1074767','ERR1074767']) LIMIT 1;
+----
+1

--- a/test/sql/read_ena_sequences.test
+++ b/test/sql/read_ena_sequences.test
@@ -9,6 +9,10 @@ require httpfs
 
 require miint
 
+# Skip when ENA Portal API is not reachable (offline CI, blocked network).
+# run_tests.sh probes and exports this; unset → skip the whole file.
+require-env ENA_AVAILABLE
+
 # ---- Error handling ----
 
 statement error
@@ -111,3 +115,17 @@ query I
 SELECT COUNT(DISTINCT run_accession) FROM read_ena_sequences(['ERR1074767','ERR1074767']) LIMIT 1;
 ----
 1
+
+# ---- Literal-arg dispatch regression guard ----
+
+# Literal calls must stay on the standard (non-in-out) path to preserve
+# parallelism and byte-based progress. The physical plan must not include
+# INOUT_FUNCTION when args are constants.
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+query II
+EXPLAIN SELECT * FROM read_ena_sequences('ERR1074767') LIMIT 1;
+----
+physical_plan	<!REGEX>:.*INOUT_FUNCTION.*

--- a/test/sql/read_ena_sequences_lateral.test
+++ b/test/sql/read_ena_sequences_lateral.test
@@ -1,0 +1,78 @@
+# name: test/sql/read_ena_sequences_lateral.test
+# description: Test read_ena_sequences with lateral joins / correlated args
+# group: [sql]
+
+# NOTE: This test requires network access to EBI/ENA servers.
+# ERR1074767 is a SINGLE-end run from the American Gut Project.
+
+require httpfs
+
+require miint
+
+# Skip when ENA Portal API is not reachable (offline CI, blocked network).
+# run_tests.sh probes and exports this; unset → skip the whole file.
+require-env ENA_AVAILABLE
+
+# ---- Basic lateral ----
+
+statement ok
+CREATE TEMP TABLE runs(run_accession VARCHAR);
+
+statement ok
+INSERT INTO runs VALUES ('ERR1074767');
+
+query I
+SELECT COUNT(*) > 0
+FROM runs AS r,
+     LATERAL (SELECT read_id FROM read_ena_sequences(r.run_accession) LIMIT 1) seq;
+----
+true
+
+# Column values correct
+query II
+SELECT r.run_accession, length(seq.sequence1) > 0
+FROM runs AS r,
+     LATERAL (SELECT sequence1 FROM read_ena_sequences(r.run_accession) LIMIT 1) seq;
+----
+ERR1074767	true
+
+# ---- Cache exercise: duplicate outer rows ----
+
+statement ok
+INSERT INTO runs VALUES ('ERR1074767');
+
+query I
+SELECT COUNT(*)
+FROM runs AS r,
+     LATERAL (SELECT sequence1 FROM read_ena_sequences(r.run_accession) LIMIT 1) seq;
+----
+2
+
+# ---- Subquery in place of literal also triggers in-out path ----
+
+query IIIIII
+DESCRIBE SELECT * FROM read_ena_sequences((SELECT 'ERR1074767'));
+----
+sequence_index	BIGINT	YES	NULL	NULL	NULL
+read_id	VARCHAR	YES	NULL	NULL	NULL
+comment	VARCHAR	YES	NULL	NULL	NULL
+sequence1	VARCHAR	YES	NULL	NULL	NULL
+sequence2	VARCHAR	YES	NULL	NULL	NULL
+qual1	UTINYINT[]	YES	NULL	NULL	NULL
+qual2	UTINYINT[]	YES	NULL	NULL	NULL
+run_accession	VARCHAR	YES	NULL	NULL	NULL
+sample_accession	VARCHAR	YES	NULL	NULL	NULL
+experiment_accession	VARCHAR	YES	NULL	NULL	NULL
+
+# ---- EXPLAIN shows the in-out physical operator for the lateral path ----
+
+statement ok
+PRAGMA explain_output = PHYSICAL_ONLY;
+
+query II
+EXPLAIN
+SELECT r.run_accession
+FROM runs AS r,
+     LATERAL (SELECT 1 FROM read_ena_sequences(r.run_accession) LIMIT 1) seq;
+----
+physical_plan	<REGEX>:.*INOUT_FUNCTION.*

--- a/test/sql/read_ena_sequences_lateral.test
+++ b/test/sql/read_ena_sequences_lateral.test
@@ -76,3 +76,15 @@ FROM runs AS r,
      LATERAL (SELECT 1 FROM read_ena_sequences(r.run_accession) LIMIT 1) seq;
 ----
 physical_plan	<REGEX>:.*INOUT_FUNCTION.*
+
+# ---- max_sequences respected per-run in lateral mode ----
+
+statement ok
+PRAGMA explain_output = DEFAULT;
+
+query I
+SELECT COUNT(*) <= 5
+FROM (VALUES ('ERR1074767')) AS r(run_accession),
+     LATERAL (SELECT 1 FROM read_ena_sequences(r.run_accession, max_sequences=5)) seq;
+----
+true

--- a/test/sql/read_ena_sequences_prefer_format.test
+++ b/test/sql/read_ena_sequences_prefer_format.test
@@ -8,16 +8,15 @@ require miint
 #   'auto'  (default) - use FASTQ when available, fall back to SFF
 #   'sff'   - prefer SFF, fall back to FASTQ when SFF is unavailable
 #   'fastq' - FASTQ only, skip runs that lack FASTQ
-# trim (BOOLEAN, default true) - applies SFF clip trimming (ignored for FASTQ)
+# trim_sff (BOOLEAN, default true) - applies SFF clip trimming (ignored for FASTQ)
 #
-# NOTE: the tests below use the arrow-syntax (`name => value`) rather than
+# NOTE: the tests below use arrow-syntax (`name => value`) rather than
 # `name=value` for named parameters. read_ena_sequences has both `function`
 # and `in_out_function` set on a single TableFunction (dual-path), and DuckDB's
 # binder routes any `name=value` to the in-out path where named-parameter
 # extraction is skipped, producing a spurious "Referenced column ... was not
 # found" error. Arrow syntax parses the value as a scalar-with-alias and
-# survives the in-out-path check. `"trim"` is additionally quoted because
-# `TRIM` is a SQL function keyword.
+# survives the in-out-path check.
 # TODO: upstream DuckDB fix — https://github.com/duckdb/duckdb-miint/issues
 # (tracking issue to be filed).
 
@@ -38,6 +37,6 @@ read_ena_sequences: prefer_format must be 'auto', 'fastq', or 'sff'
 # instead of the prefer_format error.
 
 statement error
-SELECT * FROM read_ena_sequences('ERR1074767', "trim" => true, prefer_format => 'bad');
+SELECT * FROM read_ena_sequences('ERR1074767', trim_sff => true, prefer_format => 'bad');
 ----
 read_ena_sequences: prefer_format must be 'auto', 'fastq', or 'sff'

--- a/test/sql/read_ena_sequences_prefer_format.test
+++ b/test/sql/read_ena_sequences_prefer_format.test
@@ -9,16 +9,27 @@ require miint
 #   'sff'   - prefer SFF, fall back to FASTQ when SFF is unavailable
 #   'fastq' - FASTQ only, skip runs that lack FASTQ
 # trim (BOOLEAN, default true) - applies SFF clip trimming (ignored for FASTQ)
+#
+# NOTE: the tests below use the arrow-syntax (`name => value`) rather than
+# `name=value` for named parameters. read_ena_sequences has both `function`
+# and `in_out_function` set on a single TableFunction (dual-path), and DuckDB's
+# binder routes any `name=value` to the in-out path where named-parameter
+# extraction is skipped, producing a spurious "Referenced column ... was not
+# found" error. Arrow syntax parses the value as a scalar-with-alias and
+# survives the in-out-path check. `"trim"` is additionally quoted because
+# `TRIM` is a SQL function keyword.
+# TODO: upstream DuckDB fix — https://github.com/duckdb/duckdb-miint/issues
+# (tracking issue to be filed).
 
 # ---- Invalid prefer_format values ----
 
 statement error
-SELECT * FROM read_ena_sequences('ERR1074767', prefer_format='invalid');
+SELECT * FROM read_ena_sequences('ERR1074767', prefer_format => 'invalid');
 ----
 read_ena_sequences: prefer_format must be 'auto', 'fastq', or 'sff'
 
 statement error
-SELECT * FROM read_ena_sequences('ERR1074767', prefer_format='');
+SELECT * FROM read_ena_sequences('ERR1074767', prefer_format => '');
 ----
 read_ena_sequences: prefer_format must be 'auto', 'fastq', or 'sff'
 
@@ -27,6 +38,6 @@ read_ena_sequences: prefer_format must be 'auto', 'fastq', or 'sff'
 # instead of the prefer_format error.
 
 statement error
-SELECT * FROM read_ena_sequences('ERR1074767', trim=true, prefer_format='bad');
+SELECT * FROM read_ena_sequences('ERR1074767', "trim" => true, prefer_format => 'bad');
 ----
 read_ena_sequences: prefer_format must be 'auto', 'fastq', or 'sff'

--- a/test/sql/read_ena_sequences_sff.test
+++ b/test/sql/read_ena_sequences_sff.test
@@ -9,6 +9,9 @@ require httpfs
 
 require miint
 
+# Skip when ENA Portal API is not reachable (offline CI, blocked network).
+require-env ENA_AVAILABLE
+
 # ---- prefer_format='sff' returns data ----
 
 statement ok

--- a/test/sql/read_ena_sequences_sff.test
+++ b/test/sql/read_ena_sequences_sff.test
@@ -12,11 +12,11 @@ require miint
 # Skip when ENA Portal API is not reachable (offline CI, blocked network).
 require-env ENA_AVAILABLE
 
-# ---- prefer_format='sff' returns data ----
+# ---- prefer_format => 'sff' returns data ----
 
 statement ok
 CREATE TEMP TABLE sff_reads AS
-SELECT * FROM read_ena_sequences('ERR215818', prefer_format='sff') LIMIT 50;
+SELECT * FROM read_ena_sequences('ERR215818', prefer_format => 'sff') LIMIT 50;
 
 query I
 SELECT COUNT(*) > 0 FROM sff_reads;
@@ -47,11 +47,11 @@ SELECT COUNT(*) = 0 FROM sff_reads WHERE qual1 IS NULL;
 ----
 true
 
-# ---- trim=false should work ----
+# ---- trim_sff=false should work ----
 
 statement ok
 CREATE TEMP TABLE sff_untrimmed AS
-SELECT * FROM read_ena_sequences('ERR215818', prefer_format='sff', trim=false) LIMIT 10;
+SELECT * FROM read_ena_sequences('ERR215818', prefer_format => 'sff', trim_sff => false) LIMIT 10;
 
 query I
 SELECT COUNT(*) > 0 FROM sff_untrimmed;
@@ -59,7 +59,7 @@ SELECT COUNT(*) > 0 FROM sff_untrimmed;
 true
 
 # ---- default (auto) prefers FASTQ ----
-# Note: prefer_format='sff' falls back to FASTQ when SFF is unavailable.
+# Note: prefer_format => 'sff' falls back to FASTQ when SFF is unavailable.
 # prefer_format='auto' (default) uses FASTQ when available, falls back to SFF.
 
 statement ok


### PR DESCRIPTION
Enables SQL like the below, which would scan each sample for a specific sequence, stop the download prematurely if found, and report sample accessions containing the sequence.

```
SELECT r.run_accession
FROM read_ena('PRJEB11419') AS r,
     LATERAL (SELECT 1 FROM read_ena_sequences(r.run_accession)
              WHERE sequence1.contains('AACGTAGGTCACAAGCGTTGTCCGGA')
              LIMIT 1);
```

Where each outer row opens its own run and LIMIT short-circuits via LocalState destruction. Per-query LRU cache + shared ENAClient dedupe metadata lookups across outer rows. 