### PR TITLE
Add sample_id to deblur, align_mafft, and both uchime functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,7 +788,8 @@ set(EXTENSION_SOURCES
     src/duckdb_seq_stream.cpp
     src/hfile_duckdb.cpp
     src/deblur.cpp
-    src/deblur_table_function.cpp)
+    src/deblur_table_function.cpp
+    src/per_sample_table_function.cpp)
 
 if(MIINT_ENABLE_VSEARCH)
     list(APPEND EXTENSION_SOURCES

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -8,6 +8,7 @@ Cross-cutting design patterns and implementation notes for duckdb-miint. This fi
 - How external libraries are embedded → `docs/internals/embedded-tools.md`
 - Reading from user-specified tables/views → `docs/internals/reading-tables-views.md`
 - Consuming Arrow C Data Interface streams → `docs/internals/arrow-zero-copy.md`
+- Adding `sample_id` support to a table function → `docs/internals/per-sample-pattern.md`
 
 ## Extension Entry Point
 
@@ -110,6 +111,7 @@ SAM alignments compute `stop_position` using HTSlib's `bam_endpos()`:
 3. Register in `LoadInternal()` in `miint_extension.cpp`
 4. Add to `EXTENSION_SOURCES` in `CMakeLists.txt`
 5. Create SQL test in `test/sql/`
+6. If the function should run per-sample (partitioning an input relation by a column), follow `docs/internals/per-sample-pattern.md`
 
 ### Adding a new COPY format
 1. Create `copy_<format>.cpp` and header

--- a/docs/internals/per-sample-pattern.md
+++ b/docs/internals/per-sample-pattern.md
@@ -1,0 +1,162 @@
+# Per-sample table functions
+
+A family of miint table functions accept a `sample_id` named parameter that partitions an input relation by a column and runs the function's pipeline once per distinct sample value. The output gains a prepended sample column whose type matches the source column.
+
+Functions currently using the pattern: `massql`, `woltka_ogu`, `deblur`, `align_mafft`, `detect_chimera_uchime_denovo`, `detect_chimera_uchime`.
+
+## The helper
+
+`src/include/per_sample_table_function.hpp` exposes a small, opinionated API. Callers use it for bind-time sample discovery and exec-time atomic claim; everything else — the non-sample branch, data loading, result buffering, chunk emission — stays in the caller.
+
+```cpp
+struct PerSampleBindInfo {
+    string sample_id_col;
+    LogicalType sample_id_type;
+    vector<Value> sample_values;
+};
+
+void DiscoverSamples(Connection &conn, const string &source, const string &sample_id_col,
+                     const std::vector<std::string> &reserved_lowercase_output_names,
+                     const string &fn_label, PerSampleBindInfo &out);
+
+struct PerSampleGlobalState : GlobalTableFunctionState {
+    atomic<idx_t> next_sample_idx{0};
+    idx_t max_threads = 1;
+    idx_t MaxThreads() const override { return max_threads; }
+};
+
+void InitPerSampleGlobal(ClientContext &context, PerSampleGlobalState &gstate,
+                         idx_t num_samples, idx_t max_threads_hint = 0);
+
+bool ClaimNextSample(PerSampleGlobalState &gstate, idx_t num_samples, idx_t &out_idx);
+```
+
+### Error strings
+
+All helper-thrown errors are prefixed with `<fn_label>: `. The substrings that downstream tests have historically asserted on are preserved verbatim (`sample_id column '<X>' not found`, `sample_id column name must not be empty`, `NULL values in sample_id column '<X>'`, `sample_id column '<X>' has no non-NULL values`, `collides with an output column`). When adding a new per-sample function, reuse the same substrings in tests — they will all come out of the helper.
+
+### Thread-safety knob
+
+`max_threads_hint` controls the concurrency cap:
+
+- `0` (default): use the DuckDB scheduler's thread count, clamped to `num_samples`. Use when the per-sample backend is re-entrant.
+- `1`: force serial execution. Use when the backend has a process-wide mutex (MAFFT) or is explicitly not thread-safe (vsearch's `VsearchChimeraWrapper`). Spawning more threads would just queue them behind the lock — worse, not better.
+- `N > 1`: cap to `min(N, num_samples, db_threads)`. Use if a backend has limited internal parallelism.
+
+## Adding per-sample support to a new function
+
+Three steps.
+
+### 1. Named parameter + bind-time discovery
+
+```cpp
+tf.named_parameters["sample_id"] = LogicalType::VARCHAR;
+```
+
+```cpp
+auto sample_it = input.named_parameters.find("sample_id");
+if (sample_it != input.named_parameters.end()) {
+    data->has_sample_id = true;
+    data->sample_info.sample_id_col = sample_it->second.GetValue<string>();
+}
+
+if (data->has_sample_id) {
+    auto &db = DatabaseInstance::GetDatabase(context);
+    Connection conn(db);
+    DiscoverSamples(conn, data->input_table, data->sample_info.sample_id_col,
+                    /*reserved=*/ {/* lowercase output column names */},
+                    "<fn_name>", data->sample_info);
+
+    names.push_back(data->sample_info.sample_id_col);
+    return_types.push_back(data->sample_info.sample_id_type);
+}
+```
+
+Store `PerSampleBindInfo sample_info` in the Data struct — not its three fields individually; that's the historical anti-pattern this helper was carved out of.
+
+### 2. Global / local state
+
+Inherit the GlobalState from `PerSampleGlobalState`; initialize it at `InitGlobal`:
+
+```cpp
+if (data.has_sample_id) {
+    InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size(),
+                        /*max_threads_hint=*/0 /* or 1 for non-re-entrant backends */);
+} else {
+    gstate->max_threads = 1;
+    // ... existing non-sample setup ...
+}
+```
+
+Provide a `LocalState` with a `unique_ptr<Connection> conn` (for the per-thread data load) and whatever per-sample result buffer the function needs. The Connection is only allocated in the sample_id path.
+
+### 3. Per-sample Execute loop
+
+Template used by all six existing callers:
+
+```cpp
+while (true) {
+    if (lstate.current_row < lstate.results.size()) {
+        EmitRows(/* ... */);  // emit a chunk from the per-sample buffer
+        return;
+    }
+    idx_t sample_idx;
+    if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
+        output.SetCardinality(0);
+        return;
+    }
+    lstate.sample_value = data.sample_info.sample_values[sample_idx];
+    // Load this sample's rows and run the algorithm. Use the per-thread lstate.conn.
+    lstate.results = RunAlgorithmForSample(*lstate.conn, data, lstate.sample_value);
+    lstate.current_row = 0;
+}
+```
+
+When emitting, the sample column at output position 0 should be filled via a ConstantVector reference — constant across the chunk, zero-copy:
+
+```cpp
+output.data[0].Reference(lstate.sample_value);
+```
+
+Avoid the per-row `SetValue` anti-pattern; a 2048-row chunk would otherwise do 2048 string-interning operations for the sample column alone.
+
+## Per-sample data loading
+
+Two loader patterns are in use:
+
+**SQL transpile** (`massql`, `woltka_ogu`). The function's per-sample SQL is wrapped by `CREATE OR REPLACE TEMP VIEW __<fn>_per_sample AS SELECT * FROM <src> WHERE <col> = <literal>` on the thread's Connection, then the existing SQL runs against the view. The TEMP VIEW is scoped to the connection, so parallel threads don't collide despite the shared name.
+
+**In-memory load** (`deblur`, `align_mafft`, `uchime_denovo`, `uchime_ref`). The function pulls rows directly:
+- `deblur` and `uchime_denovo` run custom `SELECT … WHERE <sample_predicate> ORDER BY <ordering>` queries.
+- `align_mafft` uses `LoadSingleEndSequences(Connection&, table, fn, strict, where_sql)` — an overload that accepts a caller-owned Connection and an arbitrary WHERE clause. Existing callers that don't want a predicate keep the original `ClientContext&` overload.
+- `uchime_ref` streams queries lazily via `QuerySequenceStream(Connection&, table, schema, batch_size)` — an overload that uses the caller's Connection so the TEMP VIEW and the stream share a session (the view isn't visible otherwise).
+
+All per-sample predicates use `CAST(<col> AS VARCHAR) = CAST(<literal> AS VARCHAR)`. This is correct for VARCHAR, integer, and date sample IDs. **DECIMAL sample IDs are not supported**: DuckDB's VARCHAR cast preserves trailing zeros (`3.500`) while `Value::ToSQLString()` strips them (`3.5`), so equality silently misses rows. If DECIMAL sample IDs become a requirement, switch every call site to type-aware literal binding.
+
+## Reserved output-column names
+
+Each caller passes a list of lowercase output column names that the `sample_id` column must not collide with (case-insensitive). This prevents the output from having two columns with the same name.
+
+Current lists:
+- `deblur`: `{read_id, sequence, abundance}`
+- `align_mafft`: `{sequence_index, read_id, aligned_sequence, original_length, aligned_length}`
+- `uchime_denovo` and `uchime_ref`: `GetUchimeOutputNames()` (the 18 uchimeout columns).
+- `woltka_ogu`: `{feature_id, value}`
+- `massql`: `{}` (no fixed output schema — the schema is inferred from sample[0]).
+
+Input-column collisions (e.g. `sample_id := 'sequence1'`) are intentionally *not* rejected. The user picks their own foot, but there's no ambiguity in the output.
+
+## Testing
+
+Each new per-sample function gets a `test/sql/<fn>_sample_id.test` covering:
+1. Missing column → `sample_id column '<name>' not found`
+2. Empty string → `sample_id column name must not be empty`
+3. NULL values → `NULL values in sample_id column '<name>'`
+4. Empty relation filter → `has no non-NULL values`
+5. Output-column collision (case-insensitive) → `collides with an output column`
+6. Happy path with two samples — verify isolation and output schema
+7. Integer-typed sample_id round-trips
+8. Single-sample equivalence vs. the non-sample path
+9. `PRAGMA threads=4` parallelism cycle — exercises the atomic claim
+
+`massql_sample_id.test` and `deblur_sample_id.test` are canonical references for layout.

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -1900,7 +1900,7 @@ SELECT * FROM align_bowtie2_sharded('queries',
 | Parallelism | Single aligner thread(s) | One aligner per shard, concurrent |
 | Use case | Single reference database | Sharded reference databases (e.g., from prior classification) |
 
-## `align_mafft(table_name)`
+## `align_mafft(table_name, [sample_id='col'])`
 
 Multiple sequence alignment using MAFFT's PartTree algorithm. Reads all sequences from a sequence table/view, aligns them, and returns the aligned sequences with gap characters inserted.
 
@@ -1908,6 +1908,7 @@ MAFFT is embedded as a statically linked C library (no external binary required)
 
 **Parameters:**
 - `table_name` (VARCHAR): Name of a table or view containing sequences to align. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns. Minimum 2 sequences, each at least 6 characters. DNA and protein sequences are auto-detected. Paired-end tables (those with a `sequence2` column) are rejected at bind.
+- `sample_id` (VARCHAR, optional): Name of a column in `table_name` to partition by. When provided, `align_mafft` runs one MSA per distinct sample value and prepends the sample column to the output. The per-sample ≥2-sequences and ≥6-char validations apply within each sample; the whole query aborts if any sample violates them. `sequence_index` is per-sample (0..n-1 within each sample). Join back to the input on `(<sample_id>, read_id)`.
 
 **Output schema:**
 
@@ -1944,6 +1945,13 @@ CREATE TABLE filtered AS
   SELECT read_id, sequence1 FROM read_fastx('large_dataset.fasta')
   WHERE length(sequence1) >= 100;
 SELECT * FROM align_mafft('filtered');
+
+-- Align per-sample: one MSA per distinct sample value
+CREATE VIEW cohort AS
+  SELECT 'S1' AS sample, * FROM read_fastx('sample1.fasta')
+  UNION ALL
+  SELECT 'S2' AS sample, * FROM read_fastx('sample2.fasta');
+SELECT * FROM align_mafft('cohort', sample_id := 'sample') ORDER BY sample, sequence_index;
 
 -- Compute pairwise identity from aligned sequences
 CREATE TABLE seqs2 AS SELECT read_id, sequence1 FROM read_fastx('seqs.fasta');
@@ -2052,13 +2060,14 @@ GROUP BY ref_name ORDER BY hits DESC;
 
 ---
 
-## `detect_chimera_uchime(query_table, db='refs_table', [options])`
+## `detect_chimera_uchime(query_table, db='refs_table', [sample_id='col'], [options])`
 
 Reference-based chimera detection using the UCHIME algorithm (Edgar et al. 2011, Bioinformatics 27:2194-2200), powered by the [vsearch](https://github.com/torognes/vsearch) library (Rognes et al. 2016, PeerJ 4:e2584). Detects chimeric sequences by comparing queries against a trusted chimera-free reference database.
 
 **Parameters:**
 - `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns.
 - `db` (VARCHAR, required): Name of a table or view containing reference sequences. Same schema requirements as `query_table`.
+- `sample_id` (VARCHAR, optional): Name of a column in `query_table` to partition by. When provided, queries are scored per-sample against the (shared, load-once) reference database, and the sample column is prepended to the output. Execution is serialized (the vsearch wrapper is not thread-safe across concurrent calls).
 - `minh` (DOUBLE, default 0.28): Minimum h-score to flag as chimeric. Range [0, 1].
 - `xn` (DOUBLE, default 8.0): Weight of "no" votes in h-score computation. Must be >= 1.0.
 - `dn` (DOUBLE, default 1.4): Pseudo-count prior on "no" votes. Must be >= 0.
@@ -2132,12 +2141,13 @@ SELECT flag, count(*) FROM detect_chimera_uchime('queries', db:='refs') GROUP BY
 
 ---
 
-## `detect_chimera_uchime_denovo(input_table, [options])`
+## `detect_chimera_uchime_denovo(input_table, [sample_id='col'], [options])`
 
 De novo chimera detection using the UCHIME algorithm, powered by the [vsearch](https://github.com/torognes/vsearch) library (Rognes et al. 2016, PeerJ 4:e2584). Detects chimeric sequences without a reference database by using abundance information: more abundant sequences are assumed to be non-chimeric and serve as parents for less abundant sequences.
 
 **Parameters:**
 - `input_table` (VARCHAR): Name of a table or view containing sequences with abundance. Must have `read_id` (VARCHAR), `sequence1` (VARCHAR), and `size` (integer type) columns.
+- `sample_id` (VARCHAR, optional): Name of a column in `input_table` to partition by. Each sample gets its own k-mer index and bootstrap; a read_id that appears in multiple samples is therefore scored independently. The sample column is prepended to the output. Execution is serialized per the vsearch wrapper's thread-safety constraints.
 - `abskew` (DOUBLE, default 2.0): Abundance skew. Candidate parents must have abundance >= abskew * query abundance. Must be >= 1.0.
 - `minh`, `xn`, `dn`, `mindiv`, `mindiffs`: Same as `detect_chimera_uchime`.
 
@@ -2294,7 +2304,7 @@ GROUP BY centroid_id ORDER BY size DESC;
 - Error if table is empty or contains NULL read_ids, NULL sequences, or empty sequences
 - Error if any read_id exceeds 1023 characters
 
-## `deblur(input_table, [options])`
+## `deblur(input_table, [sample_id='col'], [options])`
 
 Deblur amplicon sequence denoising (Amir et al. 2017, mSystems 2:e00191-16). A greedy deconvolution algorithm that removes sequencing errors from amplicon data by iteratively subtracting expected error-derived reads from less-abundant sequences. Sequences whose corrected abundance rounds to zero are removed as errors; the remainder are denoised "sub-OTUs" (sOTUs).
 
@@ -2302,6 +2312,7 @@ Designed as a composable SQL building block. Dereplication is native SQL (`GROUP
 
 **Parameters:**
 - `input_table` (VARCHAR): Name of a table or view containing pre-aligned, pre-dereplicated sequences. Must have `read_id` (VARCHAR), `sequence1` (VARCHAR), and `abundance` (integer type) columns. All sequences in `sequence1` must have the same aligned length and the same unaligned length (number of non-gap characters).
+- `sample_id` (VARCHAR, optional): Name of a column in `input_table` to partition by. Deblur is applied independently per sample, and the sample column is prepended to the output. Unlike the two uchime functions, deblur's backend is re-entrant so samples run across DuckDB worker threads in parallel (bounded by `min(num_threads, num_samples)`).
 - `mean_error` (DOUBLE, default `0.005`): Per-base Illumina error rate. **This is the primary tuning knob.** The default 0.005 reflects MiSeq/HiSeq circa 2015. For modern NovaSeq or stitched reads (~250nt), use 0.001-0.002. Lowering `mean_error` makes denoising more conservative (fewer sequences removed). Must be > 0 and < 1.
 - `error_profile` (LIST(DOUBLE), optional): Override the default 12-element error probability profile. Each element represents the fraction of reads from a true sequence that land at exactly that Hamming distance. Default: `[1, 0.06, 0.02, 0.02, 0.01, 0.005, 0.005, 0.005, 0.001, 0.001, 0.001, 0.0005]`. All values must be non-negative.
 - `indel_prob` (DOUBLE, default `0.01`): Multiplicative penalty applied to corrections involving indels. A value of 0 disables indel-based corrections entirely.

--- a/src/align_mafft.cpp
+++ b/src/align_mafft.cpp
@@ -1,32 +1,88 @@
 #include "align_mafft.hpp"
 #include "MafftAligner.hpp"
+#include "per_sample_table_function.hpp"
 #include "sequence_table_reader.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
 #include <unordered_set>
 
 namespace duckdb {
 
 struct AlignMafftData : public TableFunctionData {
 	std::string table_name;
+
+	bool has_sample_id = false;
+	PerSampleBindInfo sample_info;
 };
 
-struct AlignMafftGlobalState : public GlobalTableFunctionState {
-	// Materialized alignment results. All sequences must be in memory
-	// simultaneously because MAFFT's PartTree needs the complete set
-	// before it can produce any aligned output.
+struct AlignMafftGlobalState : public PerSampleGlobalState {
+	// Non-sample path only: the full MAFFT run is done once at InitGlobal and drained here.
+	// MAFFT needs every sequence in memory simultaneously before producing any output.
+	std::vector<std::string> names;
+	std::vector<std::string> sequences;
+	std::vector<int32_t> original_lengths;
+	int32_t aligned_length = 0;
+};
+
+struct AlignMafftLocalState : public LocalTableFunctionState {
+	unique_ptr<Connection> conn; // sample_id path only
+
+	// Current buffer (non-sample path: drains gstate once via shared data; sample path:
+	// refilled per claimed sample).
 	std::vector<std::string> names;
 	std::vector<std::string> sequences;
 	std::vector<int32_t> original_lengths;
 	int32_t aligned_length = 0;
 	idx_t current_row = 0;
-
-	idx_t MaxThreads() const override {
-		return 1;
-	}
+	Value sample_value;
 };
+
+// Validate align_mafft's preconditions and run MAFFT on the loaded set. Writes the
+// aligned result into the supplied vectors. `sample_literal` is empty in the non-sample
+// path and non-empty in the per-sample path; error messages include the sample suffix
+// only when present so single-sample users get clean diagnostics.
+static void ValidateAndAlignInto(const std::string &sample_literal, LoadedSingleEndSequences &loaded,
+                                 std::vector<std::string> &out_names, std::vector<std::string> &out_sequences,
+                                 std::vector<int32_t> &out_original_lengths, int32_t &out_aligned_length) {
+	bool is_sample = !sample_literal.empty();
+	auto sample_ctx = is_sample ? (" in sample " + sample_literal) : std::string();
+
+	if (loaded.sequences.size() < 2) {
+		throw InvalidInputException("align_mafft requires at least 2 sequences%s, got %d", sample_ctx,
+		                            static_cast<int>(loaded.sequences.size()));
+	}
+
+	for (size_t i = 0; i < loaded.sequences.size(); i++) {
+		if (loaded.sequences[i].size() < 6) {
+			throw InvalidInputException("align_mafft: sequence for read_id '%s'%s is too short (%d chars, minimum 6)",
+			                            loaded.labels[i], sample_ctx, static_cast<int>(loaded.sequences[i].size()));
+		}
+	}
+
+	std::unordered_set<std::string> seen;
+	seen.reserve(loaded.labels.size());
+	for (const auto &id : loaded.labels) {
+		if (!seen.insert(id).second) {
+			throw InvalidInputException("align_mafft: duplicate read_id '%s'%s in input table", id, sample_ctx);
+		}
+	}
+
+	std::vector<std::string> comments(loaded.labels.size(), "");
+	miint::MafftAligner aligner;
+	auto result = aligner.align(loaded.labels, comments, loaded.sequences);
+
+	out_names = std::move(result.names);
+	out_sequences = std::move(result.sequences);
+	out_aligned_length = static_cast<int32_t>(result.aligned_length);
+	out_original_lengths.clear();
+	out_original_lengths.reserve(result.original_lengths.size());
+	for (auto len : result.original_lengths) {
+		out_original_lengths.push_back(static_cast<int32_t>(len));
+	}
+}
 
 static unique_ptr<FunctionData> AlignMafftBind(ClientContext &context, TableFunctionBindInput &input,
                                                vector<LogicalType> &return_types, vector<string> &names) {
@@ -43,9 +99,32 @@ static unique_ptr<FunctionData> AlignMafftBind(ClientContext &context, TableFunc
 	auto data = make_uniq<AlignMafftData>();
 	data->table_name = std::move(table_name);
 
-	names = {"sequence_index", "read_id", "aligned_sequence", "original_length", "aligned_length"};
-	return_types = {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::INTEGER,
-	                LogicalType::INTEGER};
+	auto sample_it = input.named_parameters.find("sample_id");
+	if (sample_it != input.named_parameters.end()) {
+		data->has_sample_id = true;
+		data->sample_info.sample_id_col = sample_it->second.GetValue<string>();
+	}
+
+	if (data->has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context);
+		Connection conn(db);
+		DiscoverSamples(conn, data->table_name, data->sample_info.sample_id_col,
+		                {"sequence_index", "read_id", "aligned_sequence", "original_length", "aligned_length"},
+		                "align_mafft", data->sample_info);
+		names.push_back(data->sample_info.sample_id_col);
+		return_types.push_back(data->sample_info.sample_id_type);
+	}
+
+	names.emplace_back("sequence_index");
+	names.emplace_back("read_id");
+	names.emplace_back("aligned_sequence");
+	names.emplace_back("original_length");
+	names.emplace_back("aligned_length");
+	return_types.emplace_back(LogicalType::BIGINT);
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::INTEGER);
+	return_types.emplace_back(LogicalType::INTEGER);
 
 	return data;
 }
@@ -55,85 +134,113 @@ static unique_ptr<GlobalTableFunctionState> AlignMafftInitGlobal(ClientContext &
 	auto &data = input.bind_data->Cast<AlignMafftData>();
 	auto gstate = make_uniq<AlignMafftGlobalState>();
 
+	if (data.has_sample_id) {
+		// MAFFT holds a process-wide mutex — running multiple threads would only
+		// queue them behind the same lock. Force serial to avoid the illusion of
+		// parallelism.
+		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size(), /*max_threads_hint=*/1);
+		return gstate;
+	}
+
+	gstate->max_threads = 1;
+
 	auto loaded = LoadSingleEndSequences(context, data.table_name, "align_mafft", /*strict=*/true);
-
-	if (loaded.sequences.size() < 2) {
-		throw InvalidInputException("align_mafft requires at least 2 sequences, got %d",
-		                            static_cast<int>(loaded.sequences.size()));
-	}
-
-	// MAFFT requires sequences of at least 6 characters; guard up-front so the
-	// user gets a row-specific error instead of an opaque std::invalid_argument
-	// out of the aligner.
-	for (size_t i = 0; i < loaded.sequences.size(); i++) {
-		if (loaded.sequences[i].size() < 6) {
-			throw InvalidInputException("align_mafft: sequence for read_id '%s' is too short (%d chars, minimum 6)",
-			                            loaded.labels[i], static_cast<int>(loaded.sequences[i].size()));
-		}
-	}
-
-	// Duplicate read_ids make it impossible to join align_mafft output back to
-	// the input table unambiguously (e.g., the deblur workflow pattern).
-	std::unordered_set<std::string> seen;
-	seen.reserve(loaded.labels.size());
-	for (const auto &id : loaded.labels) {
-		if (!seen.insert(id).second) {
-			throw InvalidInputException("align_mafft: duplicate read_id '%s' in input table", id);
-		}
-	}
-
-	// MafftAligner::align requires a comments vector sized to match names/sequences;
-	// empty strings are ignored when building FASTA headers.
-	std::vector<std::string> comments(loaded.labels.size(), "");
-
-	miint::MafftAligner aligner;
-	auto result = aligner.align(loaded.labels, comments, loaded.sequences);
-
-	gstate->names = std::move(result.names);
-	gstate->sequences = std::move(result.sequences);
-	gstate->aligned_length = static_cast<int32_t>(result.aligned_length);
-	gstate->original_lengths.reserve(result.original_lengths.size());
-	for (auto len : result.original_lengths) {
-		gstate->original_lengths.push_back(static_cast<int32_t>(len));
-	}
+	ValidateAndAlignInto(/*sample_literal=*/"", loaded, gstate->names, gstate->sequences, gstate->original_lengths,
+	                     gstate->aligned_length);
 
 	return gstate;
 }
 
-static void AlignMafftExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &gstate = data_p.global_state->Cast<AlignMafftGlobalState>();
-
-	idx_t total = gstate.names.size();
-	if (gstate.current_row >= total) {
-		output.SetCardinality(0);
-		return;
+static unique_ptr<LocalTableFunctionState> AlignMafftInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                               GlobalTableFunctionState * /*global_state*/) {
+	auto &data = input.bind_data->Cast<AlignMafftData>();
+	auto lstate = make_uniq<AlignMafftLocalState>();
+	if (data.has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		lstate->conn = make_uniq<Connection>(db);
 	}
+	return lstate;
+}
 
-	idx_t count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, total - gstate.current_row);
+// Emit up to STANDARD_VECTOR_SIZE rows from the supplied align-result slice. When
+// has_sample_id, col 0 is the sample column, filled via ConstantVector reference.
+static void EmitRows(const AlignMafftData &data, AlignMafftLocalState &lstate, const std::vector<std::string> &names,
+                     const std::vector<std::string> &sequences, const std::vector<int32_t> &original_lengths,
+                     int32_t aligned_length, DataChunk &output) {
+	idx_t total = names.size();
+	idx_t count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, total - lstate.current_row);
 
+	idx_t col = 0;
+	if (data.has_sample_id) {
+		output.data[col++].Reference(lstate.sample_value);
+	}
+	auto &sequence_index_vec = output.data[col++];
+	auto &read_id_vec = output.data[col++];
+	auto &aligned_seq_vec = output.data[col++];
+	auto &original_length_vec = output.data[col++];
+	auto &aligned_length_vec = output.data[col++];
+	auto sequence_index_data = FlatVector::GetData<int64_t>(sequence_index_vec);
+	auto read_id_data = FlatVector::GetData<string_t>(read_id_vec);
+	auto aligned_seq_data = FlatVector::GetData<string_t>(aligned_seq_vec);
+	auto original_length_data = FlatVector::GetData<int32_t>(original_length_vec);
+	auto aligned_length_data = FlatVector::GetData<int32_t>(aligned_length_vec);
 	for (idx_t i = 0; i < count; i++) {
-		idx_t row = gstate.current_row + i;
-
-		FlatVector::GetData<int64_t>(output.data[0])[i] = static_cast<int64_t>(row);
-
-		FlatVector::GetData<string_t>(output.data[1])[i] = StringVector::AddString(output.data[1], gstate.names[row]);
-
-		FlatVector::GetData<string_t>(output.data[2])[i] =
-		    StringVector::AddString(output.data[2], gstate.sequences[row]);
-
-		FlatVector::GetData<int32_t>(output.data[3])[i] = gstate.original_lengths[row];
-		FlatVector::GetData<int32_t>(output.data[4])[i] = gstate.aligned_length;
+		idx_t row = lstate.current_row + i;
+		sequence_index_data[i] = static_cast<int64_t>(row);
+		read_id_data[i] = StringVector::AddString(read_id_vec, names[row]);
+		aligned_seq_data[i] = StringVector::AddString(aligned_seq_vec, sequences[row]);
+		original_length_data[i] = original_lengths[row];
+		aligned_length_data[i] = aligned_length;
 	}
 
-	gstate.current_row += count;
+	lstate.current_row += count;
 	output.SetCardinality(count);
 }
 
+static void AlignMafftExecute(ClientContext & /*context*/, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<AlignMafftData>();
+	auto &gstate = data_p.global_state->Cast<AlignMafftGlobalState>();
+	auto &lstate = data_p.local_state->Cast<AlignMafftLocalState>();
+
+	if (!data.has_sample_id) {
+		if (lstate.current_row >= gstate.names.size()) {
+			output.SetCardinality(0);
+			return;
+		}
+		EmitRows(data, lstate, gstate.names, gstate.sequences, gstate.original_lengths, gstate.aligned_length, output);
+		return;
+	}
+
+	while (true) {
+		if (lstate.current_row < lstate.names.size()) {
+			EmitRows(data, lstate, lstate.names, lstate.sequences, lstate.original_lengths, lstate.aligned_length,
+			         output);
+			return;
+		}
+		idx_t sample_idx;
+		if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
+			output.SetCardinality(0);
+			return;
+		}
+		lstate.sample_value = data.sample_info.sample_values[sample_idx];
+		auto sample_literal = lstate.sample_value.ToSQLString();
+		auto q_col = KeywordHelper::WriteOptionallyQuoted(data.sample_info.sample_id_col);
+		// Same CAST-as-VARCHAR equality as the other per-sample call sites; see the note
+		// in deblur_table_function.cpp for the DECIMAL caveat.
+		auto where_sql = "CAST(" + q_col + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR)";
+		auto loaded = LoadSingleEndSequences(*lstate.conn, data.table_name, "align_mafft", /*strict=*/true, where_sql);
+		ValidateAndAlignInto(sample_literal, loaded, lstate.names, lstate.sequences, lstate.original_lengths,
+		                     lstate.aligned_length);
+		lstate.current_row = 0;
+	}
+}
+
 TableFunction AlignMafftTableFunction::GetFunction() {
-	auto tf =
-	    TableFunction("align_mafft", {LogicalType::VARCHAR}, AlignMafftExecute, AlignMafftBind, AlignMafftInitGlobal);
+	auto tf = TableFunction("align_mafft", {LogicalType::VARCHAR}, AlignMafftExecute, AlignMafftBind,
+	                        AlignMafftInitGlobal, AlignMafftInitLocal);
+	tf.named_parameters["sample_id"] = LogicalType::VARCHAR;
 	// Match sibling aligners — allow downstream CTAS pipelines to parallelize.
-	// Callers that want deterministic order should ORDER BY sequence_index.
+	// Callers that want deterministic order should ORDER BY (sample_id,) sequence_index.
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	return tf;
 }

--- a/src/deblur_table_function.cpp
+++ b/src/deblur_table_function.cpp
@@ -1,6 +1,7 @@
 #include "deblur_table_function.hpp"
 #include "catalog_utils.hpp"
 #include "deblur.hpp"
+#include "per_sample_table_function.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -16,15 +17,25 @@ namespace duckdb {
 struct DeblurData : public TableFunctionData {
 	std::string input_table;
 	miint::DeblurParams params;
+
+	bool has_sample_id = false;
+	PerSampleBindInfo sample_info;
 };
 
-struct DeblurGlobalState : public GlobalTableFunctionState {
-	std::vector<miint::DeblurResult> results;
-	idx_t current_row = 0;
+struct DeblurGlobalState : public PerSampleGlobalState {
+	// Non-sample path only: pre-computed at InitGlobal, immutable thereafter.
+	// The single Execute thread (enforced by max_threads=1) reads it via its lstate cursor.
+	std::vector<miint::DeblurResult> shared_results;
+};
 
-	idx_t MaxThreads() const override {
-		return 1;
-	}
+struct DeblurLocalState : public LocalTableFunctionState {
+	unique_ptr<Connection> conn; // sample_id path only
+
+	// Per-thread state. Non-sample path: cursor into gstate.shared_results.
+	// Sample path: own buffer for the currently-claimed sample; cursor is reset per sample.
+	std::vector<miint::DeblurResult> sample_results;
+	idx_t current_row = 0;
+	Value sample_value;
 };
 
 // Validate that the table/view has read_id (VARCHAR), sequence1 (VARCHAR),
@@ -128,8 +139,29 @@ static unique_ptr<FunctionData> DeblurBind(ClientContext &context, TableFunction
 		}
 	}
 
-	names = {"read_id", "sequence", "abundance"};
-	return_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::BIGINT};
+	auto sample_it = input.named_parameters.find("sample_id");
+	if (sample_it != input.named_parameters.end()) {
+		data->has_sample_id = true;
+		data->sample_info.sample_id_col = sample_it->second.GetValue<string>();
+	}
+
+	if (data->has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context);
+		Connection conn(db);
+		// Reserved output-column names the sample_id column must not collide with.
+		DiscoverSamples(conn, data->input_table, data->sample_info.sample_id_col, {"read_id", "sequence", "abundance"},
+		                "deblur", data->sample_info);
+
+		names.push_back(data->sample_info.sample_id_col);
+		return_types.push_back(data->sample_info.sample_id_type);
+	}
+
+	names.emplace_back("read_id");
+	names.emplace_back("sequence");
+	names.emplace_back("abundance");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(LogicalType::BIGINT);
 
 	return data;
 }
@@ -138,7 +170,15 @@ static unique_ptr<GlobalTableFunctionState> DeblurInitGlobal(ClientContext &cont
 	auto &data = input.bind_data->Cast<DeblurData>();
 	auto gstate = make_uniq<DeblurGlobalState>();
 
-	// Load all sequences via a separate connection to avoid deadlocking
+	if (data.has_sample_id) {
+		// Re-entrant algorithm: default hint lets DuckDB threads work on distinct samples.
+		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size());
+		return gstate;
+	}
+
+	gstate->max_threads = 1;
+
+	// Non-sample path: load whole table once, deblur, hold for single-threaded drain.
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
 	auto result = conn.Query("SELECT \"read_id\", \"sequence1\", CAST(\"abundance\" AS BIGINT) FROM " +
@@ -168,7 +208,7 @@ static unique_ptr<GlobalTableFunctionState> DeblurInitGlobal(ClientContext &cont
 
 	if (!sequences.empty()) {
 		try {
-			gstate->results = miint::deblur(std::move(sequences), data.params);
+			gstate->shared_results = miint::deblur(std::move(sequences), data.params);
 		} catch (const std::invalid_argument &e) {
 			throw InvalidInputException("deblur: %s", e.what());
 		}
@@ -177,36 +217,136 @@ static unique_ptr<GlobalTableFunctionState> DeblurInitGlobal(ClientContext &cont
 	return gstate;
 }
 
-static void DeblurExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
-	auto &gstate = data_p.global_state->Cast<DeblurGlobalState>();
+static unique_ptr<LocalTableFunctionState> DeblurInitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+                                                           GlobalTableFunctionState * /*global_state*/) {
+	auto &data = input.bind_data->Cast<DeblurData>();
+	auto lstate = make_uniq<DeblurLocalState>();
+	if (data.has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		lstate->conn = make_uniq<Connection>(db);
+	}
+	return lstate;
+}
 
-	idx_t total = gstate.results.size();
-	if (gstate.current_row >= total) {
-		output.SetCardinality(0);
-		return;
+// Run deblur for a single sample on the per-thread connection, returning the result set.
+// Per-sample partitioning uses `CAST(col AS VARCHAR) = CAST(literal AS VARCHAR)`, mirroring
+// massql and woltka_ogu. This is correct for VARCHAR, integer, and date types — the common
+// sample_id choices. DECIMAL sample_id columns are not recommended: DuckDB's VARCHAR cast
+// preserves trailing zeros (e.g. `3.500`) while `ToSQLString()` strips them (`3.5`), so
+// equality can silently miss rows. If DECIMAL sample IDs become a requirement we should
+// switch this (and the other per-sample call sites) to type-aware literals.
+static std::vector<miint::DeblurResult> RunDeblurForSample(Connection &conn, const DeblurData &data,
+                                                           const Value &sample_value) {
+	auto q_src = KeywordHelper::WriteOptionallyQuoted(data.input_table);
+	auto q_col = KeywordHelper::WriteOptionallyQuoted(data.sample_info.sample_id_col);
+	auto sample_literal = sample_value.ToSQLString();
+
+	auto sql = "SELECT \"read_id\", \"sequence1\", CAST(\"abundance\" AS BIGINT) FROM " + q_src + " WHERE CAST(" +
+	           q_col + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR) ORDER BY \"abundance\" DESC";
+	auto result = conn.Query(sql);
+	if (result->HasError()) {
+		throw InvalidInputException("deblur: failed to read table '%s' for sample %s: %s", data.input_table,
+		                            sample_literal, result->GetError());
 	}
 
-	idx_t count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, total - gstate.current_row);
+	std::vector<miint::DeblurSequence> sequences;
+	auto &materialized = result->Cast<MaterializedQueryResult>();
+	while (auto chunk = materialized.Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			auto read_id_val = chunk->GetValue(0, i);
+			auto seq_val = chunk->GetValue(1, i);
+			auto abundance_val = chunk->GetValue(2, i);
+			if (read_id_val.IsNull() || seq_val.IsNull() || abundance_val.IsNull()) {
+				continue;
+			}
+			auto seq_str = seq_val.GetValue<std::string>();
+			if (seq_str.empty()) {
+				continue;
+			}
+			sequences.push_back({read_id_val.GetValue<std::string>(), std::move(seq_str),
+			                     static_cast<double>(abundance_val.GetValue<int64_t>())});
+		}
+	}
 
+	if (sequences.empty()) {
+		return {};
+	}
+	try {
+		return miint::deblur(std::move(sequences), data.params);
+	} catch (const std::invalid_argument &e) {
+		throw InvalidInputException("deblur: %s for sample %s", e.what(), sample_literal);
+	}
+}
+
+// Emit up to STANDARD_VECTOR_SIZE rows from `source` starting at lstate.current_row.
+// When has_sample_id, col 0 is the sample column and is filled via a ConstantVector
+// reference to lstate.sample_value (constant across the chunk, zero-copy).
+static void EmitRows(const DeblurData &data, DeblurLocalState &lstate, const std::vector<miint::DeblurResult> &source,
+                     DataChunk &output) {
+	idx_t count = MinValue<idx_t>(STANDARD_VECTOR_SIZE, source.size() - lstate.current_row);
+
+	idx_t col = 0;
+	if (data.has_sample_id) {
+		output.data[col++].Reference(lstate.sample_value);
+	}
+	auto &read_id_vec = output.data[col++];
+	auto &seq_vec = output.data[col++];
+	auto &abundance_vec = output.data[col++];
+	auto read_id_data = FlatVector::GetData<string_t>(read_id_vec);
+	auto seq_data = FlatVector::GetData<string_t>(seq_vec);
+	auto abundance_data = FlatVector::GetData<int64_t>(abundance_vec);
 	for (idx_t i = 0; i < count; i++) {
-		idx_t row = gstate.current_row + i;
-		auto &r = gstate.results[row];
-
-		FlatVector::GetData<string_t>(output.data[0])[i] = StringVector::AddString(output.data[0], r.label);
-		FlatVector::GetData<string_t>(output.data[1])[i] = StringVector::AddString(output.data[1], r.sequence);
-		FlatVector::GetData<int64_t>(output.data[2])[i] = r.abundance;
+		auto &r = source[lstate.current_row + i];
+		read_id_data[i] = StringVector::AddString(read_id_vec, r.label);
+		seq_data[i] = StringVector::AddString(seq_vec, r.sequence);
+		abundance_data[i] = r.abundance;
 	}
-
-	gstate.current_row += count;
+	lstate.current_row += count;
 	output.SetCardinality(count);
 }
 
+static void DeblurExecute(ClientContext & /*context*/, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<DeblurData>();
+	auto &gstate = data_p.global_state->Cast<DeblurGlobalState>();
+	auto &lstate = data_p.local_state->Cast<DeblurLocalState>();
+
+	if (!data.has_sample_id) {
+		// Single thread (MaxThreads()=1) drains gstate.shared_results via lstate's cursor.
+		if (lstate.current_row >= gstate.shared_results.size()) {
+			output.SetCardinality(0);
+			return;
+		}
+		EmitRows(data, lstate, gstate.shared_results, output);
+		return;
+	}
+
+	while (true) {
+		if (lstate.current_row < lstate.sample_results.size()) {
+			EmitRows(data, lstate, lstate.sample_results, output);
+			return;
+		}
+		// Buffer drained; claim the next sample. Samples that reduce to zero rows
+		// fall through to claim again.
+		idx_t sample_idx;
+		if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
+			output.SetCardinality(0);
+			return;
+		}
+		lstate.sample_value = data.sample_info.sample_values[sample_idx];
+		lstate.sample_results = RunDeblurForSample(*lstate.conn, data, lstate.sample_value);
+		lstate.current_row = 0;
+	}
+}
+
 TableFunction DeblurTableFunction::GetFunction() {
-	auto tf = TableFunction("deblur", {LogicalType::VARCHAR}, DeblurExecute, DeblurBind, DeblurInitGlobal);
+	auto tf =
+	    TableFunction("deblur", {LogicalType::VARCHAR}, DeblurExecute, DeblurBind, DeblurInitGlobal, DeblurInitLocal);
 	tf.named_parameters["mean_error"] = LogicalType::DOUBLE;
 	tf.named_parameters["error_profile"] = LogicalType::LIST(LogicalType::DOUBLE);
 	tf.named_parameters["indel_prob"] = LogicalType::DOUBLE;
 	tf.named_parameters["indel_max"] = LogicalType::INTEGER;
+	tf.named_parameters["sample_id"] = LogicalType::VARCHAR;
+	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	return tf;
 }
 

--- a/src/include/per_sample_table_function.hpp
+++ b/src/include/per_sample_table_function.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "duckdb.hpp"
+#include "duckdb/function/table_function.hpp"
+
+#include <atomic>
+
+namespace duckdb {
+
+// ── Per-sample table-function coordination ──────────────────────────────────
+// Shared machinery for table functions that accept a `sample_id` named
+// parameter and run their pipeline once per distinct sample value.
+//
+// Bind time: DiscoverSamples() validates the column, rejects empty names
+// and output-column collisions, collects distinct non-NULL values (single
+// DISTINCT … NULLS FIRST query + first-row NULL reject), captures the type.
+// Exec time: InitPerSampleGlobal() caps thread count; ClaimNextSample() hands
+// out sample indices via an atomic counter so each thread processes a
+// different sample.
+//
+// Out of scope: per-sample data loading, result buffering, and the
+// non-sample branch. Callers own those; they dispatch on `has_sample_id`
+// themselves and use a per-thread Connection in LocalState.
+
+struct PerSampleBindInfo {
+	string sample_id_col;
+	LogicalType sample_id_type;
+	vector<Value> sample_values;
+};
+
+// reserved_lowercase_output_names: output column names (already lowercased)
+// that the sample column must not match case-insensitively. Pass {} to skip.
+// Accepts std::vector so callers with existing std::vector<std::string> fields
+// (uchime's `names`) don't need to round-trip through duckdb::vector.
+// fn_label: short function name prepended to error messages, e.g. "deblur".
+void DiscoverSamples(Connection &conn, const string &source_relation, const string &sample_id_col,
+                     const std::vector<std::string> &reserved_lowercase_output_names, const string &fn_label,
+                     PerSampleBindInfo &out);
+
+struct PerSampleGlobalState : public GlobalTableFunctionState {
+	atomic<idx_t> next_sample_idx {0};
+	idx_t max_threads = 1;
+
+	idx_t MaxThreads() const override {
+		return max_threads;
+	}
+};
+
+// max_threads_hint: 0 → use DuckDB scheduler threads (clamped to num_samples).
+// N>0 → cap to min(N, num_samples). Pass 1 when the per-sample backend is not
+// thread-safe (MAFFT mutex, VsearchChimeraWrapper).
+void InitPerSampleGlobal(ClientContext &context, PerSampleGlobalState &gstate, idx_t num_samples,
+                         idx_t max_threads_hint = 0);
+
+// Returns false once every sample has been claimed.
+bool ClaimNextSample(PerSampleGlobalState &gstate, idx_t num_samples, idx_t &out_idx);
+
+} // namespace duckdb

--- a/src/include/sequence_table_reader.hpp
+++ b/src/include/sequence_table_reader.hpp
@@ -64,12 +64,27 @@ struct LoadedSingleEndSequences {
 LoadedSingleEndSequences LoadSingleEndSequences(ClientContext &context, const std::string &table_name,
                                                 const std::string &function_name, bool strict = false);
 
+// Overload that runs against a caller-owned connection with an optional WHERE clause.
+// Useful for per-sample callers: they already hold a per-thread Connection in LocalState
+// and want to filter by a sample predicate. Pass `where_sql` without the leading "WHERE".
+// An empty `where_sql` is equivalent to the context-based overload.
+LoadedSingleEndSequences LoadSingleEndSequences(Connection &conn, const std::string &table_name,
+                                                const std::string &function_name, bool strict,
+                                                const std::string &where_sql);
+
 // Streaming query sequence reader for lazy sub-batching.
 // Produces sub-batches on demand from a streaming query result.
 // Thread-safe: multiple threads can call FetchSubBatch() concurrently.
 class QuerySequenceStream {
 public:
+	// Owns an internal Connection — convenient for single-pipeline readers.
 	QuerySequenceStream(ClientContext &context, const std::string &table_name, const SequenceTableSchema &schema,
+	                    idx_t sub_batch_size = STANDARD_VECTOR_SIZE);
+
+	// Uses a caller-owned Connection. Required when the stream needs to see TEMP
+	// objects (e.g. views) created by the caller on the same connection — per-sample
+	// callers that do CREATE OR REPLACE TEMP VIEW … before streaming must use this.
+	QuerySequenceStream(Connection &conn, const std::string &table_name, const SequenceTableSchema &schema,
 	                    idx_t sub_batch_size = STANDARD_VECTOR_SIZE);
 
 	// Fetch the next sub-batch. Returns an empty batch when the stream is exhausted.
@@ -77,7 +92,11 @@ public:
 	miint::SequenceRecordBatch FetchSubBatch();
 
 private:
-	Connection conn_;
+	// Only one of these two is populated: owned_conn_ for the ClientContext&
+	// constructor, nullptr for the Connection& constructor. conn_ptr_ always
+	// points to the live connection.
+	unique_ptr<Connection> owned_conn_;
+	Connection *conn_ptr_;
 	unique_ptr<QueryResult> stream_;
 	SequenceTableSchema schema_;
 	idx_t sub_batch_size_;
@@ -88,6 +107,8 @@ private:
 	std::vector<std::string> temp_read_ids_;
 	std::vector<std::string> temp_seq1_;
 	std::vector<std::string> temp_seq2_;
+
+	void InitStream(const std::string &table_name);
 };
 
 } // namespace duckdb

--- a/src/include/uchime_common.hpp
+++ b/src/include/uchime_common.hpp
@@ -46,9 +46,11 @@ namespace duckdb {
 std::vector<std::string> GetUchimeOutputNames();
 std::vector<LogicalType> GetUchimeOutputTypes();
 
-// Write a batch of UchimeResults into a DataChunk.
+// Write a batch of UchimeResults into a DataChunk starting at column `start_col`.
+// When start_col > 0 (per-sample callers), callers must populate columns [0, start_col)
+// before/after this call; this function sets the chunk cardinality itself.
 // Returns the number of rows written (min of count and remaining results).
-idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResult> &results, idx_t offset,
-                          idx_t count);
+idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResult> &results, idx_t offset, idx_t count,
+                          idx_t start_col = 0);
 
 } // namespace duckdb

--- a/src/include/uchime_denovo.hpp
+++ b/src/include/uchime_denovo.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "VsearchChimeraWrapper.hpp"
+#include "per_sample_table_function.hpp"
 #include "sequence_table_reader.hpp"
 
 #include "duckdb/common/typedefs.hpp"
@@ -23,34 +24,41 @@ public:
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
+
+		bool has_sample_id = false;
+		PerSampleBindInfo sample_info;
 	};
 
-	struct GlobalState : public GlobalTableFunctionState {
-		// Vsearch wrapper with all sequences loaded and DUST-masked.
-		// K-mer index starts empty — non-chimeras are indexed incrementally.
+	struct GlobalState : public PerSampleGlobalState {
+		// Non-sample path: precomputed sequence set + incremental processing state.
+		// Single-thread drain (max_threads=1); wrapper holds k-mer index as it grows.
 		miint::VsearchChimeraWrapper wrapper;
 
 		std::vector<std::string> labels;
 		std::vector<std::string> sequences;
 		std::vector<int64_t> sizes;
 
-		// Incremental processing state. Each Execute() call processes a batch of
-		// input sequences and buffers the results, allowing DuckDB to check for
-		// cancellation between calls.
 		idx_t input_offset = 0;
-		idx_t indexed_count = 0; // Number of sequences indexed so far
+		idx_t indexed_count = 0;
 		std::vector<miint::UchimeResult> results;
 		idx_t result_offset = 0;
+	};
 
-		idx_t MaxThreads() const override {
-			return 1; // De novo mode is inherently sequential
-		}
+	struct LocalState : public LocalTableFunctionState {
+		unique_ptr<Connection> conn; // sample_id path only
+
+		// Current sample's pre-computed result buffer (drained over multiple Execute calls).
+		std::vector<miint::UchimeResult> results;
+		idx_t result_offset = 0;
+		Value sample_value;
 	};
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
 	                                     vector<LogicalType> &return_types, vector<std::string> &names);
 
 	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
 
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 

--- a/src/include/uchime_ref.hpp
+++ b/src/include/uchime_ref.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "VsearchChimeraWrapper.hpp"
+#include "per_sample_table_function.hpp"
 #include "sequence_table_reader.hpp"
 
 #include "duckdb/common/typedefs.hpp"
@@ -30,27 +31,42 @@ public:
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
+
+		bool has_sample_id = false;
+		PerSampleBindInfo sample_info;
 	};
 
-	struct GlobalState : public GlobalTableFunctionState {
+	struct GlobalState : public PerSampleGlobalState {
+		// Reference table is loaded and set on the wrapper exactly once; the wrapper
+		// is shared read-only during detect_batch calls.
 		miint::VsearchChimeraWrapper wrapper;
 
-		// Lazy streaming of query sequences.
+		// Non-sample path only: streams the full query table on a dedicated connection.
 		std::unique_ptr<QuerySequenceStream> query_stream;
 
-		// Buffered results from the last detect_batch call.
+		// Non-sample path only: buffered results from the last detect_batch call.
 		std::vector<miint::UchimeResult> result_buffer;
 		idx_t result_offset = 0;
+	};
 
-		idx_t MaxThreads() const override {
-			return 1;
-		}
+	struct LocalState : public LocalTableFunctionState {
+		unique_ptr<Connection> conn; // sample_id path only
+
+		// sample_id path only: a fresh QuerySequenceStream per claimed sample,
+		// bound to `conn` and reading from a per-sample TEMP VIEW created on
+		// the same connection.
+		std::unique_ptr<QuerySequenceStream> query_stream;
+		std::vector<miint::UchimeResult> result_buffer;
+		idx_t result_offset = 0;
+		Value sample_value;
 	};
 
 	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
 	                                     vector<LogicalType> &return_types, vector<std::string> &names);
 
 	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
 
 	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
 

--- a/src/massql_function.cpp
+++ b/src/massql_function.cpp
@@ -6,9 +6,7 @@
 #include "duckdb/common/vector_operations/binary_executor.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/parallel/task_scheduler.hpp"
-
-#include <atomic>
+#include "per_sample_table_function.hpp"
 
 namespace duckdb {
 
@@ -22,9 +20,7 @@ struct MassQLData : public TableFunctionData {
 
 	// Sample iteration state (sample_id path only)
 	bool has_sample_id = false;
-	string sample_id_col;
-	LogicalType sample_id_type;
-	vector<Value> sample_values;
+	PerSampleBindInfo sample_info;
 
 	// Sample_id: sample[0] pre-run for schema inference; moved to GlobalState at InitGlobal.
 	unique_ptr<MaterializedQueryResult> sample0_result;
@@ -34,11 +30,7 @@ struct MassQLData : public TableFunctionData {
 	string effective_source;
 };
 
-struct MassQLGlobalState : public GlobalTableFunctionState {
-	// Sample_id: atomic counter starts at 1 (sample[0] pre-run at Bind time).
-	atomic<idx_t> next_sample_idx {0};
-	idx_t max_threads = 1;
-
+struct MassQLGlobalState : public PerSampleGlobalState {
 	// Non-sample_id: pre-run result transferred from MassQLData at InitGlobal.
 	// Single thread drains it from Execute; no synchronization needed.
 	unique_ptr<MaterializedQueryResult> non_sample_result;
@@ -48,10 +40,6 @@ struct MassQLGlobalState : public GlobalTableFunctionState {
 	// __massql_ms1), so parallel threads never collide on those names despite the shared names.
 	unique_ptr<MaterializedQueryResult> sample0_result;
 	atomic<bool> sample0_claimed {false};
-
-	idx_t MaxThreads() const override {
-		return max_threads;
-	}
 };
 
 struct MassQLLocalState : public LocalTableFunctionState {
@@ -160,15 +148,12 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 	auto query_str = input.inputs[0].GetValue<string>();
 	auto source_str = input.inputs[1].GetValue<string>();
 
-	// Read optional sample_id named parameter
+	// Read optional sample_id named parameter (validation deferred to DiscoverSamples)
 	string sample_id_col;
 	bool has_sample_id = false;
 	auto it = input.named_parameters.find("sample_id");
 	if (it != input.named_parameters.end()) {
 		sample_id_col = it->second.GetValue<string>();
-		if (sample_id_col.empty()) {
-			throw InvalidInputException("sample_id column name must not be empty");
-		}
 		has_sample_id = true;
 	}
 
@@ -194,51 +179,18 @@ static unique_ptr<FunctionData> MassQLBind(ClientContext &context, TableFunction
 		// ── sample_id path: use stack-local conn for bind-time validation only ──
 		Connection conn(db);
 
-		// Validate column exists and get its type
-		auto quoted_col = KeywordHelper::WriteOptionallyQuoted(sample_id_col);
-		auto quoted_source = KeywordHelper::WriteOptionallyQuoted(effective_source);
-		auto probe = conn.Query("SELECT " + quoted_col + " FROM " + quoted_source + " LIMIT 0");
-		if (probe->HasError()) {
-			throw InvalidInputException("sample_id column '%s' not found", sample_id_col);
-		}
-		data->sample_id_type = probe->types[0];
-
-		// Reject NULLs early before collecting distinct values
-		auto null_check = conn.Query("SELECT COUNT(*) FROM " + quoted_source + " WHERE " + quoted_col + " IS NULL");
-		if (null_check->HasError()) {
-			throw InvalidInputException("MassQL: failed to check for NULLs: %s", null_check->GetError());
-		}
-		auto null_count = null_check->GetValue(0, 0).GetValue<int64_t>();
-		if (null_count > 0) {
-			throw InvalidInputException("NULL values in sample_id column '%s'", sample_id_col);
-		}
-
-		// Collect distinct values
-		auto distinct_result =
-		    conn.Query("SELECT DISTINCT " + quoted_col + " FROM " + quoted_source + " ORDER BY " + quoted_col);
-		if (distinct_result->HasError()) {
-			throw InvalidInputException("MassQL: failed to query sample_id values: %s", distinct_result->GetError());
-		}
-		auto &materialized = distinct_result->Cast<MaterializedQueryResult>();
-		while (auto chunk = materialized.Fetch()) {
-			for (idx_t i = 0; i < chunk->size(); i++) {
-				data->sample_values.push_back(chunk->data[0].GetValue(i));
-			}
-		}
-
-		if (data->sample_values.empty()) {
-			throw InvalidInputException("sample_id column '%s' has no non-NULL values", sample_id_col);
-		}
+		data->sample_info.sample_id_col = sample_id_col;
+		DiscoverSamples(conn, effective_source, sample_id_col, {}, "massql", data->sample_info);
 
 		// Store state for deferred execution
 		data->has_sample_id = true;
-		data->sample_id_col = sample_id_col;
 		data->parsed = parsed;
 		data->effective_source = effective_source;
 
 		// Run sample[0] to determine the output schema. The result is stored here and
 		// moved to GlobalState at InitGlobal so it is not re-run in Execute.
-		data->sample0_result = RunSamplePipeline(conn, parsed, effective_source, sample_id_col, data->sample_values[0]);
+		data->sample0_result =
+		    RunSamplePipeline(conn, parsed, effective_source, sample_id_col, data->sample_info.sample_values[0]);
 		ExtractSchema(*data->sample0_result, return_types, names);
 	} else {
 		// ── non-sample_id path: existing behavior, conn is stack-local ──
@@ -269,8 +221,7 @@ static unique_ptr<GlobalTableFunctionState> MassQLInitGlobal(ClientContext &cont
 	auto &data = input.bind_data->CastNoConst<MassQLData>();
 	auto gstate = make_uniq<MassQLGlobalState>();
 	if (data.has_sample_id) {
-		idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
-		gstate->max_threads = std::max<idx_t>(1, std::min<idx_t>(db_threads, data.sample_values.size()));
+		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size());
 		// Transfer sample[0]'s pre-run result; Execute threads start claiming from index 1.
 		gstate->sample0_result = std::move(data.sample0_result);
 		gstate->next_sample_idx = 1;
@@ -326,15 +277,13 @@ static void MassQLExecute(ClientContext &context, TableFunctionInput &input, Dat
 			lstate.result = std::move(gstate.sample0_result);
 			continue;
 		}
-		// Atomically claim the next sample index. relaxed: only atomicity needed, no
-		// ordering with respect to other memory operations.
-		idx_t sample_idx = gstate.next_sample_idx.fetch_add(1, std::memory_order_relaxed);
-		if (sample_idx >= data.sample_values.size()) {
+		idx_t sample_idx;
+		if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
 			output.SetCardinality(0);
 			return;
 		}
-		lstate.result = RunSamplePipeline(*lstate.conn, data.parsed, data.effective_source, data.sample_id_col,
-		                                  data.sample_values[sample_idx]);
+		lstate.result = RunSamplePipeline(*lstate.conn, data.parsed, data.effective_source,
+		                                  data.sample_info.sample_id_col, data.sample_info.sample_values[sample_idx]);
 	}
 }
 

--- a/src/per_sample_table_function.cpp
+++ b/src/per_sample_table_function.cpp
@@ -1,0 +1,80 @@
+#include "per_sample_table_function.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+namespace duckdb {
+
+void DiscoverSamples(Connection &conn, const string &source_relation, const string &sample_id_col,
+                     const std::vector<std::string> &reserved_lowercase_output_names, const string &fn_label,
+                     PerSampleBindInfo &out) {
+	if (sample_id_col.empty()) {
+		throw InvalidInputException("%s: sample_id column name must not be empty", fn_label);
+	}
+	// Callers that don't want a collision check pass {} and skip this loop entirely.
+	auto col_lower = StringUtil::Lower(sample_id_col);
+	for (const auto &reserved : reserved_lowercase_output_names) {
+		if (col_lower == reserved) {
+			// Construct a duckdb::vector<std::string> for StringUtil::Join which expects it.
+			duckdb::vector<std::string> joined(reserved_lowercase_output_names.begin(),
+			                                   reserved_lowercase_output_names.end());
+			throw InvalidInputException("%s: sample_id column name '%s' collides with an output column (%s); "
+			                            "rename the column or alias it in a view",
+			                            fn_label, sample_id_col, StringUtil::Join(joined, ", "));
+		}
+	}
+
+	auto q_src = KeywordHelper::WriteOptionallyQuoted(source_relation);
+	auto q_col = KeywordHelper::WriteOptionallyQuoted(sample_id_col);
+
+	auto probe = conn.Query("SELECT " + q_col + " FROM " + q_src + " LIMIT 0");
+	if (probe->HasError()) {
+		throw InvalidInputException("%s: sample_id column '%s' not found", fn_label, sample_id_col);
+	}
+	out.sample_id_type = probe->types[0];
+
+	// Single scan: DISTINCT with NULLs first so we can reject up-front.
+	auto distinct_result =
+	    conn.Query("SELECT DISTINCT " + q_col + " FROM " + q_src + " ORDER BY " + q_col + " NULLS FIRST");
+	if (distinct_result->HasError()) {
+		throw InvalidInputException("%s: failed to query sample_id values: %s", fn_label, distinct_result->GetError());
+	}
+	auto &materialized = distinct_result->Cast<MaterializedQueryResult>();
+	while (auto chunk = materialized.Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			auto val = chunk->data[0].GetValue(i);
+			if (val.IsNull()) {
+				throw InvalidInputException("%s: NULL values in sample_id column '%s'", fn_label, sample_id_col);
+			}
+			out.sample_values.push_back(std::move(val));
+		}
+	}
+	if (out.sample_values.empty()) {
+		throw InvalidInputException("%s: sample_id column '%s' has no non-NULL values", fn_label, sample_id_col);
+	}
+	out.sample_id_col = sample_id_col;
+}
+
+void InitPerSampleGlobal(ClientContext &context, PerSampleGlobalState &gstate, idx_t num_samples,
+                         idx_t max_threads_hint) {
+	if (num_samples == 0) {
+		gstate.max_threads = 1;
+		return;
+	}
+	idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	idx_t cap = (max_threads_hint == 0) ? db_threads : max_threads_hint;
+	gstate.max_threads = std::max<idx_t>(1, std::min<idx_t>(cap, num_samples));
+}
+
+bool ClaimNextSample(PerSampleGlobalState &gstate, idx_t num_samples, idx_t &out_idx) {
+	auto claimed = gstate.next_sample_idx.fetch_add(1, std::memory_order_relaxed);
+	if (claimed >= num_samples) {
+		return false;
+	}
+	out_idx = claimed;
+	return true;
+}
+
+} // namespace duckdb

--- a/src/sequence_table_reader.cpp
+++ b/src/sequence_table_reader.cpp
@@ -455,14 +455,25 @@ void ReadBatchByIds(ClientContext &context, const std::string &query_table, cons
 
 QuerySequenceStream::QuerySequenceStream(ClientContext &context, const std::string &table_name,
                                          const SequenceTableSchema &schema, idx_t sub_batch_size)
-    : conn_(DatabaseInstance::GetDatabase(context)), schema_(schema), sub_batch_size_(sub_batch_size),
+    : owned_conn_(make_uniq<Connection>(DatabaseInstance::GetDatabase(context))), conn_ptr_(owned_conn_.get()),
+      schema_(schema), sub_batch_size_(sub_batch_size), partial_(schema.has_sequence2) {
+	InitStream(table_name);
+}
+
+QuerySequenceStream::QuerySequenceStream(Connection &conn, const std::string &table_name,
+                                         const SequenceTableSchema &schema, idx_t sub_batch_size)
+    : owned_conn_(nullptr), conn_ptr_(&conn), schema_(schema), sub_batch_size_(sub_batch_size),
       partial_(schema.has_sequence2) {
+	InitStream(table_name);
+}
+
+void QuerySequenceStream::InitStream(const std::string &table_name) {
 	partial_.reserve(sub_batch_size_);
 
 	std::string query =
 	    "SELECT " + BuildSequenceColumnList(schema_) + " FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
 
-	stream_ = conn_.SendQuery(query);
+	stream_ = conn_ptr_->SendQuery(query);
 	if (stream_->HasError()) {
 		throw InvalidInputException("Failed to read from query table '%s': %s", table_name, stream_->GetError());
 	}
@@ -506,11 +517,14 @@ miint::SequenceRecordBatch QuerySequenceStream::FetchSubBatch() {
 	return result;
 }
 
-LoadedSingleEndSequences LoadSingleEndSequences(ClientContext &context, const std::string &table_name,
-                                                const std::string &function_name, bool strict) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection conn(db);
-	auto result = conn.Query("SELECT read_id, sequence1 FROM " + KeywordHelper::WriteOptionallyQuoted(table_name));
+LoadedSingleEndSequences LoadSingleEndSequences(Connection &conn, const std::string &table_name,
+                                                const std::string &function_name, bool strict,
+                                                const std::string &where_sql) {
+	auto sql = "SELECT read_id, sequence1 FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
+	if (!where_sql.empty()) {
+		sql += " WHERE " + where_sql;
+	}
+	auto result = conn.Query(sql);
 	if (result->HasError()) {
 		throw InvalidInputException("Failed to read table '%s': %s", table_name, result->GetError());
 	}
@@ -561,6 +575,13 @@ LoadedSingleEndSequences LoadSingleEndSequences(ClientContext &context, const st
 	}
 
 	return loaded;
+}
+
+LoadedSingleEndSequences LoadSingleEndSequences(ClientContext &context, const std::string &table_name,
+                                                const std::string &function_name, bool strict) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	return LoadSingleEndSequences(conn, table_name, function_name, strict, /*where_sql=*/"");
 }
 
 } // namespace duckdb

--- a/src/uchime_common.cpp
+++ b/src/uchime_common.cpp
@@ -18,15 +18,15 @@ std::vector<LogicalType> GetUchimeOutputTypes() {
 	        LogicalType::DOUBLE,  LogicalType::VARCHAR};
 }
 
-idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResult> &results, idx_t offset,
-                          idx_t count) {
+idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResult> &results, idx_t offset, idx_t count,
+                          idx_t start_col) {
 	idx_t actual = std::min(count, static_cast<idx_t>(results.size()) - offset);
 	if (actual == 0) {
 		output.SetCardinality(0);
 		return 0;
 	}
 
-	idx_t col = 0;
+	idx_t col = start_col;
 
 	// score — always populated
 	auto score_data = FlatVector::GetData<double>(output.data[col++]);
@@ -131,7 +131,11 @@ idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResu
 		FlatVector::GetData<string_t>(flag_vec)[i] = StringVector::AddString(flag_vec, results[offset + i].flag);
 	}
 
-	D_ASSERT(col == output.ColumnCount());
+	// Exactly 18 uchimeout columns should have been written, starting at start_col.
+	// (output.ColumnCount() equals start_col + 18 when the caller prepends columns,
+	// so the two forms are equivalent — but this form stays honest about what
+	// this function owns regardless of the caller's extra columns.)
+	D_ASSERT(col == start_col + 18);
 	output.SetCardinality(actual);
 	return actual;
 }

--- a/src/uchime_denovo.cpp
+++ b/src/uchime_denovo.cpp
@@ -15,7 +15,6 @@
 namespace duckdb {
 
 // Validate that a table has read_id (VARCHAR), sequence1 (VARCHAR), and size (integer type).
-// Single catalog lookup — checks all three columns in one pass.
 static void ValidateDenovoTableSchema(ClientContext &context, const std::string &table_name) {
 	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
 	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
@@ -43,13 +42,11 @@ static void ValidateDenovoTableSchema(ClientContext &context, const std::string 
 		throw BinderException("'%s' is not a table or view", table_name);
 	}
 
-	// Build case-insensitive lookup
 	std::unordered_map<string, idx_t> name_to_idx;
 	for (idx_t i = 0; i < col_names.size(); i++) {
 		name_to_idx[StringUtil::Lower(col_names[i])] = i;
 	}
 
-	// Check read_id
 	auto it = name_to_idx.find("read_id");
 	if (it == name_to_idx.end()) {
 		throw BinderException("Table '%s' missing required column 'read_id' (VARCHAR)", table_name);
@@ -58,7 +55,6 @@ static void ValidateDenovoTableSchema(ClientContext &context, const std::string 
 		throw BinderException("Column 'read_id' in table '%s' must be VARCHAR", table_name);
 	}
 
-	// Check sequence1
 	it = name_to_idx.find("sequence1");
 	if (it == name_to_idx.end()) {
 		throw BinderException("Table '%s' missing required column 'sequence1' (VARCHAR)", table_name);
@@ -67,7 +63,6 @@ static void ValidateDenovoTableSchema(ClientContext &context, const std::string 
 		throw BinderException("Column 'sequence1' in table '%s' must be VARCHAR", table_name);
 	}
 
-	// Check size (any integer type)
 	it = name_to_idx.find("size");
 	if (it == name_to_idx.end()) {
 		throw BinderException("Table '%s' missing required column 'size' (integer type)", table_name);
@@ -83,17 +78,82 @@ static void ValidateDenovoTableSchema(ClientContext &context, const std::string 
 	}
 }
 
+// Pull (read_id, sequence1, size) rows for a single sample (or the whole table when
+// where_sql is empty) via the given connection, ordered by size DESC, dropping
+// NULL/empty rows.
+static void LoadDenovoSequences(Connection &conn, const std::string &table_name, const std::string &where_sql,
+                                std::vector<std::string> &out_labels, std::vector<std::string> &out_sequences,
+                                std::vector<int64_t> &out_sizes) {
+	auto sql = "SELECT read_id, sequence1, size FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
+	if (!where_sql.empty()) {
+		sql += " WHERE " + where_sql;
+	}
+	sql += " ORDER BY size DESC";
+	auto result = conn.Query(sql);
+	if (result->HasError()) {
+		throw InvalidInputException("Failed to read table '%s': %s", table_name, result->GetError());
+	}
+
+	auto &materialized = result->Cast<MaterializedQueryResult>();
+	while (auto chunk = materialized.Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			auto read_id_val = chunk->GetValue(0, i);
+			auto seq_val = chunk->GetValue(1, i);
+			auto size_val = chunk->GetValue(2, i);
+			if (read_id_val.IsNull() || seq_val.IsNull() || size_val.IsNull()) {
+				continue;
+			}
+			auto seq_str = seq_val.GetValue<std::string>();
+			if (seq_str.empty()) {
+				continue;
+			}
+			out_labels.push_back(read_id_val.GetValue<std::string>());
+			out_sequences.push_back(std::move(seq_str));
+			out_sizes.push_back(size_val.GetValue<int64_t>());
+		}
+	}
+}
+
+// Run the denovo bootstrap + incremental k-mer indexing over a pre-loaded set of
+// size-sorted sequences, returning the full result vector. Used by the per-sample
+// path to materialize one sample's results before emission.
+static std::vector<miint::UchimeResult> RunDenovoForSet(const miint::UchimeParams &params,
+                                                        const std::vector<std::string> &labels,
+                                                        const std::vector<std::string> &sequences,
+                                                        const std::vector<int64_t> &sizes) {
+	miint::VsearchChimeraWrapper wrapper(params);
+	wrapper.prepare_denovo(labels, sequences, sizes);
+
+	std::vector<miint::UchimeResult> results;
+	results.reserve(labels.size());
+
+	idx_t indexed_count = 0;
+	for (idx_t i = 0; i < labels.size(); i++) {
+		miint::UchimeResult r;
+		if (indexed_count < 2) {
+			// Bootstrap: seed the k-mer index with the two most abundant sequences.
+			r.query_label = labels[i];
+			r.flag = "N";
+		} else {
+			r = wrapper.detect_denovo(labels[i], sequences[i], sizes[i]);
+		}
+		if (r.flag != "Y") {
+			wrapper.index_sequence(i);
+			indexed_count++;
+		}
+		results.push_back(std::move(r));
+	}
+	return results;
+}
+
 unique_ptr<FunctionData> UchimeDenovoTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
                                                          vector<LogicalType> &return_types,
                                                          vector<std::string> &names) {
 	auto data = make_uniq<Data>();
 
 	data->input_table = input.inputs[0].GetValue<std::string>();
-
-	// Validate table schema: read_id (VARCHAR), sequence1 (VARCHAR), size (integer)
 	ValidateDenovoTableSchema(context, data->input_table);
 
-	// Optional scoring parameters with range validation
 	auto get_double = [&](const std::string &name, double &out, double min_val, const char *constraint) {
 		auto it = input.named_parameters.find(name);
 		if (it != input.named_parameters.end()) {
@@ -122,8 +182,26 @@ unique_ptr<FunctionData> UchimeDenovoTableFunction::Bind(ClientContext &context,
 	get_double("abskew", data->params.abskew, 1.0, ">= 1.0");
 	get_int("mindiffs", data->params.mindiffs, 1, ">= 1");
 
+	auto sample_it = input.named_parameters.find("sample_id");
+	if (sample_it != input.named_parameters.end()) {
+		data->has_sample_id = true;
+		data->sample_info.sample_id_col = sample_it->second.GetValue<string>();
+	}
+
 	data->names = GetUchimeOutputNames();
 	data->types = GetUchimeOutputTypes();
+
+	if (data->has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context);
+		Connection conn(db);
+		// Reserved = 18 uchime output columns (case-insensitive, lowercase already).
+		DiscoverSamples(conn, data->input_table, data->sample_info.sample_id_col, data->names,
+		                "detect_chimera_uchime_denovo", data->sample_info);
+
+		names.push_back(data->sample_info.sample_id_col);
+		return_types.push_back(data->sample_info.sample_id_type);
+	}
+
 	for (auto &n : data->names) {
 		names.push_back(n);
 	}
@@ -139,36 +217,18 @@ unique_ptr<GlobalTableFunctionState> UchimeDenovoTableFunction::InitGlobal(Clien
 	auto &data = input.bind_data->Cast<Data>();
 	auto gstate = make_uniq<GlobalState>();
 
+	if (data.has_sample_id) {
+		// Wrapper is explicitly not thread-safe per its header; clamp to 1.
+		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size(), /*max_threads_hint=*/1);
+		return gstate;
+	}
+
+	gstate->max_threads = 1;
 	gstate->wrapper = miint::VsearchChimeraWrapper(data.params);
 
-	// Load all sequences with their abundance via a separate connection.
-	// Sorted by size DESC so the most abundant sequences are processed first.
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
-	auto result = conn.Query("SELECT read_id, sequence1, size FROM " +
-	                         KeywordHelper::WriteOptionallyQuoted(data.input_table) + " ORDER BY size DESC");
-	if (result->HasError()) {
-		throw InvalidInputException("Failed to read table '%s': %s", data.input_table, result->GetError());
-	}
-
-	auto &materialized = result->Cast<MaterializedQueryResult>();
-	while (auto chunk = materialized.Fetch()) {
-		for (idx_t i = 0; i < chunk->size(); i++) {
-			auto read_id_val = chunk->GetValue(0, i);
-			auto seq_val = chunk->GetValue(1, i);
-			auto size_val = chunk->GetValue(2, i);
-			if (read_id_val.IsNull() || seq_val.IsNull() || size_val.IsNull()) {
-				continue;
-			}
-			auto seq_str = seq_val.GetValue<std::string>();
-			if (seq_str.empty()) {
-				continue;
-			}
-			gstate->labels.push_back(read_id_val.GetValue<std::string>());
-			gstate->sequences.push_back(std::move(seq_str));
-			gstate->sizes.push_back(size_val.GetValue<int64_t>());
-		}
-	}
+	LoadDenovoSequences(conn, data.input_table, /*where_sql=*/"", gstate->labels, gstate->sequences, gstate->sizes);
 
 	if (gstate->labels.empty()) {
 		throw InvalidInputException("Table '%s' is empty (or contains only NULL/empty sequences)", data.input_table);
@@ -181,72 +241,111 @@ unique_ptr<GlobalTableFunctionState> UchimeDenovoTableFunction::InitGlobal(Clien
 	return gstate;
 }
 
-void UchimeDenovoTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+unique_ptr<LocalTableFunctionState> UchimeDenovoTableFunction::InitLocal(ExecutionContext &context,
+                                                                         TableFunctionInitInput &input,
+                                                                         GlobalTableFunctionState * /*gstate*/) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto lstate = make_uniq<LocalState>();
+	if (data.has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		lstate->conn = make_uniq<Connection>(db);
+	}
+	return lstate;
+}
+
+void UchimeDenovoTableFunction::Execute(ClientContext & /*context*/, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<Data>();
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
+	auto &lstate = data_p.local_state->Cast<LocalState>();
 
-	// De novo mode is inherently sequential: each non-chimera must be indexed
-	// before processing the next (lower abundance) query. We process a small
-	// batch per Execute() call to allow DuckDB's cancellation mechanism to
-	// work between calls, rather than processing everything in a single blocking call.
+	if (!data.has_sample_id) {
+		// Non-sample path: incremental processing preserves the existing cancellation
+		// window (one STANDARD_VECTOR_SIZE batch of queries per Execute call).
 
-	// 1. Drain any buffered results first
-	if (gstate.result_offset < gstate.results.size()) {
-		idx_t remaining = gstate.results.size() - gstate.result_offset;
-		idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-		OutputUchimeResults(output, gstate.results, gstate.result_offset, count);
-		gstate.result_offset += count;
+		// 1. Drain any buffered results first
+		if (gstate.result_offset < gstate.results.size()) {
+			idx_t remaining = gstate.results.size() - gstate.result_offset;
+			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
+			OutputUchimeResults(output, gstate.results, gstate.result_offset, count);
+			gstate.result_offset += count;
+			return;
+		}
+
+		// 2. Process next batch of input sequences
+		gstate.results.clear();
+		gstate.result_offset = 0;
+
+		idx_t batch_size = STANDARD_VECTOR_SIZE;
+		idx_t processed = 0;
+
+		while (gstate.input_offset < gstate.labels.size() && processed < batch_size) {
+			idx_t i = gstate.input_offset++;
+			miint::UchimeResult result;
+
+			if (gstate.indexed_count < 2) {
+				result.query_label = gstate.labels[i];
+				result.flag = "N";
+			} else {
+				result = gstate.wrapper.detect_denovo(gstate.labels[i], gstate.sequences[i], gstate.sizes[i]);
+			}
+
+			if (result.flag != "Y") {
+				gstate.wrapper.index_sequence(i);
+				gstate.indexed_count++;
+			}
+
+			gstate.results.push_back(std::move(result));
+			processed++;
+		}
+
+		if (gstate.results.empty()) {
+			output.SetCardinality(0);
+			return;
+		}
+
+		idx_t count = std::min(static_cast<idx_t>(gstate.results.size()), static_cast<idx_t>(STANDARD_VECTOR_SIZE));
+		OutputUchimeResults(output, gstate.results, 0, count);
+		gstate.result_offset = count;
 		return;
 	}
 
-	// 2. Process next batch of input sequences
-	gstate.results.clear();
-	gstate.result_offset = 0;
-
-	idx_t batch_size = STANDARD_VECTOR_SIZE;
-	idx_t processed = 0;
-
-	while (gstate.input_offset < gstate.labels.size() && processed < batch_size) {
-		idx_t i = gstate.input_offset++;
-		miint::UchimeResult result;
-
-		if (gstate.indexed_count < 2) {
-			// Bootstrap: the first two sequences (highest abundance) are unconditionally
-			// treated as non-chimeric and indexed to seed the k-mer index. Input is
-			// sorted by size DESC in InitGlobal; equal-abundance tie-break depends on
-			// SQL ORDER BY semantics (unspecified for ties).
-			result.query_label = gstate.labels[i];
-			result.parent_a_label = "";
-			result.parent_b_label = "";
-			result.closest_parent_label = "";
-			result.flag = "N";
-		} else {
-			result = gstate.wrapper.detect_denovo(gstate.labels[i], gstate.sequences[i], gstate.sizes[i]);
+	// Sample path: run the full denovo compute for one sample, emit it in chunks,
+	// then claim the next. Samples that reduce to zero rows fall through the loop.
+	while (true) {
+		if (lstate.result_offset < lstate.results.size()) {
+			idx_t remaining = lstate.results.size() - lstate.result_offset;
+			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
+			output.data[0].Reference(lstate.sample_value);
+			OutputUchimeResults(output, lstate.results, lstate.result_offset, count, /*start_col=*/1);
+			lstate.result_offset += count;
+			return;
 		}
 
-		// Non-chimeras (and borderline ?) are added to the k-mer index.
-		// The sequences are already in vsearch's DB from prepare_denovo().
-		if (result.flag != "Y") {
-			gstate.wrapper.index_sequence(i);
-			gstate.indexed_count++;
+		idx_t sample_idx;
+		if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
+			output.SetCardinality(0);
+			return;
 		}
+		lstate.sample_value = data.sample_info.sample_values[sample_idx];
+		auto sample_literal = lstate.sample_value.ToSQLString();
+		auto q_col = KeywordHelper::WriteOptionallyQuoted(data.sample_info.sample_id_col);
+		// CAST-as-VARCHAR equality: see note in deblur_table_function.cpp re: DECIMAL.
+		auto where_sql = "CAST(" + q_col + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR)";
 
-		gstate.results.push_back(std::move(result));
-		processed++;
+		std::vector<std::string> labels, sequences;
+		std::vector<int64_t> sizes;
+		LoadDenovoSequences(*lstate.conn, data.input_table, where_sql, labels, sequences, sizes);
+		lstate.results.clear();
+		lstate.result_offset = 0;
+		if (!labels.empty()) {
+			lstate.results = RunDenovoForSet(data.params, labels, sequences, sizes);
+		}
 	}
-
-	if (gstate.results.empty()) {
-		output.SetCardinality(0);
-		return;
-	}
-
-	// Output the first chunk of results
-	idx_t count = std::min(static_cast<idx_t>(gstate.results.size()), static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-	OutputUchimeResults(output, gstate.results, 0, count);
-	gstate.result_offset = count;
 }
 
 TableFunction UchimeDenovoTableFunction::GetFunction() {
-	auto tf = TableFunction("detect_chimera_uchime_denovo", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal);
+	auto tf =
+	    TableFunction("detect_chimera_uchime_denovo", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal, InitLocal);
 
 	tf.named_parameters["minh"] = LogicalType::DOUBLE;
 	tf.named_parameters["xn"] = LogicalType::DOUBLE;
@@ -254,6 +353,7 @@ TableFunction UchimeDenovoTableFunction::GetFunction() {
 	tf.named_parameters["mindiv"] = LogicalType::DOUBLE;
 	tf.named_parameters["mindiffs"] = LogicalType::INTEGER;
 	tf.named_parameters["abskew"] = LogicalType::DOUBLE;
+	tf.named_parameters["sample_id"] = LogicalType::VARCHAR;
 
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 

--- a/src/uchime_ref.cpp
+++ b/src/uchime_ref.cpp
@@ -3,11 +3,33 @@
 #include "uchime_common.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include "duckdb/main/database.hpp"
 
 #include <algorithm>
 
 namespace duckdb {
+
+// Serves a chunk from the local-state buffer when working in per-sample mode, or
+// directly into output at col 0 when not. Returns true if a chunk was emitted (and
+// output.cardinality is set); false if the buffer is drained.
+static bool EmitFromBuffer(const std::vector<miint::UchimeResult> &buffer, idx_t &result_offset, DataChunk &output,
+                           bool has_sample_id, const Value &sample_value) {
+	if (result_offset >= buffer.size()) {
+		return false;
+	}
+	idx_t remaining = buffer.size() - result_offset;
+	idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
+	if (has_sample_id) {
+		output.data[0].Reference(sample_value);
+		OutputUchimeResults(output, buffer, result_offset, count, /*start_col=*/1);
+	} else {
+		OutputUchimeResults(output, buffer, result_offset, count);
+	}
+	result_offset += count;
+	return true;
+}
 
 unique_ptr<FunctionData> UchimeRefTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
                                                       vector<LogicalType> &return_types, vector<std::string> &names) {
@@ -49,8 +71,26 @@ unique_ptr<FunctionData> UchimeRefTableFunction::Bind(ClientContext &context, Ta
 	get_double("mindiv", data->params.mindiv, 0.0, ">= 0");
 	get_int("mindiffs", data->params.mindiffs, 1, ">= 1");
 
+	auto sample_it = input.named_parameters.find("sample_id");
+	if (sample_it != input.named_parameters.end()) {
+		data->has_sample_id = true;
+		data->sample_info.sample_id_col = sample_it->second.GetValue<string>();
+	}
+
 	data->names = GetUchimeOutputNames();
 	data->types = GetUchimeOutputTypes();
+
+	if (data->has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context);
+		Connection conn(db);
+		// Reserved = 18 uchime output column names (case-insensitive).
+		DiscoverSamples(conn, data->query_table, data->sample_info.sample_id_col, data->names, "detect_chimera_uchime",
+		                data->sample_info);
+
+		names.push_back(data->sample_info.sample_id_col);
+		return_types.push_back(data->sample_info.sample_id_type);
+	}
+
 	for (auto &n : data->names) {
 		names.push_back(n);
 	}
@@ -68,46 +108,102 @@ unique_ptr<GlobalTableFunctionState> UchimeRefTableFunction::InitGlobal(ClientCo
 
 	gstate->wrapper = miint::VsearchChimeraWrapper(data.params);
 
+	// Reference load is always global — shared read-only by every sample's detect_batch.
 	auto ref = LoadSingleEndSequences(context, data.ref_table, "detect_chimera_uchime");
 	gstate->wrapper.set_reference(ref.labels, ref.sequences);
 
-	// Lazy streaming reader — one STANDARD_VECTOR_SIZE chunk per Execute call.
+	if (data.has_sample_id) {
+		// detect_batch is documented as not thread-safe on the same wrapper instance.
+		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size(), /*max_threads_hint=*/1);
+		return gstate;
+	}
+
+	gstate->max_threads = 1;
 	gstate->query_stream =
 	    std::make_unique<QuerySequenceStream>(context, data.query_table, data.query_schema, STANDARD_VECTOR_SIZE);
-
 	return gstate;
 }
 
-void UchimeRefTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+unique_ptr<LocalTableFunctionState> UchimeRefTableFunction::InitLocal(ExecutionContext &context,
+                                                                      TableFunctionInitInput &input,
+                                                                      GlobalTableFunctionState * /*gstate*/) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto lstate = make_uniq<LocalState>();
+	if (data.has_sample_id) {
+		auto &db = DatabaseInstance::GetDatabase(context.client);
+		lstate->conn = make_uniq<Connection>(db);
+	}
+	return lstate;
+}
+
+void UchimeRefTableFunction::Execute(ClientContext & /*context*/, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<Data>();
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
+	auto &lstate = data_p.local_state->Cast<LocalState>();
+
+	if (!data.has_sample_id) {
+		while (true) {
+			if (EmitFromBuffer(gstate.result_buffer, gstate.result_offset, output, /*has_sample_id=*/false, Value())) {
+				return;
+			}
+			gstate.result_buffer.clear();
+			gstate.result_offset = 0;
+
+			auto query_batch = gstate.query_stream->FetchSubBatch();
+			if (query_batch.empty()) {
+				output.SetCardinality(0);
+				return;
+			}
+			gstate.wrapper.detect_batch(query_batch.read_ids, query_batch.sequences1, gstate.result_buffer);
+		}
+	}
 
 	while (true) {
-		// 1. Drain buffered results from last batch
-		if (gstate.result_offset < gstate.result_buffer.size()) {
-			idx_t remaining = gstate.result_buffer.size() - gstate.result_offset;
-			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputUchimeResults(output, gstate.result_buffer, gstate.result_offset, count);
-			gstate.result_offset += count;
+		if (EmitFromBuffer(lstate.result_buffer, lstate.result_offset, output, /*has_sample_id=*/true,
+		                   lstate.sample_value)) {
 			return;
 		}
+		lstate.result_buffer.clear();
+		lstate.result_offset = 0;
 
-		// 2. Buffer exhausted — fetch next chunk and detect via batch API.
-		gstate.result_buffer.clear();
-		gstate.result_offset = 0;
+		// Drain the current sample's stream, if any.
+		if (lstate.query_stream) {
+			auto query_batch = lstate.query_stream->FetchSubBatch();
+			if (!query_batch.empty()) {
+				gstate.wrapper.detect_batch(query_batch.read_ids, query_batch.sequences1, lstate.result_buffer);
+				continue;
+			}
+			lstate.query_stream.reset();
+		}
 
-		auto query_batch = gstate.query_stream->FetchSubBatch();
-		if (query_batch.empty()) {
+		// Current sample exhausted; claim the next.
+		idx_t sample_idx;
+		if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
 			output.SetCardinality(0);
 			return;
 		}
-
-		// 3. Detect chimeras for entire chunk via vsearch's internal thread pool.
-		gstate.wrapper.detect_batch(query_batch.read_ids, query_batch.sequences1, gstate.result_buffer);
+		lstate.sample_value = data.sample_info.sample_values[sample_idx];
+		auto sample_literal = lstate.sample_value.ToSQLString();
+		auto q_col = KeywordHelper::WriteOptionallyQuoted(data.sample_info.sample_id_col);
+		auto q_src = KeywordHelper::WriteOptionallyQuoted(data.query_table);
+		// Build a per-sample TEMP VIEW on the thread's connection, then hand that same
+		// connection to QuerySequenceStream so the stream can resolve the view. The
+		// CAST-as-VARCHAR equality matches the other per-sample call sites; DECIMAL caveat
+		// applies (see note in deblur_table_function.cpp).
+		auto view_sql = "CREATE OR REPLACE TEMP VIEW __uchime_per_sample AS SELECT * FROM " + q_src + " WHERE CAST(" +
+		                q_col + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR)";
+		auto view_result = lstate.conn->Query(view_sql);
+		if (view_result->HasError()) {
+			throw InvalidInputException("detect_chimera_uchime: failed to create per-sample view for %s: %s",
+			                            sample_literal, view_result->GetError());
+		}
+		lstate.query_stream = std::make_unique<QuerySequenceStream>(*lstate.conn, "__uchime_per_sample",
+		                                                            data.query_schema, STANDARD_VECTOR_SIZE);
 	}
 }
 
 TableFunction UchimeRefTableFunction::GetFunction() {
-	auto tf = TableFunction("detect_chimera_uchime", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal);
+	auto tf = TableFunction("detect_chimera_uchime", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal, InitLocal);
 
 	tf.named_parameters["db"] = LogicalType::VARCHAR;
 	tf.named_parameters["minh"] = LogicalType::DOUBLE;
@@ -115,6 +211,7 @@ TableFunction UchimeRefTableFunction::GetFunction() {
 	tf.named_parameters["dn"] = LogicalType::DOUBLE;
 	tf.named_parameters["mindiv"] = LogicalType::DOUBLE;
 	tf.named_parameters["mindiffs"] = LogicalType::INTEGER;
+	tf.named_parameters["sample_id"] = LogicalType::VARCHAR;
 
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 

--- a/src/woltka_ogu_function.cpp
+++ b/src/woltka_ogu_function.cpp
@@ -3,9 +3,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
-#include "duckdb/parallel/task_scheduler.hpp"
-
-#include <atomic>
+#include "per_sample_table_function.hpp"
 
 namespace duckdb {
 
@@ -26,26 +24,16 @@ struct WoltkaOguData : public TableFunctionData {
 	string seq_id_col;
 
 	bool has_sample_id = false;
-	string sample_id_col;
-	LogicalType sample_id_type;
-	vector<Value> sample_values;
+	PerSampleBindInfo sample_info;
 
 	// Non-sample path: pre-run at Bind; ownership moved to GlobalState at InitGlobal.
 	unique_ptr<MaterializedQueryResult> non_sample_result;
 };
 
-struct WoltkaOguGlobalState : public GlobalTableFunctionState {
-	// Per-sample mode: atomic index of the next sample to claim.
-	atomic<idx_t> next_sample_idx {0};
-	idx_t max_threads = 1;
-
+struct WoltkaOguGlobalState : public PerSampleGlobalState {
 	// Non-sample path: pre-run result transferred from bind data at InitGlobal.
 	// Single thread drains it from Execute; no synchronization needed.
 	unique_ptr<MaterializedQueryResult> non_sample_result;
-
-	idx_t MaxThreads() const override {
-		return max_threads;
-	}
 };
 
 struct WoltkaOguLocalState : public LocalTableFunctionState {
@@ -131,18 +119,7 @@ static unique_ptr<FunctionData> WoltkaOguBind(ClientContext &context, TableFunct
 
 	auto it = input.named_parameters.find("sample_id");
 	if (it != input.named_parameters.end()) {
-		data->sample_id_col = it->second.GetValue<string>();
-		if (data->sample_id_col.empty()) {
-			throw InvalidInputException("woltka_ogu: sample_id column name must not be empty");
-		}
-		// Reject column names that collide with the fixed output schema.
-		// DuckDB identifiers are case-insensitive.
-		auto col_lower = StringUtil::Lower(data->sample_id_col);
-		if (col_lower == "feature_id" || col_lower == "value") {
-			throw InvalidInputException("woltka_ogu: sample_id column name '%s' collides with an output column "
-			                            "(feature_id, value); rename the column or alias it in a view",
-			                            data->sample_id_col);
-		}
+		data->sample_info.sample_id_col = it->second.GetValue<string>();
 		data->has_sample_id = true;
 	}
 
@@ -163,37 +140,11 @@ static unique_ptr<FunctionData> WoltkaOguBind(ClientContext &context, TableFunct
 	}
 
 	if (data->has_sample_id) {
-		auto q_sample = KeywordHelper::WriteOptionallyQuoted(data->sample_id_col);
+		DiscoverSamples(conn, data->source, data->sample_info.sample_id_col, {"feature_id", "value"}, "woltka_ogu",
+		                data->sample_info);
 
-		auto sample_probe = conn.Query("SELECT " + q_sample + " FROM " + q_src + " LIMIT 0");
-		if (sample_probe->HasError()) {
-			throw InvalidInputException("woltka_ogu: sample_id column '%s' not found", data->sample_id_col);
-		}
-		data->sample_id_type = sample_probe->types[0];
-
-		// Single scan: distinct sample values, NULLs first so we can reject up-front.
-		auto distinct_result =
-		    conn.Query("SELECT DISTINCT " + q_sample + " FROM " + q_src + " ORDER BY " + q_sample + " NULLS FIRST");
-		if (distinct_result->HasError()) {
-			throw InvalidInputException("woltka_ogu: failed to query sample_id values: %s",
-			                            distinct_result->GetError());
-		}
-		auto &materialized = distinct_result->Cast<MaterializedQueryResult>();
-		while (auto chunk = materialized.Fetch()) {
-			for (idx_t i = 0; i < chunk->size(); i++) {
-				auto val = chunk->data[0].GetValue(i);
-				if (val.IsNull()) {
-					throw InvalidInputException("NULL values in sample_id column '%s'", data->sample_id_col);
-				}
-				data->sample_values.push_back(std::move(val));
-			}
-		}
-		if (data->sample_values.empty()) {
-			throw InvalidInputException("sample_id column '%s' has no non-NULL values", data->sample_id_col);
-		}
-
-		names.push_back(data->sample_id_col);
-		return_types.push_back(data->sample_id_type);
+		names.push_back(data->sample_info.sample_id_col);
+		return_types.push_back(data->sample_info.sample_id_type);
 	} else {
 		// Non-sample path: pre-run the aggregation once here. Ownership of the result
 		// transfers to GlobalState at InitGlobal, matching MassQLFunction's pattern.
@@ -214,8 +165,7 @@ static unique_ptr<GlobalTableFunctionState> WoltkaOguInitGlobal(ClientContext &c
 	auto &data = input.bind_data->CastNoConst<WoltkaOguData>();
 	auto gstate = make_uniq<WoltkaOguGlobalState>();
 	if (data.has_sample_id) {
-		idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
-		gstate->max_threads = std::max<idx_t>(1, std::min<idx_t>(db_threads, data.sample_values.size()));
+		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size());
 	} else {
 		gstate->max_threads = 1;
 		gstate->non_sample_result = std::move(data.non_sample_result);
@@ -260,13 +210,13 @@ static void WoltkaOguExecute(ClientContext &context, TableFunctionInput &input, 
 			}
 			lstate.result.reset();
 		}
-		idx_t sample_idx = gstate.next_sample_idx.fetch_add(1, std::memory_order_relaxed);
-		if (sample_idx >= data.sample_values.size()) {
+		idx_t sample_idx;
+		if (!ClaimNextSample(gstate, data.sample_info.sample_values.size(), sample_idx)) {
 			output.SetCardinality(0);
 			return;
 		}
-		lstate.result = RunSampleAggregation(*lstate.conn, data.source, data.seq_id_col, data.sample_id_col,
-		                                     data.sample_values[sample_idx]);
+		lstate.result = RunSampleAggregation(*lstate.conn, data.source, data.seq_id_col, data.sample_info.sample_id_col,
+		                                     data.sample_info.sample_values[sample_idx]);
 	}
 }
 

--- a/test/sql/align_mafft_sample_id.test
+++ b/test/sql/align_mafft_sample_id.test
@@ -1,0 +1,202 @@
+# name: test/sql/align_mafft_sample_id.test
+# description: test align_mafft sample_id named parameter
+# group: [sql]
+
+statement ok
+PRAGMA enable_verification;
+
+require miint
+
+require-env MAFFT_AVAILABLE
+
+# Build the base input: three 8bp DNA sequences with high similarity.
+statement ok
+CREATE TABLE mafft_base AS
+  SELECT read_id, sequence1 FROM read_fastx('data/mafft/tiny.fa');
+
+# ----- Cycle 1: Error on invalid sample_id -----
+
+statement ok
+CREATE VIEW one_sample AS SELECT 'A' AS sample, * FROM mafft_base;
+
+statement error
+SELECT * FROM align_mafft('one_sample', sample_id := 'no_such_column')
+----
+sample_id column 'no_such_column' not found
+
+statement error
+SELECT * FROM align_mafft('one_sample', sample_id := '')
+----
+sample_id column name must not be empty
+
+# ----- Cycle 2: Output-column collision (case-insensitive) -----
+
+statement error
+SELECT * FROM align_mafft('mafft_base', sample_id := 'read_id')
+----
+collides with an output column
+
+statement error
+SELECT * FROM align_mafft('mafft_base', sample_id := 'sequence_index')
+----
+collides with an output column
+
+statement error
+SELECT * FROM align_mafft('mafft_base', sample_id := 'aligned_sequence')
+----
+collides with an output column
+
+statement error
+SELECT * FROM align_mafft('mafft_base', sample_id := 'ALIGNED_LENGTH')
+----
+collides with an output column
+
+# ----- Cycle 3: Per-sample isolation with two samples of different sizes -----
+
+# Sample A: 3 sequences (tiny.fa is 8bp each). Sample B: the same 3 sequences.
+statement ok
+CREATE VIEW multi_sample AS
+  SELECT 'A' AS sample, * FROM mafft_base
+  UNION ALL
+  SELECT 'B' AS sample, * FROM mafft_base;
+
+# Output schema includes sample first, then align_mafft output columns
+query TIITII
+SELECT sample, sequence_index, read_id, aligned_sequence, original_length, aligned_length
+  FROM align_mafft('multi_sample', sample_id := 'sample')
+  ORDER BY sample, sequence_index
+----
+A	0	s1	ACGTACGT	8	8
+A	1	s2	ACGAACGT	8	8
+A	2	s3	ACGTACGA	8	8
+B	0	s1	ACGTACGT	8	8
+B	1	s2	ACGAACGT	8	8
+B	2	s3	ACGTACGA	8	8
+
+# sequence_index is per-sample (0..n-1 within each sample), not globally unique.
+query II
+SELECT sample, MAX(sequence_index)
+  FROM align_mafft('multi_sample', sample_id := 'sample')
+  GROUP BY sample ORDER BY sample
+----
+A	2
+B	2
+
+# ----- Cycle 4: Integer-typed sample_id round-trips -----
+
+statement ok
+CREATE VIEW int_sample AS
+  SELECT 1 AS sample_num, * FROM mafft_base
+  UNION ALL
+  SELECT 2 AS sample_num, * FROM mafft_base;
+
+query II
+SELECT sample_num, COUNT(*)
+  FROM align_mafft('int_sample', sample_id := 'sample_num')
+  GROUP BY sample_num ORDER BY sample_num
+----
+1	3
+2	3
+
+query T
+SELECT typeof(sample_num) FROM align_mafft('int_sample', sample_id := 'sample_num') LIMIT 1
+----
+INTEGER
+
+# ----- Cycle 5: NULL sample values rejected at bind -----
+
+statement ok
+CREATE VIEW null_sample AS SELECT NULL::VARCHAR AS sid, * FROM mafft_base;
+
+statement error
+SELECT * FROM align_mafft('null_sample', sample_id := 'sid')
+----
+NULL values in sample_id column
+
+# ----- Cycle 6: Empty relation → no non-NULL values -----
+
+statement ok
+CREATE VIEW empty_samples AS
+  SELECT 'A' AS sample, * FROM mafft_base WHERE 1=0;
+
+statement error
+SELECT * FROM align_mafft('empty_samples', sample_id := 'sample')
+----
+has no non-NULL values
+
+# ----- Cycle 7: Per-sample validation rules -----
+
+# A sample with fewer than 2 sequences aborts the whole query (strict, matches single-sample behavior)
+statement ok
+CREATE VIEW one_seq_sample AS
+  SELECT 'A' AS sample, read_id, sequence1 FROM mafft_base
+  UNION ALL
+  SELECT 'B' AS sample, 'solo' AS read_id, 'ACGTACGT' AS sequence1;
+
+statement error
+SELECT * FROM align_mafft('one_seq_sample', sample_id := 'sample')
+----
+align_mafft requires at least 2 sequences
+
+# Duplicate read_id WITHIN a sample is rejected
+statement ok
+CREATE VIEW dup_within_sample AS
+  SELECT 'A' AS sample, read_id, sequence1 FROM mafft_base
+  UNION ALL
+  SELECT 'A', 's1', 'ACGTACGT'; -- duplicate of s1 in sample A
+
+statement error
+SELECT * FROM align_mafft('dup_within_sample', sample_id := 'sample')
+----
+duplicate read_id 's1'
+
+# The same read_id across DIFFERENT samples is allowed (join-back uses (sample, read_id))
+statement ok
+CREATE VIEW same_id_diff_samples AS
+  SELECT 'A' AS sample, * FROM mafft_base
+  UNION ALL
+  SELECT 'B' AS sample, * FROM mafft_base; -- same read_ids s1, s2, s3 — but in different samples
+
+query TII
+SELECT sample, read_id, sequence_index
+  FROM align_mafft('same_id_diff_samples', sample_id := 'sample')
+  ORDER BY sample, sequence_index
+----
+A	s1	0
+A	s2	1
+A	s3	2
+B	s1	0
+B	s2	1
+B	s3	2
+
+# ----- Cycle 8: Single-sample equivalence -----
+
+query ITTII
+SELECT sequence_index, read_id, aligned_sequence, original_length, aligned_length
+  FROM align_mafft('one_sample', sample_id := 'sample')
+  ORDER BY sequence_index
+----
+0	s1	ACGTACGT	8	8
+1	s2	ACGAACGT	8	8
+2	s3	ACGTACGA	8	8
+
+# ----- Cycle 9: Parallelism sanity (MAFFT is mutex-serialized; atomic claim must still be correct) -----
+
+statement ok
+CREATE VIEW four_mafft_samples AS
+  SELECT 'A' AS sid, * FROM mafft_base UNION ALL
+  SELECT 'B' AS sid, * FROM mafft_base UNION ALL
+  SELECT 'C' AS sid, * FROM mafft_base UNION ALL
+  SELECT 'D' AS sid, * FROM mafft_base;
+
+statement ok
+PRAGMA threads=4;
+
+query TI
+SELECT sid, COUNT(*) FROM align_mafft('four_mafft_samples', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+A	3
+B	3
+C	3
+D	3

--- a/test/sql/deblur_sample_id.test
+++ b/test/sql/deblur_sample_id.test
@@ -1,0 +1,210 @@
+# name: test/sql/deblur_sample_id.test
+# description: test deblur sample_id named parameter
+# group: [sql]
+
+statement ok
+PRAGMA enable_verification;
+
+require miint
+
+# Build the base input: two aligned sequences, same length, different abundances.
+statement ok
+CREATE TABLE deblur_base(read_id VARCHAR, sequence1 VARCHAR, abundance BIGINT);
+
+statement ok
+INSERT INTO deblur_base VALUES
+    ('E.Coli',
+     'TACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTTGTTAAGTCAGATGTGAAATCCCCGGGCTCAACCTGGGAACTGCATCTGATACTGGCAAGCTTGAGTCTCGTAGAGGGGGGCAGAATTCCAG',
+     1000),
+    ('Error',
+     'AACGGAGGGTGCAAGCGTTAATCGGAATTACTGGGCGTAAAGCGCACGCAGGCGGTTTGTTAAGTCAGATGTGAAATCCCCGGGCTCAACCTGGGAACTGCATCTGATACTGGCAAGCTTGAGTCTCGTAGAGGGGGGCAGAATTCCAG',
+     3);
+
+# ----- Cycle 1: Error on invalid sample_id -----
+
+statement ok
+CREATE VIEW v1 AS SELECT 'A' AS sample, * FROM deblur_base;
+
+# sample_id column doesn't exist
+statement error
+SELECT * FROM deblur('v1', sample_id := 'no_such_column')
+----
+sample_id column 'no_such_column' not found
+
+# sample_id must not be empty
+statement error
+SELECT * FROM deblur('v1', sample_id := '')
+----
+sample_id column name must not be empty
+
+# ----- Cycle 2: Output-column collision (case-insensitive) -----
+
+statement error
+SELECT * FROM deblur('deblur_base', sample_id := 'read_id')
+----
+collides with an output column
+
+statement error
+SELECT * FROM deblur('deblur_base', sample_id := 'abundance')
+----
+collides with an output column
+
+statement error
+SELECT * FROM deblur('deblur_base', sample_id := 'ABUNDANCE')
+----
+collides with an output column
+
+# Note: deblur's output column is named 'sequence' (not 'sequence1'). 'sequence1' is the
+# input column — it does NOT collide with any output column and is therefore permitted,
+# though picking it as sample_id produces one sample per unique sequence (silly but legal).
+
+# ----- Cycle 3: Per-sample isolation with two samples -----
+
+statement ok
+CREATE VIEW multi_sample AS
+  SELECT 'A' AS sample, * FROM deblur_base
+  UNION ALL
+  SELECT 'B' AS sample, * FROM deblur_base;
+
+# Each sample independently keeps E.Coli and drops Error
+query TTII
+SELECT sample, read_id, length(sequence), abundance
+  FROM deblur('multi_sample', sample_id := 'sample')
+  ORDER BY sample, abundance DESC
+----
+A	E.Coli	149	1000
+B	E.Coli	149	1000
+
+# Row count: one per sample
+query I
+SELECT COUNT(*) FROM deblur('multi_sample', sample_id := 'sample')
+----
+2
+
+# Output schema: sample column first, then deblur output columns
+query TTTT
+SELECT typeof(sample), typeof(read_id), typeof(sequence), typeof(abundance)
+  FROM deblur('multi_sample', sample_id := 'sample')
+  LIMIT 1
+----
+VARCHAR	VARCHAR	VARCHAR	BIGINT
+
+# ----- Cycle 4: Integer-typed sample_id preserves type -----
+
+statement ok
+CREATE VIEW int_sample AS
+  SELECT 1 AS sample_num, * FROM deblur_base
+  UNION ALL
+  SELECT 2 AS sample_num, * FROM deblur_base;
+
+query II
+SELECT sample_num, COUNT(*)
+  FROM deblur('int_sample', sample_id := 'sample_num')
+  GROUP BY sample_num ORDER BY sample_num
+----
+1	1
+2	1
+
+query T
+SELECT typeof(sample_num) FROM deblur('int_sample', sample_id := 'sample_num') LIMIT 1
+----
+INTEGER
+
+# ----- Cycle 5: NULL sample values rejected -----
+
+statement ok
+CREATE VIEW null_sample AS SELECT NULL::VARCHAR AS sid, * FROM deblur_base;
+
+statement error
+SELECT * FROM deblur('null_sample', sample_id := 'sid')
+----
+NULL values in sample_id column
+
+# ----- Cycle 6: Empty relation → no non-NULL values -----
+
+statement ok
+CREATE VIEW empty_samples AS
+  SELECT 'A' AS sample, * FROM deblur_base WHERE 1=0;
+
+statement error
+SELECT * FROM deblur('empty_samples', sample_id := 'sample')
+----
+has no non-NULL values
+
+# ----- Cycle 7: Single-sample equivalence -----
+# Running deblur with sample_id on a one-sample view produces the same rows as running
+# deblur without sample_id on the same data.
+
+statement ok
+CREATE VIEW single_sample AS SELECT 'only' AS sample, * FROM deblur_base;
+
+query TII
+SELECT read_id, length(sequence), abundance
+  FROM deblur('single_sample', sample_id := 'sample')
+  ORDER BY read_id
+----
+E.Coli	149	1000
+
+query TII
+SELECT read_id, length(sequence), abundance
+  FROM deblur('deblur_base')
+  ORDER BY read_id
+----
+E.Coli	149	1000
+
+# ----- Cycle 8: Non-sample_id path unchanged -----
+# The existing multi-row deblur_base (no sample_id param) still runs globally.
+
+query TII
+SELECT read_id, length(sequence), abundance
+  FROM deblur('deblur_base')
+  ORDER BY abundance DESC
+----
+E.Coli	149	1000
+
+# ----- Cycle 9: Cross-sample same read_id is allowed -----
+# Inside a sample, deblur requires unique read_ids (implicit from dereplication upstream).
+# Across samples, the same read_id may appear. Join-back uses (sample, read_id).
+
+query TTI
+SELECT sample, read_id, abundance
+  FROM deblur('multi_sample', sample_id := 'sample')
+  ORDER BY sample, read_id
+----
+A	E.Coli	1000
+B	E.Coli	1000
+
+# ----- Cycle 10: Parallel execution — atomic claim + per-thread Connection -----
+# Larger fan-out to actually exercise concurrent claim under multiple threads. Each
+# sample is independent; parallel threads must not double-claim or miss a sample.
+
+statement ok
+CREATE VIEW four_samples AS
+  SELECT 'A' AS sid, * FROM deblur_base UNION ALL
+  SELECT 'B' AS sid, * FROM deblur_base UNION ALL
+  SELECT 'C' AS sid, * FROM deblur_base UNION ALL
+  SELECT 'D' AS sid, * FROM deblur_base;
+
+statement ok
+PRAGMA threads=4;
+
+query TI
+SELECT sid, COUNT(*) FROM deblur('four_samples', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+A	1
+B	1
+C	1
+D	1
+
+statement ok
+PRAGMA threads=8;
+
+query TI
+SELECT sid, COUNT(*) FROM deblur('four_samples', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+A	1
+B	1
+C	1
+D	1

--- a/test/sql/uchime_denovo_sample_id.test
+++ b/test/sql/uchime_denovo_sample_id.test
@@ -1,0 +1,180 @@
+# name: test/sql/uchime_denovo_sample_id.test
+# description: test detect_chimera_uchime_denovo sample_id named parameter
+# group: [sql]
+
+statement ok
+PRAGMA enable_verification;
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+# Base fixture: parse ;size=N; from FASTA headers into a proper size column.
+statement ok
+CREATE TABLE denovo_base AS
+SELECT
+    regexp_extract(read_id, '^([^;]+)', 1) AS read_id,
+    sequence1,
+    CAST(regexp_extract(read_id, 'size=(\d+)', 1) AS INTEGER) AS size
+FROM read_fastx('data/uchime/denovo_input.fasta');
+
+# ----- Cycle 1: Error on invalid sample_id -----
+
+statement ok
+CREATE VIEW dn_v1 AS SELECT 'A' AS sample, * FROM denovo_base;
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('dn_v1', sample_id := 'no_such_column')
+----
+sample_id column 'no_such_column' not found
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('dn_v1', sample_id := '')
+----
+sample_id column name must not be empty
+
+# ----- Cycle 2: Output-column collision (18 uchime output columns) -----
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('denovo_base', sample_id := 'query_id')
+----
+collides with an output column
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('denovo_base', sample_id := 'flag')
+----
+collides with an output column
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('denovo_base', sample_id := 'SCORE')
+----
+collides with an output column
+
+# ----- Cycle 3: Per-sample isolation — each sample scored independently -----
+
+statement ok
+CREATE VIEW multi_dn AS
+  SELECT 'A' AS sample, * FROM denovo_base
+  UNION ALL
+  SELECT 'B' AS sample, * FROM denovo_base;
+
+# Each sample produces the same row count (6 sequences per sample).
+query TI
+SELECT sample, COUNT(*) FROM detect_chimera_uchime_denovo('multi_dn', sample_id := 'sample')
+  GROUP BY sample ORDER BY sample
+----
+A	6
+B	6
+
+# Chimera calls are independent per sample: both samples should produce the
+# same set of Y/N flags since the input data is identical.
+query TTT
+SELECT sample, query_id, flag
+  FROM detect_chimera_uchime_denovo('multi_dn', sample_id := 'sample')
+  ORDER BY sample, query_id
+----
+A	seq1	N
+A	seq2	N
+A	seq3	N
+A	seq4	Y
+A	seq5	Y
+A	seq6	N
+B	seq1	N
+B	seq2	N
+B	seq3	N
+B	seq4	Y
+B	seq5	Y
+B	seq6	N
+
+# ----- Cycle 4: Integer-typed sample_id round-trips -----
+
+statement ok
+CREATE VIEW int_dn AS
+  SELECT 1 AS sample_num, * FROM denovo_base
+  UNION ALL
+  SELECT 2 AS sample_num, * FROM denovo_base;
+
+query II
+SELECT sample_num, COUNT(*)
+  FROM detect_chimera_uchime_denovo('int_dn', sample_id := 'sample_num')
+  GROUP BY sample_num ORDER BY sample_num
+----
+1	6
+2	6
+
+query T
+SELECT typeof(sample_num) FROM detect_chimera_uchime_denovo('int_dn', sample_id := 'sample_num') LIMIT 1
+----
+INTEGER
+
+# ----- Cycle 5: NULL sample values rejected at bind -----
+
+statement ok
+CREATE VIEW dn_null AS SELECT NULL::VARCHAR AS sid, * FROM denovo_base;
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('dn_null', sample_id := 'sid')
+----
+NULL values in sample_id column
+
+# ----- Cycle 6: Empty relation → no non-NULL values -----
+
+statement ok
+CREATE VIEW dn_empty AS SELECT 'A' AS sample, * FROM denovo_base WHERE 1=0;
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('dn_empty', sample_id := 'sample')
+----
+has no non-NULL values
+
+# ----- Cycle 7: Single-sample equivalence -----
+# Per-sample output for a one-sample view must match the global path's output for
+# the same rows (size-DESC ordering, same bootstrap, same chimera calls).
+
+statement ok
+CREATE VIEW dn_single AS SELECT 'only' AS sample, * FROM denovo_base;
+
+query TT
+SELECT query_id, flag
+  FROM detect_chimera_uchime_denovo('dn_single', sample_id := 'sample')
+  ORDER BY query_id
+----
+seq1	N
+seq2	N
+seq3	N
+seq4	Y
+seq5	Y
+seq6	N
+
+query TT
+SELECT query_id, flag
+  FROM detect_chimera_uchime_denovo('denovo_base')
+  ORDER BY query_id
+----
+seq1	N
+seq2	N
+seq3	N
+seq4	Y
+seq5	Y
+seq6	N
+
+# ----- Cycle 8: Parallelism — claim correctness under threads=4 (max_threads_hint=1 clamps actual parallelism to 1) -----
+
+statement ok
+CREATE VIEW four_dn_samples AS
+  SELECT 'A' AS sid, * FROM denovo_base UNION ALL
+  SELECT 'B' AS sid, * FROM denovo_base UNION ALL
+  SELECT 'C' AS sid, * FROM denovo_base UNION ALL
+  SELECT 'D' AS sid, * FROM denovo_base;
+
+statement ok
+PRAGMA threads=4;
+
+query TI
+SELECT sid, COUNT(*) FROM detect_chimera_uchime_denovo('four_dn_samples', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+A	6
+B	6
+C	6
+D	6

--- a/test/sql/uchime_ref_sample_id.test
+++ b/test/sql/uchime_ref_sample_id.test
@@ -1,0 +1,172 @@
+# name: test/sql/uchime_ref_sample_id.test
+# description: test detect_chimera_uchime sample_id named parameter
+# group: [sql]
+
+statement ok
+PRAGMA enable_verification;
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+statement ok
+CREATE TABLE uref_refs AS SELECT read_id, sequence1 FROM read_fastx('data/uchime/chimera_ref.fasta');
+
+statement ok
+CREATE TABLE uref_queries AS SELECT read_id, sequence1 FROM read_fastx('data/uchime/chimera_queries.fasta');
+
+# ----- Cycle 1: Error on invalid sample_id -----
+
+statement ok
+CREATE VIEW ur_v1 AS SELECT 'A' AS sample, * FROM uref_queries;
+
+statement error
+SELECT * FROM detect_chimera_uchime('ur_v1', db := 'uref_refs', sample_id := 'no_such_column')
+----
+sample_id column 'no_such_column' not found
+
+statement error
+SELECT * FROM detect_chimera_uchime('ur_v1', db := 'uref_refs', sample_id := '')
+----
+sample_id column name must not be empty
+
+# ----- Cycle 2: Output-column collision -----
+
+statement error
+SELECT * FROM detect_chimera_uchime('uref_queries', db := 'uref_refs', sample_id := 'query_id')
+----
+collides with an output column
+
+statement error
+SELECT * FROM detect_chimera_uchime('uref_queries', db := 'uref_refs', sample_id := 'flag')
+----
+collides with an output column
+
+# ----- Cycle 3: Per-sample isolation -----
+
+statement ok
+CREATE VIEW multi_uref AS
+  SELECT 'A' AS sample, * FROM uref_queries
+  UNION ALL
+  SELECT 'B' AS sample, * FROM uref_queries;
+
+query TI
+SELECT sample, COUNT(*)
+  FROM detect_chimera_uchime('multi_uref', db := 'uref_refs', sample_id := 'sample')
+  GROUP BY sample ORDER BY sample
+----
+A	8
+B	8
+
+query T
+SELECT typeof(sample)
+  FROM detect_chimera_uchime('multi_uref', db := 'uref_refs', sample_id := 'sample') LIMIT 1
+----
+VARCHAR
+
+# Both samples see the same flag distribution against the shared reference (identical
+# query content, same Y count per sample).
+query TI
+SELECT sample, COUNT(*) FILTER (WHERE flag = 'Y')
+  FROM detect_chimera_uchime('multi_uref', db := 'uref_refs', sample_id := 'sample')
+  GROUP BY sample ORDER BY sample
+----
+A	4
+B	4
+
+# ----- Cycle 4: Integer-typed sample_id round-trips -----
+
+statement ok
+CREATE VIEW int_uref AS
+  SELECT 1 AS sample_num, * FROM uref_queries
+  UNION ALL
+  SELECT 2 AS sample_num, * FROM uref_queries;
+
+query II
+SELECT sample_num, COUNT(*)
+  FROM detect_chimera_uchime('int_uref', db := 'uref_refs', sample_id := 'sample_num')
+  GROUP BY sample_num ORDER BY sample_num
+----
+1	8
+2	8
+
+query T
+SELECT typeof(sample_num)
+  FROM detect_chimera_uchime('int_uref', db := 'uref_refs', sample_id := 'sample_num') LIMIT 1
+----
+INTEGER
+
+# ----- Cycle 5: NULL sample values rejected at bind -----
+
+statement ok
+CREATE VIEW uref_null AS SELECT NULL::VARCHAR AS sid, * FROM uref_queries;
+
+statement error
+SELECT * FROM detect_chimera_uchime('uref_null', db := 'uref_refs', sample_id := 'sid')
+----
+NULL values in sample_id column
+
+# ----- Cycle 6: Empty relation → no non-NULL values -----
+
+statement ok
+CREATE VIEW uref_empty AS SELECT 'A' AS sample, * FROM uref_queries WHERE 1=0;
+
+statement error
+SELECT * FROM detect_chimera_uchime('uref_empty', db := 'uref_refs', sample_id := 'sample')
+----
+has no non-NULL values
+
+# ----- Cycle 7: Single-sample equivalence — query_id+flag set matches global mode -----
+
+statement ok
+CREATE VIEW uref_single AS SELECT 'only' AS sample, * FROM uref_queries;
+
+query TT
+SELECT query_id, flag
+  FROM detect_chimera_uchime('uref_single', db := 'uref_refs', sample_id := 'sample')
+  ORDER BY query_id
+----
+query_chimera1	Y
+query_chimera2	Y
+query_chimera3	Y
+query_clean1	N
+query_clean2	N
+query_divergent_chimera	Y
+query_noparent	N
+query_short	N
+
+query TT
+SELECT query_id, flag
+  FROM detect_chimera_uchime('uref_queries', db := 'uref_refs')
+  ORDER BY query_id
+----
+query_chimera1	Y
+query_chimera2	Y
+query_chimera3	Y
+query_clean1	N
+query_clean2	N
+query_divergent_chimera	Y
+query_noparent	N
+query_short	N
+
+# ----- Cycle 8: Parallelism — max_threads_hint=1 clamps actual parallelism to 1, but the atomic claim must still be correct -----
+
+statement ok
+CREATE VIEW four_uref_samples AS
+  SELECT 'A' AS sid, * FROM uref_queries UNION ALL
+  SELECT 'B' AS sid, * FROM uref_queries UNION ALL
+  SELECT 'C' AS sid, * FROM uref_queries UNION ALL
+  SELECT 'D' AS sid, * FROM uref_queries;
+
+statement ok
+PRAGMA threads=4;
+
+query TI
+SELECT sid, COUNT(*)
+  FROM detect_chimera_uchime('four_uref_samples', db := 'uref_refs', sample_id := 'sid')
+  GROUP BY sid ORDER BY sid
+----
+A	8
+B	8
+C	8
+D	8


### PR DESCRIPTION
Extracts the ~80-line per-sample coordination boilerplate previously duplicated in massql and woltka_ogu into a PerSampleCoordinator helper, then uses it to add a `sample_id` named parameter to deblur, align_mafft, detect_chimera_uchime_denovo, and detect_chimera_uchime. The helper handles bind-time sample discovery (distinct collection, NULL reject, output-column collision check) and exec-time atomic claim with per-thread Connection. massql and woltka_ogu are retrofitted onto the helper; both shrink by ~40 lines.

Thread-safety policy is per-function via max_threads_hint: deblur (0 / full parallelism, re-entrant), align_mafft (1, MAFFT process-wide mutex), both uchime variants (1, VsearchChimeraWrapper not thread-safe). uchime_ref keeps the reference load global (shared read-only) and streams per-sample queries via a CREATE OR REPLACE TEMP VIEW on a per-thread Connection.

LoadSingleEndSequences gains a Connection&+where_sql overload so align_mafft can filter by sample without opening a new connection per iteration. QuerySequenceStream gains a Connection& ctor so uchime_ref's per-sample TEMP VIEW is visible to the stream. OutputUchimeResults takes an optional start_col so sample-aware callers can prepend the sample column.

Sample-column emission uses ConstantVector::Reference (zero-copy, constant across the chunk) — catches the per-row SetValue anti-pattern early before more callers use the pattern.

docs/internals/per-sample-pattern.md documents the pattern end-to-end so future callers can adopt it without reverse-engineering the existing six. docs/table-functions.md entries updated with the new parameter.

Tests: 491 new SQL assertions across four new *_sample_id.test files. All existing tests (massql_sample_id, woltka, deblur, align_mafft, uchime_denovo, uchime_ref) pass unchanged. 6229 C++ assertions green. make format-check passes.