### PR TITLE
Add queryable miint_warnings() via DuckDB log sink

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,6 +762,7 @@ set(EXTENSION_SOURCES
     src/ena_resolver_cache.cpp
     src/ena_search_field_registry.cpp
     src/ena_attributes_filter.cpp
+    src/miint_log.cpp
     src/per_run_reader.cpp
     src/read_ena.cpp
     src/read_ena_attributes.cpp

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -37,6 +37,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`cluster_sequences_vsearch`](#cluster_sequences_vsearchinput_table-idthreshold-options) - Greedy sequence clustering
 - [`deblur`](#deblurinput_table-options) - Deblur amplicon sequence denoising
 - [`alignment_slice`](#alignment_slicetable_name-start-stop-include_deletionsfalse) - Slice alignments to a genomic region
+- [`miint_warnings`](#miint_warnings) - Query miint's operational warnings as a table
 
 ## `read_alignments(filename, [reference_lengths='table_name'], [include_filepath=false], [include_seq_qual=false])`
 Read SAM/BAM alignment files.
@@ -2486,3 +2487,31 @@ SELECT * FROM deblur('aligned_seqs', error_profile := [1, 0.04, 0.01, 0.005]);
 - Error if `indel_max` is negative
 - Error if `error_profile` contains negative values or is empty
 - Error if sequences have different aligned lengths or different unaligned lengths
+
+---
+
+## `miint_warnings()`
+
+Returns miint's operational warnings as a queryable table. Populated by user-facing warning sites — skipped accessions in `read_ena_sequences`, the SFF `max_sequences` caveat, the `threads` parameter being ignored in `align_bowtie2_sharded`, mid-stream download failures, etc. Every entry is also printed to stderr (today's behavior), so interactive users see no change; pipeline and `COPY TO` users now have a way to inspect warnings after the fact.
+
+**Returns:**
+| Column | Type | Description |
+|---|---|---|
+| `timestamp` | `TIMESTAMP WITH TIME ZONE` | When the warning was emitted |
+| `message` | `VARCHAR` | Human-readable warning text |
+
+**Example:**
+```sql
+-- Scan a study, then see what got skipped
+SELECT COUNT(*) FROM read_ena_sequences('PRJEB1234');
+SELECT timestamp, message FROM miint_warnings();
+```
+
+**Behavior:**
+- The log is process-scoped and in-memory by default; entries accumulate across queries within a single DuckDB session.
+- Warnings are captured regardless of the `enable_logging` / `logging_level` settings — miint writes directly to DuckDB's global log sink so `miint_warnings()` works without any setup.
+- Under the hood, entries have type `'MiintWarning'` and live alongside DuckDB's own logs in `duckdb_logs()`; the macro just filters on type.
+
+**Interactions with DuckDB logging settings:**
+- `SET logging_storage='stderr'` — entries go straight to stderr instead of the in-memory sink, so `miint_warnings()` stops returning rows in that mode (the stderr output is the workaround). Default storage is in-memory; leave it alone unless you have reason to change it.
+- `SET warnings_as_errors=true` — miint suppresses the log-storage write for that query so a skip-warning doesn't abort the retry or the partial-data path it was designed to allow. The stderr message still fires, so nothing is silently dropped, but `miint_warnings()` will not see the row for that call.

--- a/src/align_bowtie2_sharded.cpp
+++ b/src/align_bowtie2_sharded.cpp
@@ -1,5 +1,6 @@
 #include "align_bowtie2_sharded.hpp"
 #include "align_common.hpp"
+#include "miint_log.hpp"
 #include "shard_debug.hpp"
 #include "duckdb/common/file_system.hpp"
 
@@ -91,10 +92,10 @@ unique_ptr<FunctionData> AlignBowtie2ShardedTableFunction::Bind(ClientContext &c
 	if (threads_param != input.named_parameters.end() && !threads_param->second.IsNull()) {
 		int32_t threads_val = threads_param->second.GetValue<int32_t>();
 		if (threads_val != 1) {
-			Printer::Print("WARNING: Parameter 'threads' is ignored in sharded mode. "
-			               "In sharded mode, each bowtie2 process uses a single thread. "
-			               "Parallelism comes from running multiple processes per shard "
-			               "(max_threads_per_shard) across multiple shards.\n");
+			miint::EmitWarning(context, "WARNING: Parameter 'threads' is ignored in sharded mode. "
+			                            "In sharded mode, each bowtie2 process uses a single thread. "
+			                            "Parallelism comes from running multiple processes per shard "
+			                            "(max_threads_per_shard) across multiple shards.");
 		}
 	}
 	data->config.threads = 1;

--- a/src/include/miint_log.hpp
+++ b/src/include/miint_log.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/logging/log_type.hpp"
+#include "duckdb/logging/logging.hpp"
+
+#include <string>
+
+namespace duckdb {
+class ClientContext;
+class DatabaseInstance;
+} // namespace duckdb
+
+namespace miint {
+
+class MiintWarningLogType : public duckdb::LogType {
+public:
+	static constexpr const char *NAME = "MiintWarning";
+	static constexpr duckdb::LogLevel LEVEL = duckdb::LogLevel::LOG_WARNING;
+
+	MiintWarningLogType();
+};
+
+// Register the miint warning log type with the database's LogManager. Call once
+// from the extension loader; subsequent loads on the same instance are no-ops.
+void RegisterMiintLogType(duckdb::DatabaseInstance &db);
+
+// Emit a user-facing warning. Writes to BOTH:
+//   1. The global MutableLogger (queryable via duckdb_logs() / miint_warnings())
+//   2. Printer::Print (stderr, matches today's interactive visibility)
+//
+// The MutableLogger writes unconditionally, so miint_warnings() returns rows
+// regardless of the user's enable_logging / logging_storage settings (as long
+// as the default in-memory storage is kept).
+void EmitWarning(duckdb::ClientContext &ctx, const std::string &msg);
+
+template <typename... Args>
+void EmitWarning(duckdb::ClientContext &ctx, const char *fmt, Args &&...args) {
+	EmitWarning(ctx, duckdb::StringUtil::Format(fmt, std::forward<Args>(args)...));
+}
+
+} // namespace miint

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -7,6 +7,13 @@ namespace duckdb {
 
 // woltka_ogu is now a C++ table function — see src/woltka_ogu_function.cpp
 
+const std::string MIINT_WARNINGS = // NOLINT
+    "CREATE OR REPLACE MACRO miint_warnings() AS TABLE "
+    "SELECT timestamp, message "
+    "FROM duckdb_logs() "
+    "WHERE type = 'MiintWarning' "
+    "ORDER BY timestamp;";
+
 const std::string PARSE_GFF_ATTRIBUTES = // NOLINT
     "CREATE OR REPLACE MACRO parse_gff_attributes(kvp_string) AS ( "
     "  map_from_entries( "
@@ -718,6 +725,8 @@ public:
 				throw InternalException("Failed to register macro '%s': %s", name, result->GetError());
 			}
 		};
+
+		register_macro(MIINT_WARNINGS, "miint_warnings");
 
 		register_macro(PARSE_GFF_ATTRIBUTES, "parse_gff_attributes");
 		register_macro(READ_GFF, "read_gff");

--- a/src/include/per_run_reader.hpp
+++ b/src/include/per_run_reader.hpp
@@ -12,6 +12,10 @@
 #include <mutex>
 #include <string>
 
+namespace duckdb {
+class ClientContext;
+} // namespace duckdb
+
 namespace miint {
 
 // Per-run streaming reader for ENA FASTX / SFF / Aspera runs.
@@ -36,8 +40,13 @@ class PerRunReader {
 public:
 	// `max_sequences == 0` means unlimited. For paired-end runs, `max_sequences`
 	// counts pairs (one batch row per pair), not underlying FASTQ records.
+	// `log_context` is optional; when non-null, user-facing warnings (e.g. the
+	// SFF max_sequences caveat) route through miint_warnings() in addition to
+	// stderr. A null context falls back to stderr only, keeping the reader
+	// usable from non-DuckDB-linked C++ harnesses.
 	PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspera, bool trim, std::mutex &open_mutex,
-	             const AsperaConfig *aspera_config, uint64_t max_sequences = 0);
+	             const AsperaConfig *aspera_config, uint64_t max_sequences = 0,
+	             duckdb::ClientContext *log_context = nullptr);
 	~PerRunReader();
 
 	PerRunReader(const PerRunReader &) = delete;
@@ -87,6 +96,7 @@ private:
 	bool finished_ = false;
 	uint64_t max_sequences_ = 0; // 0 = unlimited
 	uint64_t sequences_emitted_ = 0;
+	duckdb::ClientContext *log_context_ = nullptr;
 
 	void OpenHTTP();
 	void OpenSFF();

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -30,6 +30,7 @@
 #include <read_ena_attributes.hpp>
 #include <read_ena_searchable_fields.hpp>
 #include <read_ena_sequences.hpp>
+#include <miint_log.hpp>
 #include <miint_macros.hpp>
 #include "duckdb/main/extension_helper.hpp"
 #include "duckdb/main/database.hpp"
@@ -169,6 +170,8 @@ static void MiintVersionsExecute(ClientContext &context, TableFunctionInput &dat
 static void LoadInternal(ExtensionLoader &loader) {
 	// TODO: use [[nodiscard]] throughout in headers
 	// TODO: //! comment on headers
+
+	miint::RegisterMiintLogType(loader.GetDatabaseInstance());
 
 	ScalarFunction version_func("miint_version", {}, LogicalType::VARCHAR, MiintVersionFunction);
 	loader.RegisterFunction(version_func);

--- a/src/miint_log.cpp
+++ b/src/miint_log.cpp
@@ -1,0 +1,63 @@
+#include "miint_log.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/printer.hpp"
+#include "duckdb/logging/log_manager.hpp"
+#include "duckdb/logging/logger.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace miint {
+
+MiintWarningLogType::MiintWarningLogType() : duckdb::LogType(NAME, LEVEL) {
+}
+
+void RegisterMiintLogType(duckdb::DatabaseInstance &db) {
+	auto &log_manager = db.GetLogManager();
+	// LookupLogType + RegisterLogType is check-then-act. DuckDB's extension
+	// loader serializes Load() calls per DatabaseInstance, so concurrent
+	// registration is not a concern in practice; this guard just makes a
+	// second LOAD of the extension on the same instance a no-op.
+	if (log_manager.LookupLogType(MiintWarningLogType::NAME)) {
+		return;
+	}
+	log_manager.RegisterLogType(duckdb::make_uniq<MiintWarningLogType>());
+}
+
+void EmitWarning(duckdb::ClientContext &ctx, const std::string &msg) {
+	// Why GlobalLogger instead of Logger::Get(ctx)?
+	//   Logger::Get(ctx) returns ClientContext::logger, which is a NopLogger
+	//   when enable_logging=false (DuckDB's default). Routing through it would
+	//   make miint_warnings() silently empty for any user who hasn't run
+	//   `SET enable_logging=true`. The plan requires that miint_warnings()
+	//   works out of the box, so we write through the database-scoped
+	//   GlobalLogger instead — LogManager::Initialize() always constructs it
+	//   as a MutableLogger (mutable_settings=true in CreateLogger), whose
+	//   WriteLogInternal skips the ShouldLog gate and writes to storage
+	//   unconditionally.
+	//
+	// This relies on a DuckDB internal detail (GlobalLogger is always a
+	// MutableLogger). If a future DuckDB refactor returns a NopLogger here,
+	// miint_warnings() would silently return zero rows; the dedicated
+	// emit-assertion SQL test exists to catch that regression.
+	//
+	// WarningsAsErrors interaction: LogManager::WriteLogEntry throws
+	// InvalidInputException when the user has set warnings_as_errors=true.
+	// That would convert every skip-warning into a hard query error that
+	// aborts retries and surfaces partial-data skips as fatal — a behavior
+	// change from the pre-logging Printer::Print path. We catch it here and
+	// still emit to stderr so the user sees the warning in both modes; they
+	// keep getting the "continue after skipping" behavior the calling code
+	// was designed around.
+	try {
+		duckdb::LogManager::Get(ctx).GlobalLogger().WriteLog(MiintWarningLogType::NAME, MiintWarningLogType::LEVEL,
+		                                                     msg);
+	} catch (...) {
+		// Fall through to stderr only. miint_warnings() will not see this row
+		// under warnings_as_errors=true; that's acceptable because the
+		// interactive stderr channel still delivers the message.
+	}
+	duckdb::Printer::Print(msg);
+}
+
+} // namespace miint

--- a/src/miint_log.cpp
+++ b/src/miint_log.cpp
@@ -50,8 +50,14 @@ void EmitWarning(duckdb::ClientContext &ctx, const std::string &msg) {
 	// keep getting the "continue after skipping" behavior the calling code
 	// was designed around.
 	try {
-		duckdb::LogManager::Get(ctx).GlobalLogger().WriteLog(MiintWarningLogType::NAME, MiintWarningLogType::LEVEL,
-		                                                     msg);
+		auto &logger = duckdb::LogManager::Get(ctx).GlobalLogger();
+		logger.WriteLog(MiintWarningLogType::NAME, MiintWarningLogType::LEVEL, msg);
+		// InMemoryLogStorage buffers writes up to STANDARD_VECTOR_SIZE entries
+		// before flushing to the ColumnDataCollection that duckdb_logs() scans.
+		// Our warnings are rare, so a single unflushed entry would sit invisible
+		// until the next 2047 warnings arrived. Flush on every emit so
+		// miint_warnings() sees the row immediately.
+		logger.Flush();
 	} catch (...) {
 		// Fall through to stderr only. miint_warnings() will not see this row
 		// under warnings_as_errors=true; that's acceptable because the

--- a/src/per_run_reader.cpp
+++ b/src/per_run_reader.cpp
@@ -1,5 +1,6 @@
 #include "per_run_reader.hpp"
 #include "duckdb_seq_stream.hpp"
+#include "miint_log.hpp"
 #include "table_function_common.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_open_flags.hpp"
@@ -14,9 +15,10 @@
 namespace miint {
 
 PerRunReader::PerRunReader(duckdb::FileSystem &fs, ENARunInfo run, bool use_aspera, bool trim, std::mutex &open_mutex,
-                           const AsperaConfig *aspera_config, uint64_t max_sequences)
+                           const AsperaConfig *aspera_config, uint64_t max_sequences,
+                           duckdb::ClientContext *log_context)
     : fs_(fs), run_(std::move(run)), use_aspera_(use_aspera), trim_(trim), open_mutex_(open_mutex),
-      aspera_config_(aspera_config), max_sequences_(max_sequences) {
+      aspera_config_(aspera_config), max_sequences_(max_sequences), log_context_(log_context) {
 }
 
 PerRunReader::~PerRunReader() {
@@ -108,7 +110,11 @@ void PerRunReader::Finish() {
 	// When both processes errored we surface R1 via the thrown exception;
 	// log R2's message first so the user doesn't lose half the story.
 	if (!err_r1.empty() && !err_r2.empty()) {
-		duckdb::Printer::Print(err_r2);
+		if (log_context_) {
+			miint::EmitWarning(*log_context_, err_r2);
+		} else {
+			duckdb::Printer::Print(err_r2);
+		}
 	}
 	if (!err_r1.empty()) {
 		throw duckdb::IOException(err_r1);
@@ -183,10 +189,16 @@ void PerRunReader::OpenSFF() {
 	// by the time ReadBatch() starts enforcing the cap. Warn loudly once per
 	// SFF run so users don't silently assume the cap saved them a download.
 	if (max_sequences_ > 0) {
-		duckdb::Printer::PrintF("read_ena_sequences: WARNING: max_sequences=%llu on SFF run '%s' — SFF requires "
-		                        "downloading the full file before any record can be parsed; the row cap applies "
-		                        "but bandwidth savings do not",
-		                        static_cast<unsigned long long>(max_sequences_), run_.run_accession);
+		auto msg =
+		    duckdb::StringUtil::Format("read_ena_sequences: WARNING: max_sequences=%llu on SFF run '%s' — SFF requires "
+		                               "downloading the full file before any record can be parsed; the row cap applies "
+		                               "but bandwidth savings do not",
+		                               static_cast<unsigned long long>(max_sequences_), run_.run_accession);
+		if (log_context_) {
+			miint::EmitWarning(*log_context_, msg);
+		} else {
+			duckdb::Printer::Print(msg);
+		}
 	}
 
 	auto temp_dir = GetTempDir();

--- a/src/read_ena_sequences.cpp
+++ b/src/read_ena_sequences.cpp
@@ -1,7 +1,7 @@
 #include "read_ena_sequences.hpp"
 #include "SequenceRecord.hpp"
 #include "ena_resolver_cache.hpp"
-#include "duckdb/common/printer.hpp"
+#include "miint_log.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include <cerrno>
 #include <fstream>
@@ -310,7 +310,7 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 #endif
 		return std::make_unique<miint::PerRunReader>(global_state.fs, global_state.runs[idx], global_state.use_aspera,
 		                                             global_state.trim, global_state.open_mutex, cfg,
-		                                             bind_data.max_sequences);
+		                                             bind_data.max_sequences, &context);
 	};
 
 	miint::SequenceRecordBatch batch;
@@ -334,15 +334,23 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 			if (all_claimed) {
 				// Print skipped-runs warning exactly once across all threads
 				if (!global_state.skipped_warned.exchange(true, std::memory_order_acq_rel)) {
-					lock_guard<mutex> skip_guard(global_state.skipped_lock);
-					if (!global_state.skipped_runs.empty()) {
-						std::string msg =
-						    "read_ena_sequences: WARNING: " + std::to_string(global_state.skipped_runs.size()) +
-						    " run(s) skipped due to download errors:";
-						for (const auto &acc : global_state.skipped_runs) {
-							msg += " " + acc;
+					// Build the message under skipped_lock, then drop the lock
+					// before EmitWarning acquires LogManager::lock. Avoids
+					// establishing a skipped_lock → LogManager::lock ordering
+					// that future code could deadlock against.
+					std::string msg;
+					{
+						lock_guard<mutex> skip_guard(global_state.skipped_lock);
+						if (!global_state.skipped_runs.empty()) {
+							msg = "read_ena_sequences: WARNING: " + std::to_string(global_state.skipped_runs.size()) +
+							      " run(s) skipped due to download errors:";
+							for (const auto &acc : global_state.skipped_runs) {
+								msg += " " + acc;
+							}
 						}
-						Printer::Print(msg);
+					}
+					if (!msg.empty()) {
+						miint::EmitWarning(context, msg);
 					}
 				}
 				output.SetCardinality(0);
@@ -358,16 +366,16 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 				global_state.readers[local_state.current_run_idx]->Open();
 			} catch (const std::exception &e) {
 				auto &run = global_state.runs[local_state.current_run_idx];
-				Printer::PrintF("read_ena_sequences: warning: run '%s' failed to open (%s), retrying...",
-				                run.run_accession, e.what());
+				miint::EmitWarning(context, "read_ena_sequences: warning: run '%s' failed to open (%s), retrying...",
+				                   run.run_accession, e.what());
 				global_state.readers[local_state.current_run_idx].reset();
 				global_state.run_sequence_counters[local_state.current_run_idx] = 1;
 				try {
 					global_state.readers[local_state.current_run_idx] = make_reader(local_state.current_run_idx);
 					global_state.readers[local_state.current_run_idx]->Open();
 				} catch (const std::exception &e2) {
-					Printer::PrintF("read_ena_sequences: warning: run '%s' failed on retry (%s), skipping",
-					                run.run_accession, e2.what());
+					miint::EmitWarning(context, "read_ena_sequences: warning: run '%s' failed on retry (%s), skipping",
+					                   run.run_accession, e2.what());
 					global_state.readers[local_state.current_run_idx].reset();
 					{
 						lock_guard<mutex> skip_guard(global_state.skipped_lock);
@@ -403,9 +411,10 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 			uint64_t emitted = global_state.run_sequence_counters[current_run_idx] > 0
 			                       ? global_state.run_sequence_counters[current_run_idx] - 1
 			                       : 0;
-			Printer::PrintF("read_ena_sequences: WARNING: run '%s' failed mid-stream after emitting %llu read(s) "
-			                "(%s); skipping remainder — downstream sees partial data for this run",
-			                run.run_accession, static_cast<unsigned long long>(emitted), e.what());
+			miint::EmitWarning(context,
+			                   "read_ena_sequences: WARNING: run '%s' failed mid-stream after emitting %llu read(s) "
+			                   "(%s); skipping remainder — downstream sees partial data for this run",
+			                   run.run_accession, static_cast<unsigned long long>(emitted), e.what());
 			global_state.readers[current_run_idx].reset();
 			{
 				lock_guard<mutex> skip_guard(global_state.skipped_lock);
@@ -530,11 +539,12 @@ void ReadENASequencesTableFunction::FillOutputFromBatch(DataChunk &output, const
 // advances between callbacks — the dispatcher loops until state progresses to
 // a data-emitting call or a NEED_MORE_INPUT / terminal return.
 //
-// CRITICAL user-facing invariant: every skip path prints a loud Printer
-// warning via record_skip(). Silent skips in lateral mode are dangerous — the
-// outer query just sees zero rows for the failed accession, indistinguishable
-// from "no matches". The user depends on these warnings to notice lost
-// samples. Both per-attempt retry messages AND final skip notices are emitted.
+// CRITICAL user-facing invariant: every skip path emits a loud warning via
+// record_skip() (miint::EmitWarning → stderr + miint_warnings()). Silent skips
+// in lateral mode are dangerous — the outer query just sees zero rows for the
+// failed accession, indistinguishable from "no matches". The user depends on
+// these warnings to notice lost samples. Both per-attempt retry messages AND
+// final skip notices are emitted.
 //
 // `lateral_sequence_counter` is reset to 1 when a new outer row is consumed
 // (Phase 1) AND on open-retry / mid-stream retry (matching the literal path's
@@ -550,17 +560,19 @@ OperatorResultType ReadENASequencesTableFunction::ExecuteInOut(ExecutionContext 
 	// Record a skipped accession and emit a loud warning. Both pieces are
 	// user-critical: the user must know which samples they did not get data
 	// for, so they can decide whether to retry manually or investigate.
-	auto record_skip = [&bind_data](const std::string &outer_accession, const std::string &run_accession,
-	                                const std::string &reason) {
+	auto record_skip = [&bind_data, &context](const std::string &outer_accession, const std::string &run_accession,
+	                                          const std::string &reason) {
 		{
 			std::lock_guard<std::mutex> guard(bind_data.lateral_skipped_lock);
 			bind_data.lateral_skipped_accessions.push_back(run_accession.empty() ? outer_accession : run_accession);
 		}
 		if (run_accession.empty()) {
-			Printer::PrintF("read_ena_sequences: WARNING: skipped outer accession '%s' — %s", outer_accession, reason);
+			miint::EmitWarning(context.client, "read_ena_sequences: WARNING: skipped outer accession '%s' — %s",
+			                   outer_accession, reason);
 		} else {
-			Printer::PrintF("read_ena_sequences: WARNING: skipped run '%s' (from outer accession '%s') — %s",
-			                run_accession, outer_accession, reason);
+			miint::EmitWarning(context.client,
+			                   "read_ena_sequences: WARNING: skipped run '%s' (from outer accession '%s') — %s",
+			                   run_accession, outer_accession, reason);
 		}
 	};
 
@@ -570,7 +582,7 @@ OperatorResultType ReadENASequencesTableFunction::ExecuteInOut(ExecutionContext 
 	auto make_reader_for = [&](const miint::ENARunInfo &run) {
 		return std::make_unique<miint::PerRunReader>(
 		    global.fs, run, /*use_aspera=*/false, bind_data.trim, global.open_mutex,
-		    static_cast<const miint::AsperaConfig *>(nullptr), bind_data.max_sequences);
+		    static_cast<const miint::AsperaConfig *>(nullptr), bind_data.max_sequences, &context.client);
 	};
 
 	// Phase 1: need a fresh outer row → pull and resolve.
@@ -633,8 +645,8 @@ OperatorResultType ReadENASequencesTableFunction::ExecuteInOut(ExecutionContext 
 		try {
 			local.current_reader->Open();
 		} catch (const std::exception &e) {
-			Printer::PrintF("read_ena_sequences: warning: run '%s' failed to open (%s), retrying...", run.run_accession,
-			                e.what());
+			miint::EmitWarning(context.client, "read_ena_sequences: warning: run '%s' failed to open (%s), retrying...",
+			                   run.run_accession, e.what());
 			local.current_reader.reset();
 			local.lateral_sequence_counter = 1; // No rows emitted yet; keep counter consistent.
 			local.current_reader = make_reader_for(run);

--- a/test/sql/miint_warnings.test
+++ b/test/sql/miint_warnings.test
@@ -1,0 +1,20 @@
+# name: test/sql/miint_warnings.test
+# description: Test the miint_warnings() SQL macro surfaces miint warning log entries
+# group: [sql]
+
+require miint
+
+# ---- Macro is registered and has the documented schema ----
+
+query IIIIII
+DESCRIBE SELECT * FROM miint_warnings();
+----
+timestamp	TIMESTAMP WITH TIME ZONE	YES	NULL	NULL	NULL
+message	VARCHAR	YES	NULL	NULL	NULL
+
+# ---- Baseline: no miint warnings emitted in this fresh session ----
+
+query I
+SELECT COUNT(*) FROM miint_warnings();
+----
+0

--- a/test/sql/miint_warnings_bowtie2.test
+++ b/test/sql/miint_warnings_bowtie2.test
@@ -1,0 +1,34 @@
+# name: test/sql/miint_warnings_bowtie2.test
+# description: Assert that align_bowtie2_sharded's threads!=1 warning surfaces via miint_warnings()
+# group: [sql]
+
+require miint
+
+require-env BOWTIE2_AVAILABLE
+
+# The threads-ignored warning fires in Bind() before Execute, so EXPLAIN is
+# enough to trigger EmitWarning without running bowtie2 on the test shards.
+
+statement ok
+CREATE TABLE queries AS SELECT * FROM (VALUES
+    ('query1', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE read_to_shard AS SELECT * FROM (VALUES
+    ('query1', 'shard_a')
+) AS t(read_id, shard_name);
+
+statement ok
+EXPLAIN SELECT * FROM align_bowtie2_sharded('queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard',
+    threads := 2);
+
+# Assert the warning landed in miint_warnings() — the round-trip that
+# miint_warnings.test's baseline can't prove on its own.
+query I
+SELECT COUNT(*) >= 1 FROM miint_warnings()
+WHERE message LIKE '%Parameter ''threads'' is ignored in sharded mode%';
+----
+true

--- a/test/sql/miint_warnings_ena.test
+++ b/test/sql/miint_warnings_ena.test
@@ -1,0 +1,22 @@
+# name: test/sql/miint_warnings_ena.test
+# description: Assert that a skipped-accession warning from read_ena_sequences surfaces via miint_warnings()
+# group: [sql]
+
+require httpfs
+
+require miint
+
+# Requires the ENA Portal API; run_tests.sh probes and exports this.
+require-env ENA_AVAILABLE
+
+# A non-existent accession → record_skip() fires EmitWarning with the accession
+# substring in the message. miint_warnings() should then see that row.
+statement ok
+SELECT COUNT(*) FROM (VALUES ('NOT_A_REAL_ACCESSION_XYZ123')) AS t(acc),
+                LATERAL (SELECT 1 FROM read_ena_sequences(t.acc)) lt;
+
+query I
+SELECT COUNT(*) >= 1 FROM miint_warnings()
+WHERE message LIKE '%NOT_A_REAL_ACCESSION_XYZ123%';
+----
+true


### PR DESCRIPTION
Converts the 10 user-facing Printer::Print* warning sites in read_ena_sequences, per_run_reader, and align_bowtie2_sharded to miint::EmitWarning, which writes to DuckDB's global MutableLogger (queryable via the new miint_warnings() SQL macro) while preserving the existing stderr output.

The global MutableLogger is used instead of ClientContext's logger so miint_warnings() works without the user first setting enable_logging=true. WriteLog is wrapped in try/catch so a user-set warnings_as_errors=true does not turn skip-warnings into query failures that abort retries / partial-data paths.