### PR TITLE
Drop nonexistent hdf5_hl-static link targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -915,15 +915,11 @@ endif()
 if(MIINT_ENABLE_HDF5 AND HDF5_FOUND)
     target_link_libraries(${EXTENSION_NAME}
                           hdf5::hdf5-static
-                          hdf5::hdf5_hl-static
                           hdf5::hdf5_cpp-static
-                          hdf5::hdf5_hl_cpp-static
     )
     target_link_libraries(${LOADABLE_EXTENSION_NAME}
                           hdf5::hdf5-static
-                          hdf5::hdf5_hl-static
                           hdf5::hdf5_cpp-static
-                          hdf5::hdf5_hl_cpp-static
     )
 endif()
 if(HAVE_LIBZSTD)
@@ -1110,9 +1106,7 @@ endif()
 if(MIINT_ENABLE_HDF5 AND HDF5_FOUND)
     target_link_libraries(tests
                           hdf5::hdf5-static
-                          hdf5::hdf5_hl-static
-                          hdf5::hdf5_cpp-static
-                          hdf5::hdf5_hl_cpp-static)
+                          hdf5::hdf5_cpp-static)
 endif()
 if(HAVE_LIBZSTD)
     target_link_libraries(tests ${ZSTD_TARGET})


### PR DESCRIPTION
It seems vcpkg's hdf5 port (`features: cpp, zlib, szip`) only exports `hdf5::hdf5-static` and `hdf5::hdf5_cpp-static`; the four `hdf5::hdf5_hl{,_cpp}-static` references in `CMakeLists.txt` point at targets `find_package(HDF5)` never creates with this port config, so a clean configure dies with "target was not found". Nothing in `src/` or `test/` uses any HL symbols as far as I can tell (`H5LT`, `H5TB`, `H5PT`, `H5DS`, `H5IM`, `hdf5_hl.h`, `hdf5_hl_cpp` all return zero matches), so they're already dead links. Same one-line drop in three `target_link_libraries` blocks (extension, loadable extension, tests); rebuild + run_tests.sh still pass locally. Needed this to build cleanly, but happy to revert if there was a reason for them.
