### PR TITLE
Use CIGAR for alignment functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ CREATE VIEW high_quality AS
     SELECT * FROM all_alignments
     WHERE alignment_is_primary(flags)
       AND mapq >= 30
-      AND alignment_query_coverage(cigar) > 0.9;
+      AND cigar_query_coverage(cigar) > 0.9;
 
 -- Compute OGU counts using Woltka algorithm
 CREATE VIEW ogu_counts AS

--- a/docs/scalar-functions.md
+++ b/docs/scalar-functions.md
@@ -6,7 +6,7 @@ Scalar functions for alignment analysis and sequence processing.
 
 - [SAM Flag Functions](#sam-flag-functions) - Test individual SAM flag bits
 - [`alignment_seq_identity`](#alignment_seq_identitycigar-nm-md-type) - Sequence identity calculation
-- [`alignment_query_length`](#alignment_query_lengthcigar-include_hard_clipstrue) - Query length from CIGAR
+- [`cigar_query_length`](#cigar_query_lengthcigar-include_hard_clipstrue) - Query length from CIGAR
 - [`alignment_query_coverage`](#alignment_query_coveragecigar-typealigned) - Query coverage from CIGAR
 - [`mask_dust`](#mask_dustsequence-hardmaskfalse) - DUST low-complexity masking
 - [`merge_pairs_vsearch`](#merge_pairsfwd_seq-fwd_qual-rev_seq-rev_qual-options) - Paired-end read merging
@@ -108,7 +108,7 @@ FROM alignment_slice('my_alignments', 1000, 2000);
 
 **Reference:** [On the definition of sequence identity](https://lh3.github.io/2018/11/25/on-the-definition-of-sequence-identity) by Heng Li
 
-## `alignment_query_length(cigar, [include_hard_clips=true])`
+## `cigar_query_length(cigar, [include_hard_clips=true])`
 
 Calculate the total query length from a CIGAR string. This is useful for understanding read lengths and query coverage.
 
@@ -128,22 +128,22 @@ Calculate the total query length from a CIGAR string. This is useful for underst
 **Examples:**
 ```sql
 -- Get query length including hard clips (default)
-SELECT read_id, alignment_query_length(cigar) AS query_len
+SELECT read_id, cigar_query_length(cigar) AS query_len
 FROM read_alignments('alignments.sam');
 
 -- Get query length excluding hard clips (matches bam_cigar2qlen)
-SELECT read_id, alignment_query_length(cigar, false) AS query_len
+SELECT read_id, cigar_query_length(cigar, false) AS query_len
 FROM read_alignments('alignments.sam');
 
 -- Compare lengths with and without hard clips
 SELECT read_id, cigar,
-  alignment_query_length(cigar, true) AS len_with_hard,
-  alignment_query_length(cigar, false) AS len_without_hard
+  cigar_query_length(cigar, true) AS len_with_hard,
+  cigar_query_length(cigar, false) AS len_without_hard
 FROM read_alignments('alignments.sam')
 WHERE cigar LIKE '%H%';
 
 -- Calculate average query length per reference
-SELECT reference, AVG(alignment_query_length(cigar)) AS avg_query_len
+SELECT reference, AVG(cigar_query_length(cigar)) AS avg_query_len
 FROM read_alignments('alignments.bam')
 WHERE NOT alignment_is_unmapped(flags)
 GROUP BY reference;

--- a/docs/scalar-functions.md
+++ b/docs/scalar-functions.md
@@ -5,7 +5,8 @@ Scalar functions for alignment analysis and sequence processing.
 ## Table of Contents
 
 - [SAM Flag Functions](#sam-flag-functions) - Test individual SAM flag bits
-- [`alignment_seq_identity`](#alignment_seq_identitycigar-nm-md-type) - Sequence identity calculation
+- [`alignment_seq_identity`](#alignment_seq_identitycigar-nm-md-type) - Sequence identity calculation (multi-mode, requires NM/MD for legacy CIGAR)
+- [`cigar_sequence_identity`](#cigar_sequence_identitycigar) - Sequence identity from extended CIGAR alone
 - [`cigar_query_length`](#cigar_query_lengthcigar-include_hard_clipstrue) - Query length from CIGAR
 - [`cigar_query_coverage`](#cigar_query_coveragecigar-typealigned) - Query coverage from CIGAR
 - [`mask_dust`](#mask_dustsequence-hardmaskfalse) - DUST low-complexity masking
@@ -107,6 +108,39 @@ FROM alignment_slice('my_alignments', 1000, 2000);
 ```
 
 **Reference:** [On the definition of sequence identity](https://lh3.github.io/2018/11/25/on-the-definition-of-sequence-identity) by Heng Li
+
+## `cigar_sequence_identity(cigar)`
+
+One-arg convenience wrapper over `alignment_seq_identity(cigar, NULL, NULL, 'cigar')`. Use this when your CIGAR uses extended `=`/`X` ops and you don't need NM/MD-based identity flavors.
+
+**Parameters:**
+- `cigar` (VARCHAR): CIGAR string with extended ops (`=` for match, `X` for mismatch). Aligners must be invoked with `--xeq` (bowtie2) or `-eqx` (minimap2) for this to work; legacy `M`-only CIGAR cannot be used.
+
+**Formula:** `match_ops / alignment_columns` where `match_ops` is the count of `=` operations and `alignment_columns` is `M + I + D` (with `=`/`X` counting as `M`).
+
+**Returns:** DOUBLE in [0.0, 1.0], or NULL when identity can't be determined from CIGAR alone:
+- CIGAR is NULL, empty, or `*` (unmapped)
+- CIGAR uses only `M` (legacy — can't distinguish matches from mismatches; use `alignment_seq_identity` with NM or MD instead)
+- CIGAR mixes `M` with `=`/`X` (inconsistent encoding)
+- CIGAR has no `=`/`X` ops at all (e.g. pure `I`, `D`, `S`, `H`, `N`, `P`)
+
+**Example:**
+```sql
+-- Modern CIGAR (=/X), no NM/MD needed
+SELECT read_id, cigar_sequence_identity(cigar) AS identity
+FROM read_alignments('alignments.sam');
+
+-- Filter high-identity alignments
+SELECT COUNT(*)
+FROM read_alignments('alignments.bam')
+WHERE cigar_sequence_identity(cigar) > 0.95;
+
+-- Same as alignment_seq_identity(cigar, NULL, NULL, 'cigar') but shorter:
+SELECT read_id, cigar_sequence_identity(cigar) AS identity
+FROM alignment_slice('my_alignments', 1000, 2000);
+```
+
+**See also:** `alignment_seq_identity` for legacy `M`-only CIGAR or BLAST/gap-compressed/gap-excluded identity flavors.
 
 ## `cigar_query_length(cigar, [include_hard_clips=true])`
 

--- a/docs/scalar-functions.md
+++ b/docs/scalar-functions.md
@@ -7,7 +7,7 @@ Scalar functions for alignment analysis and sequence processing.
 - [SAM Flag Functions](#sam-flag-functions) - Test individual SAM flag bits
 - [`alignment_seq_identity`](#alignment_seq_identitycigar-nm-md-type) - Sequence identity calculation
 - [`cigar_query_length`](#cigar_query_lengthcigar-include_hard_clipstrue) - Query length from CIGAR
-- [`alignment_query_coverage`](#alignment_query_coveragecigar-typealigned) - Query coverage from CIGAR
+- [`cigar_query_coverage`](#cigar_query_coveragecigar-typealigned) - Query coverage from CIGAR
 - [`mask_dust`](#mask_dustsequence-hardmaskfalse) - DUST low-complexity masking
 - [`merge_pairs_vsearch`](#merge_pairsfwd_seq-fwd_qual-rev_seq-rev_qual-options) - Paired-end read merging
 
@@ -151,7 +151,7 @@ GROUP BY reference;
 
 **Note:** When `include_hard_clips=false`, this function's output matches HTSlib's `bam_cigar2qlen` behavior, which counts M, I, S, =, and X operations.
 
-## `alignment_query_coverage(cigar, [type='aligned'])`
+## `cigar_query_coverage(cigar, [type='aligned'])`
 
 Calculate the proportion of query bases covered by the reference alignment. This helps assess how much of a read actually aligns versus being clipped.
 
@@ -181,35 +181,35 @@ Calculate the proportion of query bases covered by the reference alignment. This
 **Examples:**
 ```sql
 -- Get aligned coverage (default)
-SELECT read_id, alignment_query_coverage(cigar) AS aligned_cov
+SELECT read_id, cigar_query_coverage(cigar) AS aligned_cov
 FROM read_alignments('alignments.sam');
 
 -- Get mapped coverage (includes insertions)
-SELECT read_id, alignment_query_coverage(cigar, 'mapped') AS mapped_cov
+SELECT read_id, cigar_query_coverage(cigar, 'mapped') AS mapped_cov
 FROM read_alignments('alignments.sam');
 
 -- Compare aligned vs mapped coverage
 SELECT read_id, cigar,
-  alignment_query_coverage(cigar, 'aligned') AS aligned_cov,
-  alignment_query_coverage(cigar, 'mapped') AS mapped_cov
+  cigar_query_coverage(cigar, 'aligned') AS aligned_cov,
+  cigar_query_coverage(cigar, 'mapped') AS mapped_cov
 FROM read_alignments('alignments.sam')
 WHERE cigar LIKE '%I%';  -- Reads with insertions show the difference
 
 -- Filter reads with high query coverage
 SELECT COUNT(*)
 FROM read_alignments('alignments.bam')
-WHERE alignment_query_coverage(cigar, 'aligned') > 0.9;
+WHERE cigar_query_coverage(cigar, 'aligned') > 0.9;
 
 -- Find heavily clipped reads
-SELECT read_id, cigar, alignment_query_coverage(cigar) AS coverage
+SELECT read_id, cigar, cigar_query_coverage(cigar) AS coverage
 FROM read_alignments('alignments.sam')
-WHERE alignment_query_coverage(cigar) < 0.5
+WHERE cigar_query_coverage(cigar) < 0.5
 ORDER BY coverage;
 
 -- Calculate average coverage per reference
 SELECT reference,
-  AVG(alignment_query_coverage(cigar, 'aligned')) AS avg_aligned_cov,
-  AVG(alignment_query_coverage(cigar, 'mapped')) AS avg_mapped_cov
+  AVG(cigar_query_coverage(cigar, 'aligned')) AS avg_aligned_cov,
+  AVG(cigar_query_coverage(cigar, 'mapped')) AS avg_mapped_cov
 FROM read_alignments('alignments.bam')
 WHERE NOT alignment_is_unmapped(flags)
 GROUP BY reference;

--- a/onboarding-tutorials/advanced.md
+++ b/onboarding-tutorials/advanced.md
@@ -118,7 +118,7 @@ for sample in "${OUTDIR}"/sample_a.parquet "${OUTDIR}"/sample_b.parquet "${OUTDI
     CREATE VIEW filtered AS
         SELECT * FROM alns
         WHERE alignment_is_primary(flags)
-          AND alignment_query_coverage(cigar) >= 0.99
+          AND cigar_query_coverage(cigar) >= 0.99
           AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') >= 0.97;
     SELECT '${name}' AS sample, * FROM woltka_ogu('filtered', 'read_id');
     "
@@ -208,7 +208,7 @@ and
 the gene annotations to see which operons our reads hit:
 
 We filter to primary alignments with high
-[query coverage](../docs/scalar-functions.md#alignment_query_coveragecigar-typealigned)
+[query coverage](../docs/scalar-functions.md#cigar_query_coveragecigar-typealigned)
 (&ge; 99% of the read aligned) to exclude partial soft-clipped matches that
 inflate counts &mdash; see the
 [intermediate tutorial](intermediate.md#step-5-the-query-coverage-lesson) for
@@ -219,7 +219,7 @@ WITH good_alns AS (
     SELECT reference, position, stop_position
     FROM alignments
     WHERE alignment_is_primary(flags)
-      AND alignment_query_coverage(cigar) >= 0.99
+      AND cigar_query_coverage(cigar) >= 0.99
 ),
 compressed AS (
     SELECT reference,
@@ -339,7 +339,7 @@ WITH good_alns AS (
     SELECT reference, position, stop_position
     FROM alignments
     WHERE alignment_is_primary(flags)
-      AND alignment_query_coverage(cigar) >= 0.99
+      AND cigar_query_coverage(cigar) >= 0.99
 ),
 compressed AS (
     SELECT reference,
@@ -537,7 +537,7 @@ Every scalar function in miint follows the same pattern:
 3. **Register it** in `LoadInternal()` in
    `src/miint_extension.cpp`.
 
-For example, `alignment_query_coverage` is defined in
+For example, `cigar_query_coverage` is defined in
 `src/alignment_functions.cpp` and registered via a static `Register()` method.
 
 ### Getting started

--- a/onboarding-tutorials/intermediate.md
+++ b/onboarding-tutorials/intermediate.md
@@ -140,7 +140,7 @@ provides flag-checking functions for all standard
 
 Even among primary alignments, not all are trustworthy. Two key metrics:
 
-- [`alignment_query_coverage(cigar)`](../docs/scalar-functions.md#alignment_query_coveragecigar-typealigned)
+- [`cigar_query_coverage(cigar)`](../docs/scalar-functions.md#cigar_query_coveragecigar-typealigned)
   &mdash; what fraction of the read actually aligned? A value of 1.0 means the
   entire read matched; 0.6 means 40% of the read was soft-clipped (ignored by
   the aligner).
@@ -151,13 +151,13 @@ Even among primary alignments, not all are trustworthy. Two key metrics:
 
 ```sql
 SELECT read_id,
-       round(alignment_query_coverage(cigar), 2) AS query_cov,
+       round(cigar_query_coverage(cigar), 2) AS query_cov,
        round(alignment_seq_identity(cigar, tag_nm, tag_md, 'blast'), 3)
            AS seq_identity,
        cigar
 FROM alignments
 WHERE alignment_is_primary(flags)
-ORDER BY alignment_query_coverage(cigar) ASC
+ORDER BY cigar_query_coverage(cigar) ASC
 LIMIT 10;
 ```
 
@@ -191,7 +191,7 @@ temporary named result you can query like a table:
 WITH quality AS (
     SELECT
         read_id,
-        alignment_query_coverage(cigar) AS qcov,
+        cigar_query_coverage(cigar) AS qcov,
         alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') AS identity
     FROM alignments
     WHERE alignment_is_primary(flags)
@@ -248,7 +248,7 @@ CREATE VIEW filtered_alignments AS
     SELECT *
     FROM alignments
     WHERE alignment_is_primary(flags)
-      AND alignment_query_coverage(cigar) >= 0.8;
+      AND cigar_query_coverage(cigar) >= 0.8;
 ```
 
 Now compare unfiltered vs. filtered counts using
@@ -282,14 +282,14 @@ CREATE VIEW strict_97 AS
     SELECT *
     FROM alignments
     WHERE alignment_is_primary(flags)
-      AND alignment_query_coverage(cigar) >= 0.99
+      AND cigar_query_coverage(cigar) >= 0.99
       AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') >= 0.97;
 
 CREATE VIEW strict_99 AS
     SELECT *
     FROM alignments
     WHERE alignment_is_primary(flags)
-      AND alignment_query_coverage(cigar) >= 0.99
+      AND cigar_query_coverage(cigar) >= 0.99
       AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') >= 0.99;
 
 SELECT 'qcov >= 99%, id >= 97%' AS threshold, *
@@ -326,7 +326,7 @@ CREATE OR REPLACE MACRO quality_filtered(
     SELECT *
     FROM alignments
     WHERE alignment_is_primary(flags)
-      AND alignment_query_coverage(cigar) >= min_query_coverage
+      AND cigar_query_coverage(cigar) >= min_query_coverage
       AND alignment_seq_identity(cigar, tag_nm, tag_md, 'blast')
           >= min_seq_identity;
 ```

--- a/python/src/miint_cli/cli.py
+++ b/python/src/miint_cli/cli.py
@@ -316,7 +316,7 @@ def cmd_transform_woltka_ogu(con, args):
     """Run WoLTKA OGU feature table generation with optional filters."""
     has_filters = (
         args.alignment_seq_identity is not None
-        or args.alignment_query_coverage is not None
+        or args.cigar_query_coverage is not None
     )
     has_genome_cov = args.genome_coverage is not None
 
@@ -329,9 +329,9 @@ def cmd_transform_woltka_ogu(con, args):
         where_parts.append(
             f"alignment_seq_identity(cigar, tag_nm, tag_md, 'blast') >= {float(args.alignment_seq_identity)}"
         )
-    if args.alignment_query_coverage is not None:
+    if args.cigar_query_coverage is not None:
         where_parts.append(
-            f"alignment_query_coverage(cigar) >= {float(args.alignment_query_coverage)}"
+            f"cigar_query_coverage(cigar) >= {float(args.cigar_query_coverage)}"
         )
     where_sql = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
 
@@ -529,7 +529,7 @@ def build_parser():
         help="Min sequence identity threshold (0-1)",
     )
     p.add_argument(
-        "--alignment-query-coverage",
+        "--cigar-query-coverage",
         type=float,
         help="Min query coverage threshold (0-1)",
     )

--- a/src/alignment_functions.cpp
+++ b/src/alignment_functions.cpp
@@ -156,26 +156,14 @@ static void AlignmentSeqIdentityScalarFunction(DataChunk &args, ExpressionState 
 
 		} else if (type_str == "cigar") {
 			// cigar: identity from extended CIGAR ops (= and X) only.
-			// Requires CIGAR to use =/X (not M). Does not need NM or MD tags.
-			// Formula: match_ops / alignment_columns
-			// Returns NULL if:
-			//   - CIGAR uses only M (ambiguous — can't distinguish matches from mismatches)
-			//   - CIGAR mixes M with =/X (inconsistent)
-			if (cigar_stats.match_ops + cigar_stats.mismatch_ops == 0) {
-				// No = or X ops observed (M-only, or degenerate S/N/P-only CIGAR)
+			// Math lives in miint::ComputeCigarIdentity (internal helper); std::nullopt
+			// means "can't compute from CIGAR alone" (M-only, mixed M+=/X, or degenerate).
+			auto maybe_identity = miint::ComputeCigarIdentity(cigar_stats);
+			if (!maybe_identity.has_value()) {
 				result_validity.SetInvalid(i);
 				continue;
 			}
-
-			// If M ops are present alongside =/X, the CIGAR is inconsistent — return NULL
-			int64_t m_only = cigar_stats.matches - cigar_stats.match_ops - cigar_stats.mismatch_ops;
-			if (m_only > 0) {
-				result_validity.SetInvalid(i);
-				continue;
-			}
-
-			// alignment_columns is guaranteed > 0 here because =/X ops exist
-			identity = static_cast<double>(cigar_stats.match_ops) / static_cast<double>(cigar_stats.alignment_columns);
+			identity = *maybe_identity;
 
 		} else {
 			throw InvalidInputException("Invalid type parameter for alignment_seq_identity: '%s'. "

--- a/src/alignment_functions.cpp
+++ b/src/alignment_functions.cpp
@@ -325,8 +325,8 @@ void CigarQueryLengthFunction::Register(ExtensionLoader &loader) {
 	loader.RegisterFunction(function_set);
 }
 
-// alignment_query_coverage implementation
-static void AlignmentQueryCoverageScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+// cigar_query_coverage implementation
+static void CigarQueryCoverageScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &cigar_vector = args.data[0];
 	auto &type_vector = args.data[1];
 
@@ -354,9 +354,9 @@ static void AlignmentQueryCoverageScalarFunction(DataChunk &args, ExpressionStat
 	    });
 }
 
-ScalarFunction AlignmentQueryCoverageFunction::GetFunction() {
-	ScalarFunction func("alignment_query_coverage", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::DOUBLE,
-	                    AlignmentQueryCoverageScalarFunction);
+ScalarFunction CigarQueryCoverageFunction::GetFunction() {
+	ScalarFunction func("cigar_query_coverage", {LogicalType::VARCHAR, LogicalType::VARCHAR}, LogicalType::DOUBLE,
+	                    CigarQueryCoverageScalarFunction);
 
 	// Allow NULL values (returns NULL for NULL CIGAR, error for invalid type)
 	func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
@@ -368,13 +368,13 @@ ScalarFunction AlignmentQueryCoverageFunction::GetFunction() {
 	return func;
 }
 
-void AlignmentQueryCoverageFunction::Register(ExtensionLoader &loader) {
+void CigarQueryCoverageFunction::Register(ExtensionLoader &loader) {
 	// Register overload with both parameters
 	ScalarFunction func_two_params = GetFunction();
 
 	// Register overload with single parameter (type defaults to 'aligned')
 	ScalarFunction func_one_param(
-	    "alignment_query_coverage", {LogicalType::VARCHAR}, LogicalType::DOUBLE,
+	    "cigar_query_coverage", {LogicalType::VARCHAR}, LogicalType::DOUBLE,
 	    [](DataChunk &args, ExpressionState &state, Vector &result) {
 		    UnaryExecutor::Execute<string_t, double>(args.data[0], result, args.size(), [&](string_t cigar) {
 			    // Handle NULL or unmapped CIGAR - return 0.0 for empty/unmapped
@@ -398,7 +398,7 @@ void AlignmentQueryCoverageFunction::Register(ExtensionLoader &loader) {
 	func_one_param.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 
 	// Register both overloads as a function set
-	ScalarFunctionSet function_set("alignment_query_coverage");
+	ScalarFunctionSet function_set("cigar_query_coverage");
 	function_set.AddFunction(func_one_param);
 	function_set.AddFunction(func_two_params);
 	loader.RegisterFunction(function_set);

--- a/src/alignment_functions.cpp
+++ b/src/alignment_functions.cpp
@@ -250,8 +250,8 @@ void CigarSequenceIdentityFunction::Register(ExtensionLoader &loader) {
 	loader.RegisterFunction(GetFunction());
 }
 
-// alignment_query_length implementation
-static void AlignmentQueryLengthScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+// cigar_query_length implementation
+static void CigarQueryLengthScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &cigar_vector = args.data[0];
 	auto &include_hard_clips_vector = args.data[1];
 
@@ -275,9 +275,9 @@ static void AlignmentQueryLengthScalarFunction(DataChunk &args, ExpressionState 
 	    });
 }
 
-ScalarFunction AlignmentQueryLengthFunction::GetFunction() {
-	ScalarFunction func("alignment_query_length", {LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::BIGINT,
-	                    AlignmentQueryLengthScalarFunction);
+ScalarFunction CigarQueryLengthFunction::GetFunction() {
+	ScalarFunction func("cigar_query_length", {LogicalType::VARCHAR, LogicalType::BOOLEAN}, LogicalType::BIGINT,
+	                    CigarQueryLengthScalarFunction);
 
 	// Allow NULL CIGAR (returns NULL)
 	func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
@@ -289,13 +289,13 @@ ScalarFunction AlignmentQueryLengthFunction::GetFunction() {
 	return func;
 }
 
-void AlignmentQueryLengthFunction::Register(ExtensionLoader &loader) {
+void CigarQueryLengthFunction::Register(ExtensionLoader &loader) {
 	// Register overload with both parameters
 	ScalarFunction func_two_params = GetFunction();
 
 	// Register overload with single parameter (include_hard_clips defaults to true)
 	ScalarFunction func_one_param(
-	    "alignment_query_length", {LogicalType::VARCHAR}, LogicalType::BIGINT,
+	    "cigar_query_length", {LogicalType::VARCHAR}, LogicalType::BIGINT,
 	    [](DataChunk &args, ExpressionState &state, Vector &result) {
 		    UnaryExecutor::Execute<string_t, int64_t>(args.data[0], result, args.size(), [&](string_t cigar) {
 			    // Handle NULL or unmapped CIGAR
@@ -319,7 +319,7 @@ void AlignmentQueryLengthFunction::Register(ExtensionLoader &loader) {
 	func_one_param.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
 
 	// Register both overloads as a function set
-	ScalarFunctionSet function_set("alignment_query_length");
+	ScalarFunctionSet function_set("cigar_query_length");
 	function_set.AddFunction(func_one_param);
 	function_set.AddFunction(func_two_params);
 	loader.RegisterFunction(function_set);

--- a/src/alignment_functions.cpp
+++ b/src/alignment_functions.cpp
@@ -194,6 +194,62 @@ void AlignmentSeqIdentityFunction::Register(ExtensionLoader &loader) {
 	loader.RegisterFunction(GetFunction());
 }
 
+// cigar_sequence_identity(cigar) — one-arg convenience over the type='cigar'
+// branch of alignment_seq_identity. Same math (via miint::ComputeCigarIdentity).
+// Returns NULL when identity can't be computed from CIGAR alone (M-only CIGAR,
+// mixed M+=/X, degenerate CIGARs with no =/X ops).
+static void CigarSequenceIdentityScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &cigar_vector = args.data[0];
+
+	UnifiedVectorFormat cigar_data;
+	cigar_vector.ToUnifiedFormat(args.size(), cigar_data);
+	auto cigar_ptr = UnifiedVectorFormat::GetData<string_t>(cigar_data);
+
+	result.SetVectorType(VectorType::FLAT_VECTOR);
+	auto result_data = FlatVector::GetData<double>(result);
+	auto &result_validity = FlatVector::Validity(result);
+
+	for (idx_t i = 0; i < args.size(); i++) {
+		auto cigar_idx = cigar_data.sel->get_index(i);
+
+		if (!cigar_data.validity.RowIsValid(cigar_idx)) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		auto cigar = cigar_ptr[cigar_idx];
+		if (cigar.GetSize() == 0 || (cigar.GetSize() == 1 && cigar.GetData()[0] == '*')) {
+			result_validity.SetInvalid(i);
+			continue;
+		}
+
+		try {
+			std::string cigar_std(cigar.GetData(), cigar.GetSize());
+			miint::CigarStats cigar_stats = miint::ParseCigar(cigar_std);
+
+			auto maybe_identity = miint::ComputeCigarIdentity(cigar_stats);
+			if (!maybe_identity.has_value()) {
+				result_validity.SetInvalid(i);
+				continue;
+			}
+			result_data[i] = *maybe_identity;
+		} catch (const miint::InvalidInputException &e) {
+			throw InvalidInputException(e.what());
+		}
+	}
+}
+
+ScalarFunction CigarSequenceIdentityFunction::GetFunction() {
+	ScalarFunction func("cigar_sequence_identity", {LogicalType::VARCHAR}, LogicalType::DOUBLE,
+	                    CigarSequenceIdentityScalarFunction);
+	func.null_handling = FunctionNullHandling::SPECIAL_HANDLING;
+	return func;
+}
+
+void CigarSequenceIdentityFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
 // alignment_query_length implementation
 static void AlignmentQueryLengthScalarFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &cigar_vector = args.data[0];

--- a/src/include/alignment_functions.hpp
+++ b/src/include/alignment_functions.hpp
@@ -23,7 +23,7 @@ public:
 	static ScalarFunction GetFunction();
 };
 
-class AlignmentQueryCoverageFunction {
+class CigarQueryCoverageFunction {
 public:
 	static void Register(ExtensionLoader &loader);
 	static ScalarFunction GetFunction();

--- a/src/include/alignment_functions.hpp
+++ b/src/include/alignment_functions.hpp
@@ -17,7 +17,7 @@ public:
 	static ScalarFunction GetFunction();
 };
 
-class AlignmentQueryLengthFunction {
+class CigarQueryLengthFunction {
 public:
 	static void Register(ExtensionLoader &loader);
 	static ScalarFunction GetFunction();

--- a/src/include/alignment_functions.hpp
+++ b/src/include/alignment_functions.hpp
@@ -11,6 +11,12 @@ public:
 	static ScalarFunction GetFunction();
 };
 
+class CigarSequenceIdentityFunction {
+public:
+	static void Register(ExtensionLoader &loader);
+	static ScalarFunction GetFunction();
+};
+
 class AlignmentQueryLengthFunction {
 public:
 	static void Register(ExtensionLoader &loader);

--- a/src/include/alignment_functions_internal.hpp
+++ b/src/include/alignment_functions_internal.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 #include <cctype>
@@ -275,6 +276,32 @@ static inline double ComputeQueryCoverage(const CigarStats &stats, const std::st
 	}
 
 	return static_cast<double>(covered_bases) / static_cast<double>(query_length);
+}
+
+// Compute sequence identity from extended-CIGAR operations (= and X) alone.
+//
+// Formula: match_ops / alignment_columns, where alignment_columns = M + I + D
+// (= and X count toward the M field in CigarStats).
+//
+// Returns std::nullopt when identity cannot be determined from the CIGAR:
+//   - Legacy CIGAR with only M ops (can't distinguish matches from mismatches)
+//   - Mixed M alongside = or X (inconsistent encoding)
+//   - Degenerate CIGARs with no =/X ops at all (pure I/D/S/H/N/P)
+// SQL wrappers materialize std::nullopt as NULL.
+static inline std::optional<double> ComputeCigarIdentity(const CigarStats &stats) {
+	if (stats.match_ops + stats.mismatch_ops == 0) {
+		// No = or X ops observed (M-only or degenerate)
+		return std::nullopt;
+	}
+
+	// If M ops are present alongside =/X, the CIGAR is inconsistent
+	int64_t m_only = stats.matches - stats.match_ops - stats.mismatch_ops;
+	if (m_only > 0) {
+		return std::nullopt;
+	}
+
+	// alignment_columns is guaranteed > 0 here because =/X ops exist
+	return static_cast<double>(stats.match_ops) / static_cast<double>(stats.alignment_columns);
 }
 
 } // namespace miint

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -214,7 +214,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	AlignmentFlagFunctions::Register(loader);
 	AlignmentSeqIdentityFunction::Register(loader);
 	CigarSequenceIdentityFunction::Register(loader);
-	AlignmentQueryLengthFunction::Register(loader);
+	CigarQueryLengthFunction::Register(loader);
 	AlignmentQueryCoverageFunction::Register(loader);
 	CompressIntervalsFunction::Register(loader);
 	ComputeCoverageDepthFunction::Register(loader);

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -215,7 +215,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	AlignmentSeqIdentityFunction::Register(loader);
 	CigarSequenceIdentityFunction::Register(loader);
 	CigarQueryLengthFunction::Register(loader);
-	AlignmentQueryCoverageFunction::Register(loader);
+	CigarQueryCoverageFunction::Register(loader);
 	CompressIntervalsFunction::Register(loader);
 	ComputeCoverageDepthFunction::Register(loader);
 	AlignmentSliceTableFunction::Register(loader);

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -213,6 +213,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 
 	AlignmentFlagFunctions::Register(loader);
 	AlignmentSeqIdentityFunction::Register(loader);
+	CigarSequenceIdentityFunction::Register(loader);
 	AlignmentQueryLengthFunction::Register(loader);
 	AlignmentQueryCoverageFunction::Register(loader);
 	CompressIntervalsFunction::Register(loader);

--- a/test/cpp/test_AlignmentFunctions.cpp
+++ b/test/cpp/test_AlignmentFunctions.cpp
@@ -587,3 +587,107 @@ TEST_CASE("ComputeQueryCoverage - Aligned vs Mapped comparison", "[alignment_fun
 		REQUIRE_THAT(aligned, WithinRel(mapped, 0.001));
 	}
 }
+
+TEST_CASE("ComputeCigarIdentity - Extended CIGAR ops", "[alignment_functions]") {
+	using Catch::Matchers::WithinRel;
+
+	SECTION("Perfect match (all =)") {
+		auto stats = miint::ParseCigar("10=");
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(1.0, 0.001));
+	}
+
+	SECTION("Mixed =/X") {
+		auto stats = miint::ParseCigar("5=5X");
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(0.5, 0.001));
+	}
+
+	SECTION("With insertions: gaps lower identity") {
+		auto stats = miint::ParseCigar("5=2I3=");
+		// match_ops=8, alignment_columns = 8 + 2 = 10 → 0.8
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(0.8, 0.001));
+	}
+
+	SECTION("With deletions: gaps lower identity") {
+		auto stats = miint::ParseCigar("5=3D5=");
+		// match_ops=10, alignment_columns = 10 + 3 = 13 → 10/13
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(10.0 / 13.0, 0.001));
+	}
+
+	SECTION("Soft clips excluded from identity") {
+		auto stats = miint::ParseCigar("3S5=2X3=3S");
+		// match_ops=8, mismatch_ops=2, alignment_columns=10 → 0.8
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(0.8, 0.001));
+	}
+
+	SECTION("Hard clips excluded from identity") {
+		auto stats = miint::ParseCigar("5H5=5X5H");
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(0.5, 0.001));
+	}
+
+	SECTION("N op (RNA skip) ignored") {
+		auto stats = miint::ParseCigar("5=100N5=");
+		// match_ops=10, alignment_columns=10 (N not counted)
+		auto result = miint::ComputeCigarIdentity(stats);
+		REQUIRE(result.has_value());
+		REQUIRE_THAT(*result, WithinRel(1.0, 0.001));
+	}
+}
+
+TEST_CASE("ComputeCigarIdentity - Degenerate and ambiguous cases", "[alignment_functions]") {
+	SECTION("Legacy M-only: no =/X, return no value") {
+		auto stats = miint::ParseCigar("10M");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Mixed M with =: inconsistent, return no value") {
+		auto stats = miint::ParseCigar("5M5=");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Mixed M with X: inconsistent, return no value") {
+		auto stats = miint::ParseCigar("5M5X");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Pure insertion: no =/X, return no value") {
+		auto stats = miint::ParseCigar("10I");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Pure deletion: no =/X, return no value") {
+		auto stats = miint::ParseCigar("10D");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Soft-clip only: no =/X, return no value") {
+		auto stats = miint::ParseCigar("100S");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Hard-clip only: no =/X, return no value") {
+		auto stats = miint::ParseCigar("100H");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Empty CIGAR: no =/X, return no value") {
+		auto stats = miint::ParseCigar("");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+
+	SECTION("Unmapped (*): no =/X, return no value") {
+		auto stats = miint::ParseCigar("*");
+		REQUIRE(!miint::ComputeCigarIdentity(stats).has_value());
+	}
+}

--- a/test/sql/alignment_functions.test
+++ b/test/sql/alignment_functions.test
@@ -307,6 +307,38 @@ SELECT alignment_seq_identity(NULL, NULL, NULL, 'cigar') IS NULL;
 ----
 true
 
+# Degenerate CIGARs with no = or X ops should return NULL (no alignment columns
+# to divide by). Pins contract that cigar_sequence_identity will share.
+query I
+SELECT alignment_seq_identity('10I', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+query I
+SELECT alignment_seq_identity('10D', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+query I
+SELECT alignment_seq_identity('100S', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+query I
+SELECT alignment_seq_identity('100H', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+query I
+SELECT alignment_seq_identity('100N', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
+query I
+SELECT alignment_seq_identity('100P', NULL, NULL, 'cigar') IS NULL;
+----
+true
+
 ###############################################################################
 # ERROR HANDLING
 ###############################################################################

--- a/test/sql/alignment_functions.test
+++ b/test/sql/alignment_functions.test
@@ -391,6 +391,137 @@ SELECT alignment_seq_identity('5=2X3=', 2, '', 'gap_compressed')::FLOAT;
 0.8
 
 ###############################################################################
+# cigar_sequence_identity(cigar) — one-arg convenience over the type='cigar'
+# branch of alignment_seq_identity. Same math, simpler signature.
+# Both go through miint::ComputeCigarIdentity, so behavior must match.
+###############################################################################
+
+# Perfect match: 10=
+query R
+SELECT cigar_sequence_identity('10=')::FLOAT;
+----
+1.0
+
+# Half match: 5=5X
+query R
+SELECT cigar_sequence_identity('5=5X')::FLOAT;
+----
+0.5
+
+# With insertion: gaps drop identity. 5=2I3= → 8 matches / 10 alignment_columns
+query R
+SELECT cigar_sequence_identity('5=2I3=')::FLOAT;
+----
+0.8
+
+# With deletion: gaps drop identity. 5=3D5= → 10 matches / 13 alignment_columns
+query R
+SELECT cigar_sequence_identity('5=3D5=')::FLOAT;
+----
+0.76923
+
+# Mix of =/X plus soft clips (clips excluded from identity)
+query R
+SELECT cigar_sequence_identity('3S5=2X3=3S')::FLOAT;
+----
+0.8
+
+# Hard clips also excluded
+query R
+SELECT cigar_sequence_identity('5H5=5X5H')::FLOAT;
+----
+0.5
+
+# N (RNA skip) ignored
+query R
+SELECT cigar_sequence_identity('5=100N5=')::FLOAT;
+----
+1.0
+
+# Legacy M-only CIGAR → NULL (can't compute from CIGAR alone)
+query I
+SELECT cigar_sequence_identity('10M') IS NULL;
+----
+true
+
+# Mixed M with =/X → NULL (inconsistent)
+query I
+SELECT cigar_sequence_identity('5M5=') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('5M5X') IS NULL;
+----
+true
+
+# Unmapped / empty / NULL → NULL
+query I
+SELECT cigar_sequence_identity('*') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity(NULL) IS NULL;
+----
+true
+
+# Degenerate CIGARs with no =/X ops → NULL (same contract as characterization
+# pins on alignment_seq_identity with type='cigar')
+query I
+SELECT cigar_sequence_identity('10I') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('10D') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('100S') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('100H') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('100N') IS NULL;
+----
+true
+
+query I
+SELECT cigar_sequence_identity('100P') IS NULL;
+----
+true
+
+# Parity with the legacy-spelling: same inputs must produce same results.
+# If this ever fails, either the wrapper has drifted or the shared helper
+# is being bypassed.
+query I
+SELECT cigar_sequence_identity('5=2I3=') = alignment_seq_identity('5=2I3=', NULL, NULL, 'cigar');
+----
+true
+
+query I
+SELECT cigar_sequence_identity('5=3D5=') = alignment_seq_identity('5=3D5=', NULL, NULL, 'cigar');
+----
+true
+
+query I
+SELECT cigar_sequence_identity('3S5=2X3=3S') = alignment_seq_identity('3S5=2X3=3S', NULL, NULL, 'cigar');
+----
+true
+
+###############################################################################
 # INTEGRATION WITH read_sam
 ###############################################################################
 

--- a/test/sql/alignment_functions.test
+++ b/test/sql/alignment_functions.test
@@ -754,60 +754,60 @@ true
 
 # Perfect alignment - no clipping
 query R
-SELECT alignment_query_coverage('10M', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('10M', 'aligned')::FLOAT;
 ----
 1.0
 
 # Default parameter (type defaults to 'aligned')
 query R
-SELECT alignment_query_coverage('10M')::FLOAT;
+SELECT cigar_query_coverage('10M')::FLOAT;
 ----
 1.0
 
 # Alignment with insertions
 # 10 aligned / 15 total = 0.6667
 query R
-SELECT alignment_query_coverage('10M5I', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('10M5I', 'aligned')::FLOAT;
 ----
 0.667
 
 # Alignment with soft clips
 # 10 aligned / 20 total = 0.5
 query R
-SELECT alignment_query_coverage('5S10M5S', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('5S10M5S', 'aligned')::FLOAT;
 ----
 0.5
 
 # Alignment with hard clips
 # 10 aligned / 20 total = 0.5
 query R
-SELECT alignment_query_coverage('5H10M5H', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('5H10M5H', 'aligned')::FLOAT;
 ----
 0.5
 
 # Alignment with both soft and hard clips
 # 10 aligned / 30 total = 0.3333
 query R
-SELECT alignment_query_coverage('5H5S10M5S5H', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('5H5S10M5S5H', 'aligned')::FLOAT;
 ----
 0.333
 
 # Complex alignment with insertions and clips
 # 10 aligned / 35 total = 0.2857
 query R
-SELECT alignment_query_coverage('5H5S10M5I5S5H', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('5H5S10M5I5S5H', 'aligned')::FLOAT;
 ----
 0.286
 
 # Only soft clips - zero coverage
 query R
-SELECT alignment_query_coverage('100S', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('100S', 'aligned')::FLOAT;
 ----
 0.0
 
 # Only hard clips - zero coverage
 query R
-SELECT alignment_query_coverage('100H', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('100H', 'aligned')::FLOAT;
 ----
 0.0
 
@@ -817,54 +817,54 @@ SELECT alignment_query_coverage('100H', 'aligned')::FLOAT;
 
 # Perfect alignment - no clipping
 query R
-SELECT alignment_query_coverage('10M', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('10M', 'mapped')::FLOAT;
 ----
 1.0
 
 # Alignment with insertions
 # 15 mapped (M+I) / 15 total = 1.0
 query R
-SELECT alignment_query_coverage('10M5I', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('10M5I', 'mapped')::FLOAT;
 ----
 1.0
 
 # Alignment with soft clips
 # 10 mapped / 20 total = 0.5
 query R
-SELECT alignment_query_coverage('5S10M5S', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('5S10M5S', 'mapped')::FLOAT;
 ----
 0.5
 
 # Alignment with hard clips
 # 10 mapped / 20 total = 0.5
 query R
-SELECT alignment_query_coverage('5H10M5H', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('5H10M5H', 'mapped')::FLOAT;
 ----
 0.5
 
 # Alignment with insertions and soft clips
 # 15 mapped (M+I) / 25 total = 0.6
 query R
-SELECT alignment_query_coverage('5S10M5I5S', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('5S10M5I5S', 'mapped')::FLOAT;
 ----
 0.6
 
 # Complex alignment with all operations
 # 15 mapped (M+I) / 35 total = 0.4286
 query R
-SELECT alignment_query_coverage('5H5S10M5I5S5H', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('5H5S10M5I5S5H', 'mapped')::FLOAT;
 ----
 0.429
 
 # Only soft clips - zero coverage
 query R
-SELECT alignment_query_coverage('100S', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('100S', 'mapped')::FLOAT;
 ----
 0.0
 
 # Only hard clips - zero coverage
 query R
-SELECT alignment_query_coverage('100H', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('100H', 'mapped')::FLOAT;
 ----
 0.0
 
@@ -874,33 +874,33 @@ SELECT alignment_query_coverage('100H', 'mapped')::FLOAT;
 
 # Empty CIGAR - zero coverage (not NULL)
 query R
-SELECT alignment_query_coverage('', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('', 'aligned')::FLOAT;
 ----
 0.0
 
 # Unmapped read (*) - zero coverage
 query R
-SELECT alignment_query_coverage('*', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('*', 'aligned')::FLOAT;
 ----
 0.0
 
 # Deletions don't affect coverage calculation
 # 20 aligned / 20 total = 1.0
 query R
-SELECT alignment_query_coverage('10M5D10M', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('10M5D10M', 'aligned')::FLOAT;
 ----
 1.0
 
 # Reference skip (N) doesn't affect coverage
 # 20 aligned / 20 total = 1.0
 query R
-SELECT alignment_query_coverage('10M100N10M', 'aligned')::FLOAT;
+SELECT cigar_query_coverage('10M100N10M', 'aligned')::FLOAT;
 ----
 1.0
 
 # Verify deletions don't affect mapped coverage either
 query R
-SELECT alignment_query_coverage('10M5D10M', 'mapped')::FLOAT;
+SELECT cigar_query_coverage('10M5D10M', 'mapped')::FLOAT;
 ----
 1.0
 
@@ -910,25 +910,25 @@ SELECT alignment_query_coverage('10M5D10M', 'mapped')::FLOAT;
 
 # NULL CIGAR should return NULL
 query I
-SELECT alignment_query_coverage(NULL, 'aligned') IS NULL;
+SELECT cigar_query_coverage(NULL, 'aligned') IS NULL;
 ----
 true
 
 # NULL with default parameter
 query I
-SELECT alignment_query_coverage(NULL) IS NULL;
+SELECT cigar_query_coverage(NULL) IS NULL;
 ----
 true
 
 # NULL type parameter should return NULL
 query I
-SELECT alignment_query_coverage('10M', NULL) IS NULL;
+SELECT cigar_query_coverage('10M', NULL) IS NULL;
 ----
 true
 
 # Both NULL
 query I
-SELECT alignment_query_coverage(NULL, NULL) IS NULL;
+SELECT cigar_query_coverage(NULL, NULL) IS NULL;
 ----
 true
 
@@ -938,7 +938,7 @@ true
 
 # Invalid type parameter
 statement error
-SELECT alignment_query_coverage('10M', 'invalid_type');
+SELECT cigar_query_coverage('10M', 'invalid_type');
 ----
 Invalid Input Error: Invalid coverage type
 
@@ -951,16 +951,16 @@ Invalid Input Error: Invalid coverage type
 # mapped: 20 / 40 = 0.5
 query RR
 SELECT
-    alignment_query_coverage('10H10M10I10H', 'aligned')::FLOAT,
-    alignment_query_coverage('10H10M10I10H', 'mapped')::FLOAT;
+    cigar_query_coverage('10H10M10I10H', 'aligned')::FLOAT,
+    cigar_query_coverage('10H10M10I10H', 'mapped')::FLOAT;
 ----
 0.25	0.5
 
 # Without insertions, aligned == mapped
 query RR
 SELECT
-    alignment_query_coverage('5H5S10M5S5H', 'aligned')::FLOAT,
-    alignment_query_coverage('5H5S10M5S5H', 'mapped')::FLOAT;
+    cigar_query_coverage('5H5S10M5S5H', 'aligned')::FLOAT,
+    cigar_query_coverage('5H5S10M5S5H', 'mapped')::FLOAT;
 ----
 0.333	0.333
 
@@ -978,7 +978,7 @@ WHERE cigar_query_length(cigar, true) > 0;
 # Verify coverage function works with SAM data
 query I
 SELECT COUNT(*) FROM read_sam('data/sam/foo_has_header.sam')
-WHERE alignment_query_coverage(cigar, 'aligned') >= 0.0;
+WHERE cigar_query_coverage(cigar, 'aligned') >= 0.0;
 ----
 4
 
@@ -1004,14 +1004,14 @@ SELECT cigar_query_length('10M5');
 ----
 Invalid CIGAR string: incomplete operation (missing operation character)
 
-# Test same errors with alignment_query_coverage
+# Test same errors with cigar_query_coverage
 statement error
-SELECT alignment_query_coverage('M', 'aligned');
+SELECT cigar_query_coverage('M', 'aligned');
 ----
 Invalid CIGAR string: operation without length
 
 statement error
-SELECT alignment_query_coverage('10Z', 'aligned');
+SELECT cigar_query_coverage('10Z', 'aligned');
 ----
 Invalid CIGAR operation: Z
 

--- a/test/sql/alignment_functions.test
+++ b/test/sql/alignment_functions.test
@@ -584,67 +584,67 @@ SELECT cigar, alignment_seq_identity(cigar, tag_nm, tag_md, 'cigar')::FLOAT FROM
 
 # Simple match - no clipping
 query I
-SELECT alignment_query_length('10M', true);
+SELECT cigar_query_length('10M', true);
 ----
 10
 
 # Match with default parameter (include_hard_clips defaults to true)
 query I
-SELECT alignment_query_length('10M');
+SELECT cigar_query_length('10M');
 ----
 10
 
 # Match with insertions
 query I
-SELECT alignment_query_length('10M5I', true);
+SELECT cigar_query_length('10M5I', true);
 ----
 15
 
 # Match with deletions (deletions don't consume query)
 query I
-SELECT alignment_query_length('10M5D', true);
+SELECT cigar_query_length('10M5D', true);
 ----
 10
 
 # With soft clips only
 query I
-SELECT alignment_query_length('5S10M5S', true);
+SELECT cigar_query_length('5S10M5S', true);
 ----
 20
 
 # With hard clips - include them
 query I
-SELECT alignment_query_length('5H10M5H', true);
+SELECT cigar_query_length('5H10M5H', true);
 ----
 20
 
 # With hard clips - exclude them
 query I
-SELECT alignment_query_length('5H10M5H', false);
+SELECT cigar_query_length('5H10M5H', false);
 ----
 10
 
 # With both soft and hard clips - include hard clips
 query I
-SELECT alignment_query_length('5H5S10M5S5H', true);
+SELECT cigar_query_length('5H5S10M5S5H', true);
 ----
 30
 
 # With both soft and hard clips - exclude hard clips
 query I
-SELECT alignment_query_length('5H5S10M5S5H', false);
+SELECT cigar_query_length('5H5S10M5S5H', false);
 ----
 20
 
 # Complex CIGAR with all operations
 query I
-SELECT alignment_query_length('5H5S10M5I3D5M5S5H', true);
+SELECT cigar_query_length('5H5S10M5I3D5M5S5H', true);
 ----
 40
 
 # Complex CIGAR - exclude hard clips
 query I
-SELECT alignment_query_length('5H5S10M5I3D5M5S5H', false);
+SELECT cigar_query_length('5H5S10M5I3D5M5S5H', false);
 ----
 30
 
@@ -657,31 +657,31 @@ SELECT alignment_query_length('5H5S10M5I3D5M5S5H', false);
 
 # HTSlib example 1: 10M5I5S
 query I
-SELECT alignment_query_length('10M5I5S', false);
+SELECT cigar_query_length('10M5I5S', false);
 ----
 20
 
 # HTSlib example 2: 5S10M3D5M5S
 query I
-SELECT alignment_query_length('5S10M3D5M5S', false);
+SELECT cigar_query_length('5S10M3D5M5S', false);
 ----
 25
 
 # HTSlib example 3: 5H10M5H (hard clips excluded)
 query I
-SELECT alignment_query_length('5H10M5H', false);
+SELECT cigar_query_length('5H10M5H', false);
 ----
 10
 
 # HTSlib example 4: 5=2X3= (explicit match/mismatch)
 query I
-SELECT alignment_query_length('5=2X3=', false);
+SELECT cigar_query_length('5=2X3=', false);
 ----
 10
 
 # HTSlib example 5: 18M3D2M2D2M1I22M (complex with deletions)
 query I
-SELECT alignment_query_length('18M3D2M2D2M1I22M', false);
+SELECT cigar_query_length('18M3D2M2D2M1I22M', false);
 ----
 45
 
@@ -691,37 +691,37 @@ SELECT alignment_query_length('18M3D2M2D2M1I22M', false);
 
 # Empty string CIGAR
 query I
-SELECT alignment_query_length('', true);
+SELECT cigar_query_length('', true);
 ----
 0
 
 # Unmapped read (*)
 query I
-SELECT alignment_query_length('*', true);
+SELECT cigar_query_length('*', true);
 ----
 0
 
 # Only soft clipping
 query I
-SELECT alignment_query_length('100S', true);
+SELECT cigar_query_length('100S', true);
 ----
 100
 
 # Only hard clipping - included
 query I
-SELECT alignment_query_length('100H', true);
+SELECT cigar_query_length('100H', true);
 ----
 100
 
 # Only hard clipping - excluded
 query I
-SELECT alignment_query_length('100H', false);
+SELECT cigar_query_length('100H', false);
 ----
 0
 
 # Reference skip (N) doesn't consume query
 query I
-SELECT alignment_query_length('10M100N10M', true);
+SELECT cigar_query_length('10M100N10M', true);
 ----
 20
 
@@ -731,20 +731,20 @@ SELECT alignment_query_length('10M100N10M', true);
 
 # NULL CIGAR should return NULL
 query I
-SELECT alignment_query_length(NULL, true) IS NULL;
+SELECT cigar_query_length(NULL, true) IS NULL;
 ----
 true
 
 # NULL with default parameter
 query I
-SELECT alignment_query_length(NULL) IS NULL;
+SELECT cigar_query_length(NULL) IS NULL;
 ----
 true
 
 # NULL for include_hard_clips parameter returns NULL (not default)
 # Note: Explicitly passing NULL is different from omitting the parameter
 query I
-SELECT alignment_query_length('5H10M5H', NULL) IS NULL;
+SELECT cigar_query_length('5H10M5H', NULL) IS NULL;
 ----
 true
 
@@ -971,7 +971,7 @@ SELECT
 # Test with actual SAM data - verify functions work on real data
 query I
 SELECT COUNT(*) FROM read_sam('data/sam/foo_has_header.sam')
-WHERE alignment_query_length(cigar, true) > 0;
+WHERE cigar_query_length(cigar, true) > 0;
 ----
 4
 
@@ -988,19 +988,19 @@ WHERE alignment_query_coverage(cigar, 'aligned') >= 0.0;
 
 # Invalid CIGAR - operation without length
 statement error
-SELECT alignment_query_length('M');
+SELECT cigar_query_length('M');
 ----
 Invalid CIGAR string: operation without length
 
 # Invalid CIGAR - unknown operation character
 statement error
-SELECT alignment_query_length('10Z');
+SELECT cigar_query_length('10Z');
 ----
 Invalid CIGAR operation: Z
 
 # Invalid CIGAR - incomplete (number without operation)
 statement error
-SELECT alignment_query_length('10M5');
+SELECT cigar_query_length('10M5');
 ----
 Invalid CIGAR string: incomplete operation (missing operation character)
 
@@ -1028,7 +1028,7 @@ true
 
 # CIGAR with huge number that would overflow int64
 statement error
-SELECT alignment_query_length('999999999999999999999M');
+SELECT cigar_query_length('999999999999999999999M');
 ----
 CIGAR operation length exceeds maximum
 


### PR DESCRIPTION
Addresses #55.

Adds `cigar_sequence_identity(cigar)` alongside over the existing `alignment_seq_identity(... type='cigar')` path — same math (factored out into `miint::ComputeCigarIdentity`), but no NM/MD plumbing required when the CIGAR is already extended (`=`/`X`). Returns NULL when identity can't be derived from CIGAR alone (M-only, mixed M+`=`/`X`, degenerate ops).

Renames the two purely CIGAR-driven scalars to match the new prefix: `alignment_query_length` → `cigar_query_length`, `alignment_query_coverage` → `cigar_query_coverage`. Caller-side updates included for `docs/scalar-functions.md`, the Python CLI, the README, and the intermediate/advanced onboarding tutorials. `alignment_seq_identity` is left as-is since it still serves the NM/MD-based identity types (`gap_excluded`, `blast`, `gap_compressed`); only the cigar-only branch gets a dedicated entry point.

Is this what you had in mind, @wasade?
