### PR TITLE
Thread-enable align_mafft via mafft_api AUTO/FFTNSI path

### DIFF
--- a/src/MafftAligner.cpp
+++ b/src/MafftAligner.cpp
@@ -1,23 +1,16 @@
 #include "include/MafftAligner.hpp"
+#include "mafft_api.h"
 #include <climits>
 #include <cstring>
 #include <mutex>
 #include <stdexcept>
-
-extern "C" {
-extern int splittbfast_library(int ngui, int lgui, char **namegui, char **seqgui, int argc, char **argv,
-                               int (*callback)(int, int, char *));
-}
 
 namespace miint {
 
 // Process-wide mutex: MAFFT uses ~150 global variables and is not reentrant.
 static std::mutex g_mafft_mutex;
 
-struct MafftAligner::Impl {
-	Impl() {
-	}
-};
+struct MafftAligner::Impl {};
 
 MafftAligner::MafftAligner() {
 	impl_ = std::make_unique<Impl>();
@@ -61,7 +54,7 @@ static void restore_case(const std::string &original, std::string &aligned) {
 }
 
 MafftAlignResult MafftAligner::align(const std::vector<std::string> &names, const std::vector<std::string> &comments,
-                                     const std::vector<std::string> &sequences) {
+                                     const std::vector<std::string> &sequences, int n_threads) {
 	if (sequences.size() < 2) {
 		throw std::invalid_argument("MafftAligner: at least 2 sequences required");
 	}
@@ -83,101 +76,75 @@ MafftAlignResult MafftAligner::align(const std::vector<std::string> &names, cons
 
 	int n = static_cast<int>(sequences.size());
 
-	size_t max_len = 0;
-	for (const auto &s : sequences) {
-		if (s.size() > max_len) {
-			max_len = s.size();
-		}
-	}
-
-	// lgui = buffer size per sequence (must hold aligned result with gaps)
-	size_t lgui_sz = max_len * 3 + 1000;
-	if (lgui_sz > static_cast<size_t>(INT_MAX)) {
-		throw std::invalid_argument("MafftAligner: sequences too long (max aligned length would overflow)");
-	}
-	int lgui = static_cast<int>(lgui_sz);
-
-	char seqtype = detect_sequence_type(sequences);
-
-	// Allocate C arrays for MAFFT
-	char **seqgui = static_cast<char **>(calloc(n, sizeof(char *)));
-	char **namegui = static_cast<char **>(calloc(n, sizeof(char *)));
-	if (!seqgui || !namegui) {
-		free(seqgui);
-		free(namegui);
-		throw std::runtime_error("MafftAligner: allocation failed");
-	}
+	// Build C-array views over the input. The API copies these internally,
+	// so it is safe for the underlying std::strings to outlive only the call.
+	std::vector<std::string> full_names(n);
+	std::vector<const char *> name_ptrs(n);
+	std::vector<const char *> seq_ptrs(n);
 	for (int i = 0; i < n; i++) {
-		seqgui[i] = static_cast<char *>(calloc(lgui + 1, sizeof(char)));
-		namegui[i] = static_cast<char *>(calloc(1000, sizeof(char)));
-		strcpy(seqgui[i], sequences[i].c_str());
-		// copydatafromgui() expects plain name (it prepends '=')
-		std::string full_name = names[i];
+		full_names[i] = names[i];
 		if (!comments[i].empty()) {
-			full_name += " " + comments[i];
+			full_names[i] += " " + comments[i];
 		}
-		strncpy(namegui[i], full_name.c_str(), 999);
-		namegui[i][999] = '\0';
+		name_ptrs[i] = full_names[i].c_str();
+		seq_ptrs[i] = sequences[i].c_str();
 	}
 
-	// Construct argv for splittbfast --parttree mode
-	int argc_m = 12;
-	char **argv_m = static_cast<char **>(calloc(argc_m, sizeof(char *)));
-	for (int i = 0; i < argc_m; i++) {
-		argv_m[i] = static_cast<char *>(calloc(100, sizeof(char)));
-	}
-	strcpy(argv_m[0], "splittbfast");
-	strcpy(argv_m[1], seqtype == 'd' ? "-D" : "-P");
-	strcpy(argv_m[2], "-f");
-	strcpy(argv_m[3], "-1.53"); // gap open penalty
-	strcpy(argv_m[4], "-Q");
-	strcpy(argv_m[5], "100"); // spfactor
-	strcpy(argv_m[6], "-h");
-	strcpy(argv_m[7], "0"); // aof
-	strcpy(argv_m[8], "-p");
-	strcpy(argv_m[9], "50"); // partsize (PICKSIZE)
-	strcpy(argv_m[10], "-s");
-	strcpy(argv_m[11], "-1"); // groupsize = njob+1 (full alignment)
+	mafft_config_t cfg;
+	mafft_config_init(&cfg);
+	cfg.strategy = MAFFT_STRATEGY_AUTO;
+	cfg.seqtype = (detect_sequence_type(sequences) == 'd') ? MAFFT_SEQ_DNA : MAFFT_SEQ_PROTEIN;
+	cfg.n_threads = n_threads > 0 ? n_threads : 1;
 
-	// Call MAFFT (mutex-protected — MAFFT uses global state)
-	int result;
+	mafft_output_t *out = nullptr;
+	int rc;
+	std::string err_msg;
+	std::string mafft_log;
 	{
 		std::lock_guard<std::mutex> lock(g_mafft_mutex);
-		result = splittbfast_library(n, lgui, namegui, seqgui, argc_m, argv_m, nullptr);
-	}
-
-	// Build result before cleanup (seqgui holds aligned sequences)
-	MafftAlignResult align_result;
-	if (result == 0) {
-		align_result.names = names;
-		align_result.comments = comments;
-		align_result.aligned_length = static_cast<int>(strlen(seqgui[0]));
-
-		for (int i = 0; i < n; i++) {
-			std::string aligned(seqgui[i]);
-			restore_case(sequences[i], aligned);
-			align_result.sequences.push_back(std::move(aligned));
-			align_result.original_lengths.push_back(static_cast<int>(sequences[i].size()));
+		mafft_ctx_t *ctx = mafft_create(&cfg);
+		if (!ctx) {
+			throw std::runtime_error("MafftAligner: mafft_create failed");
 		}
+		rc = mafft_align(ctx, name_ptrs.data(), seq_ptrs.data(), n, &out, nullptr);
+		if (rc != MAFFT_OK) {
+			const char *e = mafft_last_error(ctx);
+			err_msg = e ? e : mafft_strerror(rc);
+			const char *log = mafft_ctx_log(ctx);
+			if (log && *log) {
+				mafft_log = log;
+			}
+		}
+		mafft_destroy(ctx);
 	}
 
-	// Cleanup C arrays
+	if (rc != MAFFT_OK) {
+		if (out) {
+			mafft_output_free(out);
+		}
+		std::string full = "MAFFT alignment failed: " + err_msg + " (code " + std::to_string(rc) + ")";
+		if (!mafft_log.empty()) {
+			full += "\n--- captured MAFFT log ---\n" + mafft_log + "--- end MAFFT log ---";
+		} else {
+			full += "\n(captured MAFFT log was empty)";
+		}
+		throw std::runtime_error(full);
+	}
+
+	MafftAlignResult result;
+	result.names = names;
+	result.comments = comments;
+	result.aligned_length = out->aligned_len;
+	result.sequences.reserve(n);
+	result.original_lengths.reserve(n);
 	for (int i = 0; i < n; i++) {
-		free(seqgui[i]);
-		free(namegui[i]);
+		std::string aligned(out->seqs[i]);
+		restore_case(sequences[i], aligned);
+		result.sequences.push_back(std::move(aligned));
+		result.original_lengths.push_back(static_cast<int>(sequences[i].size()));
 	}
-	free(seqgui);
-	free(namegui);
-	for (int i = 0; i < argc_m; i++) {
-		free(argv_m[i]);
-	}
-	free(argv_m);
-
-	if (result != 0) {
-		throw std::runtime_error("MAFFT alignment failed with error code " + std::to_string(result));
-	}
-
-	return align_result;
+	mafft_output_free(out);
+	return result;
 }
 
 } // namespace miint

--- a/src/align_mafft.cpp
+++ b/src/align_mafft.cpp
@@ -7,6 +7,7 @@
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include <unordered_set>
 
 namespace duckdb {
@@ -25,6 +26,11 @@ struct AlignMafftGlobalState : public PerSampleGlobalState {
 	std::vector<std::string> sequences;
 	std::vector<int32_t> original_lengths;
 	int32_t aligned_length = 0;
+
+	// Forwarded to MAFFT's internal pthread pool (cfg.n_threads). Distinct
+	// from PerSampleGlobalState::max_threads, which controls duckdb-side
+	// concurrency over the process-wide MAFFT mutex.
+	int mafft_threads = 1;
 };
 
 struct AlignMafftLocalState : public LocalTableFunctionState {
@@ -46,7 +52,8 @@ struct AlignMafftLocalState : public LocalTableFunctionState {
 // only when present so single-sample users get clean diagnostics.
 static void ValidateAndAlignInto(const std::string &sample_literal, LoadedSingleEndSequences &loaded,
                                  std::vector<std::string> &out_names, std::vector<std::string> &out_sequences,
-                                 std::vector<int32_t> &out_original_lengths, int32_t &out_aligned_length) {
+                                 std::vector<int32_t> &out_original_lengths, int32_t &out_aligned_length,
+                                 int n_threads) {
 	bool is_sample = !sample_literal.empty();
 	auto sample_ctx = is_sample ? (" in sample " + sample_literal) : std::string();
 
@@ -72,7 +79,7 @@ static void ValidateAndAlignInto(const std::string &sample_literal, LoadedSingle
 
 	std::vector<std::string> comments(loaded.labels.size(), "");
 	miint::MafftAligner aligner;
-	auto result = aligner.align(loaded.labels, comments, loaded.sequences);
+	auto result = aligner.align(loaded.labels, comments, loaded.sequences, n_threads);
 
 	out_names = std::move(result.names);
 	out_sequences = std::move(result.sequences);
@@ -134,10 +141,17 @@ static unique_ptr<GlobalTableFunctionState> AlignMafftInitGlobal(ClientContext &
 	auto &data = input.bind_data->Cast<AlignMafftData>();
 	auto gstate = make_uniq<AlignMafftGlobalState>();
 
+	// Hand the duckdb-configured thread budget to MAFFT's internal pool.
+	// Independent of max_threads (which gates duckdb-side concurrency over
+	// the MAFFT mutex); MAFFT's own pthreads run inside a single align call.
+	auto db_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
+	gstate->mafft_threads = db_threads > 0 ? NumericCast<int>(db_threads) : 1;
+
 	if (data.has_sample_id) {
-		// MAFFT holds a process-wide mutex — running multiple threads would only
-		// queue them behind the same lock. Force serial to avoid the illusion of
-		// parallelism.
+		// MAFFT holds a process-wide mutex — running multiple duckdb threads
+		// would only queue them behind the same lock. Force serial to avoid
+		// the illusion of parallelism. (MAFFT itself still threads internally
+		// via gstate->mafft_threads.)
 		InitPerSampleGlobal(context, *gstate, data.sample_info.sample_values.size(), /*max_threads_hint=*/1);
 		return gstate;
 	}
@@ -146,7 +160,7 @@ static unique_ptr<GlobalTableFunctionState> AlignMafftInitGlobal(ClientContext &
 
 	auto loaded = LoadSingleEndSequences(context, data.table_name, "align_mafft", /*strict=*/true);
 	ValidateAndAlignInto(/*sample_literal=*/"", loaded, gstate->names, gstate->sequences, gstate->original_lengths,
-	                     gstate->aligned_length);
+	                     gstate->aligned_length, gstate->mafft_threads);
 
 	return gstate;
 }
@@ -230,7 +244,7 @@ static void AlignMafftExecute(ClientContext & /*context*/, TableFunctionInput &d
 		auto where_sql = "CAST(" + q_col + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR)";
 		auto loaded = LoadSingleEndSequences(*lstate.conn, data.table_name, "align_mafft", /*strict=*/true, where_sql);
 		ValidateAndAlignInto(sample_literal, loaded, lstate.names, lstate.sequences, lstate.original_lengths,
-		                     lstate.aligned_length);
+		                     lstate.aligned_length, gstate.mafft_threads);
 		lstate.current_row = 0;
 	}
 }

--- a/src/include/MafftAligner.hpp
+++ b/src/include/MafftAligner.hpp
@@ -23,10 +23,13 @@ public:
 	MafftAligner(MafftAligner &&) noexcept;
 	MafftAligner &operator=(MafftAligner &&) noexcept;
 
-	// Align sequences using MAFFT PartTree algorithm.
-	// Thread safety: protected by internal mutex (single alignment at a time, process-wide).
+	// Align sequences using MAFFT (auto strategy: FFT-NS-2 for nseq < 200k,
+	// PartTree above). n_threads is forwarded to MAFFT's internal pthread
+	// pool; use 1 to disable. Thread safety: protected by internal mutex —
+	// only one alignment may run at a time process-wide because MAFFT uses
+	// ~150 globals.
 	MafftAlignResult align(const std::vector<std::string> &names, const std::vector<std::string> &comments,
-	                       const std::vector<std::string> &sequences);
+	                       const std::vector<std::string> &sequences, int n_threads = 1);
 
 private:
 	struct Impl;

--- a/test/cpp/test_MafftAligner.cpp
+++ b/test/cpp/test_MafftAligner.cpp
@@ -191,10 +191,12 @@ TEST_CASE("MafftAligner - Reuse", "[MafftAligner]") {
 
 // Cycle 2.7: Reference correctness — 36 protein opsin sequences
 // Input: data/mafft/sample.fa (36 opsin sequences from MAFFT test suite)
-// Reference: splittbfast -P ... produces 36 aligned sequences of length 732.
-// Verified that the sorted set of aligned sequences is byte-identical between
-// the binary and library. The aligned_length of 732 is a deterministic property
-// of this specific input + parameter combination.
+// MafftAligner now drives MAFFT through MAFFT_STRATEGY_AUTO (FFT-NS-2 for
+// inputs of this size, not PartTree). The exact aligned width is therefore
+// algorithm-dependent and may differ from the historical PartTree value of
+// 732. The invariants we still assert are: (a) 36 output rows; (b) all rows
+// share a common width; (c) ungapped content is byte-identical to the input
+// after case restoration.
 TEST_CASE("MafftAligner - Sample dataset", "[MafftAligner]") {
 	MafftAligner aligner;
 
@@ -204,11 +206,10 @@ TEST_CASE("MafftAligner - Sample dataset", "[MafftAligner]") {
 	auto result = aligner.align(names, comments, seqs);
 
 	REQUIRE(result.sequences.size() == 36);
-	// Exact expected aligned length (verified against binary output)
-	REQUIRE(result.aligned_length == 732);
-	// All aligned sequences have the same length
+	REQUIRE(result.aligned_length > 0);
+	// All aligned sequences share the reported aligned_length
 	for (const auto &s : result.sequences) {
-		REQUIRE(s.size() == 732);
+		REQUIRE(s.size() == static_cast<size_t>(result.aligned_length));
 	}
 	// Ungapped content must match original input (case-preserved)
 	for (size_t i = 0; i < result.sequences.size(); i++) {

--- a/test/sql/align_mafft.test
+++ b/test/sql/align_mafft.test
@@ -130,7 +130,12 @@ SELECT typeof(sequence_index) FROM align_mafft('tiny') LIMIT 1;
 BIGINT
 
 # --- sample_tbl: 36 opsin protein sequences ---
-# Expected aligned_length = 732 (verified against splittbfast binary output)
+# Expected aligned_length = 701 under single-threaded FFTNSI (the strategy
+# AUTO selects for n=36 protein sequences). Multi-threaded FFTNSI is
+# non-deterministic (disttbfast's parallel heuristic) and produces widths
+# in the 705-720 range, so we pin a thread count for this section.
+statement ok
+SET threads = 1;
 
 query I
 SELECT COUNT(*) FROM align_mafft('sample_tbl');
@@ -140,7 +145,7 @@ SELECT COUNT(*) FROM align_mafft('sample_tbl');
 query I
 SELECT DISTINCT aligned_length FROM align_mafft('sample_tbl');
 ----
-732
+701
 
 # Ungapped content matches original input: every aligned sequence (with gaps
 # removed) appears in the input. Set-based check — robust to duplicate or


### PR DESCRIPTION
Switches MafftAligner from the single-threaded splittbfast_library() PartTree path to the public mafft_api.h surface with strategy=MAFFT_STRATEGY_AUTO and n_threads plumbed from TaskScheduler::NumberOfThreads(). For the n<500 + len<10000 inputs that dominate duckdb-miint usage, AUTO resolves to FFTNSI which dispatches to disttbfast's parallel implementation.

Bumps ext/mafft 3a1c238 -> 956a103, picking up four upstream fixes that this path depends on: -C argv builder fix, extern "C" guards on mafft_api.h, FFTNSI-on-protein MAFFT_ERR_INTERNAL fix, FFTNSI repeated-growing-N segfault fix, and FFTNSI per-row truncation fix.

MafftAligner failure path now retrieves mafft_ctx_log() and appends the captured MAFFT stderr to the runtime exception, so future regressions surface diagnosable output instead of a bare "code -3".

test/sql/align_mafft.test pins threads=1 for the sample_tbl section because multi-threaded FFTNSI is non-deterministic by design (disttbfast's parallel heuristic). Single-threaded width is 701; the historical PartTree value of 732 no longer applies. test_MafftAligner.cpp drops the brittle aligned_length==732 equality and asserts the same-width-across-rows invariant instead.