### PR TITLE
feat: expose threads parameter on vsearch table functions

### DIFF
--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -2323,6 +2323,7 @@ Reference-based chimera detection using the UCHIME algorithm (Edgar et al. 2011,
 - `dn` (DOUBLE, default 1.4): Pseudo-count prior on "no" votes. Must be >= 0.
 - `mindiv` (DOUBLE, default 0.8): Minimum divergence (percentage points) from closest parent. Must be >= 0.
 - `mindiffs` (INTEGER, default 3): Minimum number of diffs in each segment (left and right). Must be >= 1.
+- `threads` (INTEGER, optional): Number of threads vsearch uses for the internal `chimera_detect_batch` parallel scan. Defaults to DuckDB's configured thread count (`SET threads=N`) at bind time; pass an explicit value to override. Must be 1–1024 (matching vsearch's CLI ceiling).
 
 **Output schema (18 columns, compatible with vsearch `--uchimeout`):**
 
@@ -2370,7 +2371,7 @@ SELECT flag, count(*) FROM detect_chimera_uchime('queries', db:='refs') GROUP BY
 - One output row per query sequence (all queries are reported, not just chimeras)
 - Non-chimeric sequences (flag=`N`) have NULL for parent and identity columns, and 0 for vote columns
 - `id_a_b` (parent A vs parent B identity) is only computed for chimeric (`Y`) and borderline (`?`) results. Non-chimeric results report `id_a_b=0.0`. This avoids an extra pairwise alignment per query that is not needed for classification. Note: vsearch computes `id_a_b` for all queries unconditionally.
-- Multi-threaded: queries are processed in parallel with per-thread WFA2 aligners
+- Multi-threaded: vsearch's internal `chimera_detect_batch` parallelizes across the `threads` parameter (defaults to DuckDB's configured thread count; override per-call with `threads:=N`)
 - The reference database is fully materialized in memory at init time
 - Tables and views are both supported for query and reference inputs
 
@@ -2402,7 +2403,7 @@ De novo chimera detection using the UCHIME algorithm, powered by the [vsearch](h
 - `sequence_col` (VARCHAR, default `'sequence1'`): Name of the sequence column.
 - `count_col` (VARCHAR, default `'size'`): Name of the per-sequence count column. Set to `'abundance'` to chain `deblur(...)` directly into this function.
 - `abskew` (DOUBLE, default 2.0): Abundance skew. Candidate parents must have abundance >= abskew * query abundance. Must be >= 1.0.
-- `minh`, `xn`, `dn`, `mindiv`, `mindiffs`: Same as `detect_chimera_uchime`.
+- `minh`, `xn`, `dn`, `mindiv`, `mindiffs`: Same as `detect_chimera_uchime`. (No `threads` parameter — de novo detection is sequential by construction; vsearch is run with `opt_threads=1`.)
 
 **Output schema:** Same 18 columns as `detect_chimera_uchime`.
 
@@ -2450,6 +2451,7 @@ Global pairwise sequence search, powered by the [vsearch](https://github.com/tor
 - `id` (DOUBLE, required): Minimum identity threshold (0.0-1.0). No silent default — must be specified explicitly.
 - `maxaccepts` (INTEGER, default 1): Maximum number of accepted hits per query. Must be >= 1.
 - `maxrejects` (INTEGER, default 32): Maximum rejected targets before stopping search. Must be >= 1.
+- `threads` (INTEGER, optional): Number of threads vsearch uses for its internal `search_batch` parallel scan. Defaults to DuckDB's configured thread count (`SET threads=N`) at bind time; pass an explicit value to override. Must be 1–1024 (matching vsearch's CLI ceiling).
 
 **Output schema:**
 
@@ -2485,7 +2487,7 @@ SELECT count(DISTINCT read_id) FROM search_sequences_vsearch('queries', db:='ref
 - Each query produces 0 to `maxaccepts` output rows
 - Results include both accepted (above threshold) and weak (near-miss) hits; use the `accepted` column to filter
 - Plus-strand only (no reverse complement search)
-- Multi-threaded: up to 8 threads for parallel query searching
+- Multi-threaded: vsearch's internal `search_batch` parallelizes across the `threads` parameter (defaults to DuckDB's configured thread count; override per-call with `threads:=N`)
 - Reference database is fully materialized in memory at init time
 - RNA sequences (U) are automatically converted to DNA (T)
 
@@ -2505,6 +2507,7 @@ Greedy sequence clustering, powered by the [vsearch](https://github.com/torognes
 - `input_table` (VARCHAR): Name of a table or view containing sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns.
 - `id` (DOUBLE, required): Minimum identity threshold (0.0-1.0). No silent default — must be specified explicitly.
 - `strand` (VARCHAR, default `'plus'`): `'plus'` for plus-strand only, `'both'` to also search reverse complements.
+- `threads` (INTEGER, optional): Number of threads vsearch uses for its internal `cluster_assign_batch` parallel scan. Defaults to DuckDB's configured thread count (`SET threads=N`) at bind time; pass an explicit value to override. Must be 1–1024 (matching vsearch's CLI ceiling).
 
 **Output schema:**
 

--- a/src/VsearchChimeraWrapper.cpp
+++ b/src/VsearchChimeraWrapper.cpp
@@ -169,7 +169,22 @@ void VsearchChimeraWrapper::init_common(bool denovo) {
 	opt_mindiv = params_.mindiv;
 	opt_mindiffs = params_.mindiffs;
 	// abskew: set explicitly in both modes to avoid depending on vsearch defaults.
-	opt_abskew = denovo ? params_.abskew : 0.0;
+	// Ref mode: 1.0 (not 0.0) because chimera_detect_batch's chimera_session_init
+	// runs the denovo branch (opt_uchime_ref is null in the library API path) and
+	// computes opt_maxsizeratio = 1.0/opt_abskew. With opt_abskew=0.0 that's +inf
+	// (UB-adjacent IEEE math); with 1.0 it's 1.0, and our query/target abundances
+	// are hardcoded to 1 in VsearchBatchArgs/db_add so the skew filter passes.
+	opt_abskew = denovo ? params_.abskew : 1.0;
+	// opt_threads must be set before fixups: fixups resolve 0 → arch_get_cores().
+	// De novo is sequential by construction in our caller (one detect_denovo
+	// per query, then index_sequence) — clamp to 1 so vsearch internals don't
+	// over-allocate. Reference mode passes the user/DuckDB thread count through
+	// to chimera_detect_batch's internal pool.
+	if (denovo) {
+		opt_threads = 1;
+	} else if (params_.threads > 0) {
+		opt_threads = params_.threads;
+	}
 	vsearch_apply_defaults_fixups();
 
 	// Step 4-5: load DB (caller finishes index setup after this)

--- a/src/VsearchClusterWrapper.cpp
+++ b/src/VsearchClusterWrapper.cpp
@@ -107,6 +107,10 @@ void VsearchClusterWrapper::set_sequences(const std::vector<std::string> &labels
 	opt_strand = params_.strand;
 	opt_maxaccepts = 1;
 	opt_maxrejects = 32;
+	// opt_threads must be set before fixups: fixups resolve 0 → arch_get_cores().
+	if (params_.threads > 0) {
+		opt_threads = params_.threads;
+	}
 	vsearch_apply_defaults_fixups();
 
 	// Step 4: load DB

--- a/src/VsearchSearchWrapper.cpp
+++ b/src/VsearchSearchWrapper.cpp
@@ -183,6 +183,10 @@ void VsearchSearchWrapper::set_database(const std::vector<std::string> &labels,
 	opt_id = params_.id;
 	opt_maxaccepts = params_.maxaccepts;
 	opt_maxrejects = params_.maxrejects;
+	// opt_threads must be set before fixups: fixups resolve 0 → arch_get_cores().
+	if (params_.threads > 0) {
+		opt_threads = params_.threads;
+	}
 	vsearch_apply_defaults_fixups();
 
 	// Step 4: load DB

--- a/src/cluster_sequences.cpp
+++ b/src/cluster_sequences.cpp
@@ -3,6 +3,7 @@
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/vector_size.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 #include <algorithm>
 
@@ -104,6 +105,23 @@ unique_ptr<FunctionData> ClusterSequencesTableFunction::Bind(ClientContext &cont
 		}
 	}
 
+	auto get_int = [&](const std::string &name, int &out, int min_val, int max_val, const char *constraint) {
+		auto it = input.named_parameters.find(name);
+		if (it != input.named_parameters.end()) {
+			out = it->second.GetValue<int>();
+			if (out < min_val || out > max_val) {
+				throw InvalidInputException("cluster_sequences_vsearch: %s must be %s (got %d)", name, constraint, out);
+			}
+		}
+	};
+
+	// Default to DuckDB's configured thread count so `SET threads=N` is honored.
+	// Explicit `threads:=N` overrides. Capped at vsearch's CLI ceiling (n_threads_max
+	// = 1024 in ext/vsearch/src/vsearch.cc) so we fail with a clear message rather
+	// than blowing up inside pthread_create.
+	data->params.threads = NumericCast<int>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	get_int("threads", data->params.threads, 1, 1024, ">= 1 and <= 1024");
+
 	data->names = GetClusterOutputNames();
 	data->types = GetClusterOutputTypes();
 	for (auto &n : data->names) {
@@ -153,6 +171,7 @@ TableFunction ClusterSequencesTableFunction::GetFunction() {
 
 	tf.named_parameters["id"] = LogicalType::DOUBLE;
 	tf.named_parameters["strand"] = LogicalType::VARCHAR;
+	tf.named_parameters["threads"] = LogicalType::INTEGER;
 
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 

--- a/src/include/VsearchClusterWrapper.hpp
+++ b/src/include/VsearchClusterWrapper.hpp
@@ -11,6 +11,10 @@ namespace miint {
 struct ClusterParams {
 	double id = 0.0; // minimum identity threshold (0.0-1.0)
 	int strand = 1;  // 1 = plus only, 2 = both strands
+	// vsearch's internal thread pool for cluster_assign_batch. 0 = vsearch
+	// auto-detect (= all physical cores). Callers normally pass DuckDB's
+	// configured thread count so `SET threads=N` is honored.
+	int threads = 0;
 };
 
 // Single clustering assignment result.

--- a/src/include/VsearchSearchWrapper.hpp
+++ b/src/include/VsearchSearchWrapper.hpp
@@ -12,6 +12,10 @@ struct SearchParams {
 	double id = 0.0;     // minimum identity threshold (0.0-1.0)
 	int maxaccepts = 1;  // max accepted hits per query
 	int maxrejects = 32; // max rejected targets before stopping
+	// vsearch's internal thread pool for search_batch. 0 means "use vsearch's
+	// auto-detect" (= all physical cores). Callers normally pass DuckDB's
+	// configured thread count so that `SET threads=N` is honored.
+	int threads = 0;
 };
 
 // Single search hit result.

--- a/src/include/uchime_common.hpp
+++ b/src/include/uchime_common.hpp
@@ -17,6 +17,12 @@ struct UchimeParams {
 	double mindiv = 0.8;
 	int mindiffs = 3;
 	double abskew = 2.0; // only used in de novo mode
+	// vsearch's internal thread pool for chimera_detect_batch (uchime_ref).
+	// 0 = vsearch auto-detect (= all physical cores). Callers normally pass
+	// DuckDB's configured thread count so `SET threads=N` is honored. Ignored
+	// in de novo mode, which is sequential by construction (one query per call,
+	// then index_sequence) — denovo always runs with opt_threads=1.
+	int threads = 0;
 };
 
 // Full UCHIME result for a single query (mirrors vsearch --uchimeout 18 columns).

--- a/src/search_sequences.cpp
+++ b/src/search_sequences.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 #include <algorithm>
 
@@ -122,18 +123,24 @@ unique_ptr<FunctionData> SearchSequencesTableFunction::Bind(ClientContext &conte
 	// Validate ref table exists and has required columns
 	ValidateSequenceTableSchema(context, data->ref_table);
 
-	auto get_int = [&](const std::string &name, int &out, int min_val, const char *constraint) {
+	auto get_int = [&](const std::string &name, int &out, int min_val, int max_val, const char *constraint) {
 		auto it = input.named_parameters.find(name);
 		if (it != input.named_parameters.end()) {
 			out = it->second.GetValue<int>();
-			if (out < min_val) {
+			if (out < min_val || out > max_val) {
 				throw InvalidInputException("search_sequences_vsearch: %s must be %s (got %d)", name, constraint, out);
 			}
 		}
 	};
 
-	get_int("maxaccepts", data->params.maxaccepts, 1, ">= 1");
-	get_int("maxrejects", data->params.maxrejects, 1, ">= 1");
+	get_int("maxaccepts", data->params.maxaccepts, 1, INT32_MAX, ">= 1");
+	get_int("maxrejects", data->params.maxrejects, 1, INT32_MAX, ">= 1");
+	// Default to DuckDB's configured thread count so `SET threads=N` is honored.
+	// Explicit `threads:=N` overrides. Capped at vsearch's CLI ceiling (n_threads_max
+	// = 1024 in ext/vsearch/src/vsearch.cc) so we fail with a clear message rather
+	// than blowing up inside pthread_create.
+	data->params.threads = NumericCast<int>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	get_int("threads", data->params.threads, 1, 1024, ">= 1 and <= 1024");
 
 	data->names = GetSearchOutputNames();
 	data->types = GetSearchOutputTypes();
@@ -199,6 +206,7 @@ TableFunction SearchSequencesTableFunction::GetFunction() {
 	tf.named_parameters["id"] = LogicalType::DOUBLE;
 	tf.named_parameters["maxaccepts"] = LogicalType::INTEGER;
 	tf.named_parameters["maxrejects"] = LogicalType::INTEGER;
+	tf.named_parameters["threads"] = LogicalType::INTEGER;
 
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 

--- a/src/uchime_ref.cpp
+++ b/src/uchime_ref.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/main/database.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 #include <algorithm>
 
@@ -55,11 +56,11 @@ unique_ptr<FunctionData> UchimeRefTableFunction::Bind(ClientContext &context, Ta
 			}
 		}
 	};
-	auto get_int = [&](const std::string &name, int &out, int min_val, const char *constraint) {
+	auto get_int = [&](const std::string &name, int &out, int min_val, int max_val, const char *constraint) {
 		auto it = input.named_parameters.find(name);
 		if (it != input.named_parameters.end()) {
 			out = it->second.GetValue<int>();
-			if (out < min_val) {
+			if (out < min_val || out > max_val) {
 				throw InvalidInputException("detect_chimera_uchime: %s must be %s (got %d)", name, constraint, out);
 			}
 		}
@@ -69,7 +70,13 @@ unique_ptr<FunctionData> UchimeRefTableFunction::Bind(ClientContext &context, Ta
 	get_double("xn", data->params.xn, 1.0, ">= 1.0");
 	get_double("dn", data->params.dn, 0.0, ">= 0");
 	get_double("mindiv", data->params.mindiv, 0.0, ">= 0");
-	get_int("mindiffs", data->params.mindiffs, 1, ">= 1");
+	get_int("mindiffs", data->params.mindiffs, 1, INT32_MAX, ">= 1");
+	// Default to DuckDB's configured thread count so `SET threads=N` is honored.
+	// Explicit `threads:=N` overrides. Capped at vsearch's CLI ceiling (n_threads_max
+	// = 1024 in ext/vsearch/src/vsearch.cc) so we fail with a clear message rather
+	// than blowing up inside pthread_create.
+	data->params.threads = NumericCast<int>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	get_int("threads", data->params.threads, 1, 1024, ">= 1 and <= 1024");
 
 	auto sample_it = input.named_parameters.find("sample_id");
 	if (sample_it != input.named_parameters.end()) {
@@ -212,6 +219,7 @@ TableFunction UchimeRefTableFunction::GetFunction() {
 	tf.named_parameters["mindiv"] = LogicalType::DOUBLE;
 	tf.named_parameters["mindiffs"] = LogicalType::INTEGER;
 	tf.named_parameters["sample_id"] = LogicalType::VARCHAR;
+	tf.named_parameters["threads"] = LogicalType::INTEGER;
 
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 

--- a/test/sql/cluster_sequences.test
+++ b/test/sql/cluster_sequences.test
@@ -40,6 +40,22 @@ SELECT * FROM cluster_sequences_vsearch('dummy_seqs', id:=0.97, strand:='invalid
 ----
 'plus' or 'both'
 
+# Invalid threads (zero / negative / above vsearch's 1024 ceiling)
+statement error
+SELECT * FROM cluster_sequences_vsearch('dummy_seqs', id:=0.97, threads:=0);
+----
+>= 1 and <= 1024
+
+statement error
+SELECT * FROM cluster_sequences_vsearch('dummy_seqs', id:=0.97, threads:=-1);
+----
+>= 1 and <= 1024
+
+statement error
+SELECT * FROM cluster_sequences_vsearch('dummy_seqs', id:=0.97, threads:=2048);
+----
+>= 1 and <= 1024
+
 # Empty table
 statement ok
 CREATE TABLE empty_seqs AS SELECT read_id, sequence1 FROM dummy_seqs WHERE 1=0;
@@ -92,6 +108,60 @@ FROM cluster_sequences_vsearch('ident_seqs', id:=0.97)
 WHERE read_id = 's1';
 ----
 s1	1	0	s1	100.0	(empty)	0
+
+# Explicit threads:=N produces identical results.
+query TII
+SELECT read_id, is_centroid::int, cluster_id
+FROM cluster_sequences_vsearch('div_seqs', id:=0.97, threads:=1)
+ORDER BY read_id;
+----
+a	1	0
+b	1	1
+c	1	2
+
+query TII
+SELECT read_id, is_centroid::int, cluster_id
+FROM cluster_sequences_vsearch('div_seqs', id:=0.97, threads:=4)
+ORDER BY read_id;
+----
+a	1	0
+b	1	1
+c	1	2
+
+# threads:=1024 (vsearch's hard ceiling) is accepted at bind time. Clustering
+# is sequential by design (each centroid must be indexed before the next
+# query); only the per-query candidate scan is parallelizable internally.
+query TII
+SELECT read_id, is_centroid::int, cluster_id
+FROM cluster_sequences_vsearch('div_seqs', id:=0.97, threads:=1024)
+ORDER BY read_id;
+----
+a	1	0
+b	1	1
+c	1	2
+
+# Larger input set (>4 sequences) with threads:=4 — exercises vsearch's
+# parallel candidate scan during the assign phase.
+statement ok
+CREATE TABLE many_seqs AS
+SELECT 's' || (i + 1)::VARCHAR AS read_id,
+       CASE WHEN i % 3 = 0 THEN 'ATCGATCGATCGATCGATCGATCG'
+            WHEN i % 3 = 1 THEN 'GGCCTTAAGGCCTTAAGGCCTTAA'
+            ELSE 'AAAAAAAACCCCCCCCGGGGGGGG' END AS sequence1
+FROM range(0, 12) t(i);
+
+query I
+SELECT count(DISTINCT cluster_id)
+FROM cluster_sequences_vsearch('many_seqs', id:=0.97, threads:=4);
+----
+3
+
+# Default-threads path (no explicit threads:=N) returns identical results.
+query I
+SELECT count(DISTINCT cluster_id)
+FROM cluster_sequences_vsearch('many_seqs', id:=0.97);
+----
+3
 
 # Non-centroids have a CIGAR string
 query T
@@ -238,6 +308,9 @@ DROP TABLE ident_seqs;
 
 statement ok
 DROP TABLE div_seqs;
+
+statement ok
+DROP TABLE many_seqs;
 
 statement ok
 DROP VIEW div_view;

--- a/test/sql/search_sequences.test
+++ b/test/sql/search_sequences.test
@@ -61,6 +61,22 @@ SELECT * FROM search_sequences_vsearch('dummy_queries', db:='dummy_refs', id:=0.
 ----
 >= 1
 
+# Invalid threads (zero / negative / above vsearch's 1024 ceiling)
+statement error
+SELECT * FROM search_sequences_vsearch('dummy_queries', db:='dummy_refs', id:=0.97, threads:=0);
+----
+>= 1 and <= 1024
+
+statement error
+SELECT * FROM search_sequences_vsearch('dummy_queries', db:='dummy_refs', id:=0.97, threads:=-2);
+----
+>= 1 and <= 1024
+
+statement error
+SELECT * FROM search_sequences_vsearch('dummy_queries', db:='dummy_refs', id:=0.97, threads:=1025);
+----
+>= 1 and <= 1024
+
 # Empty ref table
 statement ok
 CREATE TABLE empty_refs AS SELECT read_id, sequence1 FROM dummy_refs WHERE 1=0;
@@ -103,6 +119,63 @@ ORDER BY read_id;
 ----
 qA	refA	100.0	true
 qB	refB	100.0	true
+
+# Explicit threads:=N produces identical results (smoke test for the parameter
+# being plumbed through; we don't assert vsearch's actual thread count since
+# that's internal — but the query must succeed and return the same rows).
+query TTRI
+SELECT read_id, target_id, identity, accepted
+FROM search_sequences_vsearch('syn_queries', db:='syn_refs', id:=0.97, threads:=1)
+ORDER BY read_id;
+----
+qA	refA	100.0	true
+qB	refB	100.0	true
+
+query TTRI
+SELECT read_id, target_id, identity, accepted
+FROM search_sequences_vsearch('syn_queries', db:='syn_refs', id:=0.97, threads:=4)
+ORDER BY read_id;
+----
+qA	refA	100.0	true
+qB	refB	100.0	true
+
+# threads:=1024 (vsearch's hard ceiling) is accepted at bind time. We don't
+# actually verify 1024 OS threads are spawned — vsearch clamps active threads
+# to min(queries, opt_threads), so with 2 queries this only spawns 2 anyway.
+query TTRI
+SELECT read_id, target_id, identity, accepted
+FROM search_sequences_vsearch('syn_queries', db:='syn_refs', id:=0.97, threads:=1024)
+ORDER BY read_id;
+----
+qA	refA	100.0	true
+qB	refB	100.0	true
+
+# Larger query set so threads:=4 has > 4 queries to dispatch — exercises the
+# parallel path (vsearch's thread pool only activates when queries > 1).
+statement ok
+CREATE TABLE many_queries AS
+SELECT 'q' || (i + 1)::VARCHAR AS read_id,
+       CASE WHEN i % 3 = 0 THEN 'ATCGATCGATCGATCGATCGATCG'
+            WHEN i % 3 = 1 THEN 'GGCCTTAAGGCCTTAAGGCCTTAA'
+            ELSE 'AAAAAAAACCCCCCCCGGGGGGGG' END AS sequence1
+FROM range(0, 16) t(i);
+
+# All 16 queries should hit one of the 3 references.
+query I
+SELECT count(*)
+FROM search_sequences_vsearch('many_queries', db:='syn_refs', id:=0.97, threads:=4)
+WHERE accepted = true;
+----
+16
+
+# Default-threads path (no explicit threads:=N) returns identical results.
+# This validates the TaskScheduler::NumberOfThreads() default plumbing.
+query I
+SELECT count(*)
+FROM search_sequences_vsearch('many_queries', db:='syn_refs', id:=0.97)
+WHERE accepted = true;
+----
+16
 
 # Verify all output columns exist and have correct types
 query TTRIIIIIII
@@ -152,6 +225,9 @@ DROP TABLE syn_refs;
 
 statement ok
 DROP TABLE syn_queries;
+
+statement ok
+DROP TABLE many_queries;
 
 statement ok
 DROP TABLE div_queries;

--- a/test/sql/uchime_ref.test
+++ b/test/sql/uchime_ref.test
@@ -58,6 +58,21 @@ SELECT * FROM detect_chimera_uchime('queries', db:='refs', xn:=0.5);
 ----
 must be >= 1.0
 
+statement error
+SELECT * FROM detect_chimera_uchime('queries', db:='refs', threads:=0);
+----
+>= 1 and <= 1024
+
+statement error
+SELECT * FROM detect_chimera_uchime('queries', db:='refs', threads:=-3);
+----
+>= 1 and <= 1024
+
+statement error
+SELECT * FROM detect_chimera_uchime('queries', db:='refs', threads:=1500);
+----
+>= 1 and <= 1024
+
 # --- Basic functionality ---
 
 # Row count should equal number of query sequences (8)
@@ -143,6 +158,35 @@ WHERE read_id = 'query_chimera1';
 true	true
 
 # Count chimeras
+query I
+SELECT count(*) FROM detect_chimera_uchime('queries', db:='refs') WHERE flag = 'Y';
+----
+4
+
+# Explicit threads:=N produces identical results. The 8-query fixture has
+# enough rows that threads:=4 actually exercises the parallel chimera_detect_batch
+# path (vsearch dispatches min(queries, opt_threads) workers).
+query I
+SELECT count(*) FROM detect_chimera_uchime('queries', db:='refs', threads:=1) WHERE flag = 'Y';
+----
+4
+
+query I
+SELECT count(*) FROM detect_chimera_uchime('queries', db:='refs', threads:=4) WHERE flag = 'Y';
+----
+4
+
+# threads:=1024 (vsearch's hard ceiling) is accepted at bind time. vsearch
+# clamps active threads to min(queries, opt_threads), so this only spawns 8.
+query I
+SELECT count(*) FROM detect_chimera_uchime('queries', db:='refs', threads:=1024) WHERE flag = 'Y';
+----
+4
+
+# Default-threads path (no explicit threads:=N) returns identical results.
+# This validates the TaskScheduler::NumberOfThreads() default plumbing — the
+# basic "Row count should equal number of query sequences" assertion above
+# already exercises this implicitly, but call it out explicitly here.
 query I
 SELECT count(*) FROM detect_chimera_uchime('queries', db:='refs') WHERE flag = 'Y';
 ----


### PR DESCRIPTION
vsearch's internal thread pool reads opt_threads, which was left at vsearch's default (auto-detect = all cores) regardless of DuckDB's SET threads. Add a threads named parameter to search_sequences_vsearch, cluster_sequences_vsearch, and detect_chimera_uchime that defaults to TaskScheduler::NumberOfThreads() and overrides opt_threads between vsearch_init_defaults() and the fixups that would otherwise resolve 0 to arch_get_cores(). Validated 1..1024 (matching vsearch's CLI n_threads_max).

detect_chimera_uchime_denovo and merge_pairs_vsearch are not threaded internally and don't get the parameter; the chimera wrapper now defensively pins opt_threads=1 in denovo mode.

Also fix a latent IEEE-math hazard in the chimera ref path: opt_abskew was set to 0.0 in ref mode, so chimera_session_init's opt_maxsizeratio = 1.0 / opt_abskew computed +inf. Set opt_abskew=1.0 in ref mode instead — query and target abundances are hardcoded to 1 in our wrapper, so the skew filter behaves identically without the divide-by-zero.