### PR TITLE
fix: populate read_id and flag for uchime_ref no_alignment results

### DIFF
--- a/src/VsearchChimeraWrapper.cpp
+++ b/src/VsearchChimeraWrapper.cpp
@@ -75,7 +75,7 @@ UchimeResult VsearchChimeraWrapper::DetectHandle::detect(const std::string &quer
 	                      1, // abundance = 1 for uchime_ref
 	                      &vsearch_result);
 
-	return convert_result(&vsearch_result);
+	return convert_result(&vsearch_result, query_label);
 }
 
 // ============================================================================
@@ -278,15 +278,25 @@ void VsearchChimeraWrapper::index_sequence(uint64_t seqno) {
 	dbindex_addsequence(static_cast<unsigned int>(seqno), opt_dbmask);
 }
 
-UchimeResult VsearchChimeraWrapper::convert_result(const void *vsearch_result_ptr) {
+UchimeResult VsearchChimeraWrapper::convert_result(const void *vsearch_result_ptr, const std::string &fallback_label) {
 	const auto *r = static_cast<const chimera_result_s *>(vsearch_result_ptr);
+
+	// STOPGAP for upstream vsearch bug: chimera_detect_single only writes the
+	// result struct on Status::no_parents / low_score / suspicious / chimeric.
+	// On Status::no_alignment (eval_parents finds best_h < 0) it leaves the
+	// memset(0) state intact, so flag is '\0' and query_label is empty. Treat
+	// that case as a non-chimeric ('N') row using the input label. Remove this
+	// fallback once vsearch fixes chimera_detect_single — see
+	// localdocs/BUG-vsearch-chimera-detect-single-no-alignment.md.
+	const bool unfilled = (r->flag == '\0');
+	const char effective_flag = unfilled ? 'N' : r->flag;
 
 	UchimeResult result;
 	result.score = r->score;
-	result.query_label = r->query_label;
-	result.flag = std::string(1, r->flag);
+	result.query_label = unfilled ? fallback_label : std::string(r->query_label);
+	result.flag = std::string(1, effective_flag);
 
-	if (r->flag == 'N') {
+	if (effective_flag == 'N') {
 		return result;
 	}
 
@@ -327,7 +337,7 @@ void VsearchChimeraWrapper::detect_batch(const std::vector<std::string> &query_l
 	                     raw_results.data());
 
 	for (int i = 0; i < args.count; i++) {
-		output.push_back(convert_result(&raw_results[i]));
+		output.push_back(convert_result(&raw_results[i], query_labels[i]));
 	}
 }
 
@@ -345,7 +355,7 @@ UchimeResult VsearchChimeraWrapper::detect_denovo(const std::string &query_label
 	chimera_detect_single(state_->ci, seq.c_str(), query_label.c_str(), static_cast<int>(seq.size()),
 	                      static_cast<int>(query_abundance), &vsearch_result);
 
-	return convert_result(&vsearch_result);
+	return convert_result(&vsearch_result, query_label);
 }
 
 } // namespace miint

--- a/src/include/VsearchChimeraWrapper.hpp
+++ b/src/include/VsearchChimeraWrapper.hpp
@@ -110,7 +110,10 @@ private:
 	static void load_sequences_into_db(const std::vector<std::string> &labels,
 	                                   const std::vector<std::string> &sequences,
 	                                   const std::vector<int64_t> &abundances);
-	static UchimeResult convert_result(const void *vsearch_result);
+	// fallback_label is used when the upstream vsearch library leaves the
+	// result struct memset-zero (Status::no_alignment path in
+	// chimera_detect_single — see localdocs/BUG-vsearch-chimera-detect-single-no-alignment.md).
+	static UchimeResult convert_result(const void *vsearch_result, const std::string &fallback_label);
 };
 
 } // namespace miint


### PR DESCRIPTION
## Summary

- vsearch's `chimera_detect_single` leaves the result struct memset-zero on `Status::no_alignment` (eval_parents finds `best_h < 0`). Affected ~10% of rows on a 100k-query × 15k-ref 16S workload — empty `read_id`, `flag = '\0'`, all numerics 0.
- Stopgap in `VsearchChimeraWrapper::convert_result`: detect `r->flag == '\0'` as the unfilled sentinel and substitute the input label with `flag = 'N'` (the documented non-chimeric value). All three call sites (`DetectHandle::detect`, `detect_batch`, `detect_denovo`) pass the input label as the fallback.
- Comment block marks this as a workaround pending an upstream vsearch fix in `chimera_detect_single` itself.

## Test plan

- [x] C++ tests: `tests "[VsearchChimera]"` — 3 cases / 61 assertions pass
- [x] SQL tests (with `VSEARCH_AVAILABLE=1`):
  - [x] `uchime_ref.test` — 78 assertions
  - [x] `uchime_ref_sample_id.test` — 71 assertions
  - [x] `uchime_denovo.test` — 56 assertions
  - [x] `uchime_denovo_sample_id.test` — 94 assertions
  - [x] `uchime_denovo_column_overrides.test` — 52 assertions
  - [x] `uchime_ref_realworld.test` — 26 assertions
- [x] `make format-check` clean
- [ ] Re-run reporter's 100k-query workload and confirm previously-empty rows now carry `read_id` and `flag = 'N'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)