### PR TITLE
fix(rype): anchor read_id<->sequence correspondence on a TEMP table

### DIFF
--- a/src/include/rype_classify.hpp
+++ b/src/include/rype_classify.hpp
@@ -72,12 +72,17 @@ public:
 		// 1. current_chunk (shared_ptr — may outlive gstate via Vector ArrowAuxiliaryData)
 		// 2. arrow_table - holds pointers INTO output_schema, clear before releasing schema
 		// 3. output_schema - obtained via get_schema(), separately owned copy, release on destruction
-		// 4. output_stream - returned by rype_classify_arrow(), release on destruction
-		// 5. tmp_table  - DROPPED via input_connection while it's still alive; the DROP must
-		//                 follow output_stream release so RYpe is no longer consuming the
-		//                 stream-backed QueryResult that references the temp table's catalog state.
-		// 6. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
-		//                       and the DROP TABLE step above.
+		// 4. output_stream - returned by rype_classify_arrow(), release on destruction.
+		//                    Until released, RYpe may still pull from the input Arrow stream
+		//                    wrapper, which holds a non-owning ClientContext pointer into
+		//                    input_connection — so this must be released before the DROP and
+		//                    before input_connection.reset().
+		// 4a. negative_set / index - rype_negative_set_free / rype_index_free; safe any time
+		//                    after output_stream.release returns (RYpe is done with them).
+		// 5. tmp_table - DROPPED on input_connection (which owns the per-call TEMP). Must run
+		//                while input_connection is alive AND after step 4 returns, since
+		//                step 4 can re-enter the connection through RYpe's stream callbacks.
+		// 6. input_connection - reset last; outlives steps 4 and 5.
 		ArrowArrayStream output_stream;
 		ArrowSchema output_schema;
 		ArrowTableSchema arrow_table;

--- a/src/include/rype_classify.hpp
+++ b/src/include/rype_classify.hpp
@@ -60,13 +60,24 @@ public:
 		// in the destructor AFTER releasing RYpe streams.
 		unique_ptr<Connection> input_connection;
 
+		// Name of the per-call TEMP table that materializes (id, read_id, sequence1,
+		// sequence2?) once on input_connection. Populated by InitGlobal; the
+		// destructor drops the table before tearing down input_connection. Empty
+		// when no temp table was created (e.g., construction failed before the
+		// CREATE TEMP TABLE).
+		std::string tmp_table_name;
+
 		// Arrow output stream from RYpe.
 		// OWNERSHIP HIERARCHY (destruction must be in reverse order):
 		// 1. current_chunk (shared_ptr — may outlive gstate via Vector ArrowAuxiliaryData)
 		// 2. arrow_table - holds pointers INTO output_schema, clear before releasing schema
 		// 3. output_schema - obtained via get_schema(), separately owned copy, release on destruction
 		// 4. output_stream - returned by rype_classify_arrow(), release on destruction
-		// 5. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
+		// 5. tmp_table  - DROPPED via input_connection while it's still alive; the DROP must
+		//                 follow output_stream release so RYpe is no longer consuming the
+		//                 stream-backed QueryResult that references the temp table's catalog state.
+		// 6. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
+		//                       and the DROP TABLE step above.
 		ArrowArrayStream output_stream;
 		ArrowSchema output_schema;
 		ArrowTableSchema arrow_table;

--- a/src/include/rype_common.hpp
+++ b/src/include/rype_common.hpp
@@ -6,11 +6,14 @@
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/common/arrow/arrow_wrapper.hpp"
+#include "duckdb/common/arrow/result_arrow_wrapper.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/function/table/arrow.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/client_context.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
 
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
@@ -115,6 +118,116 @@ inline bool ValidateSequenceTable(ClientContext &context, const std::string &tab
 	}
 
 	return has_seq2;
+}
+
+// ============================================================================
+// Shared input pipeline for RYpe table functions (the row-index ↔ read_id fix).
+// ============================================================================
+//
+// Background: rype_classify, rype_extract_*, and rype_log_ratio all need to
+// build (a) a vector of read_ids indexed by a synthetic id and (b) an Arrow
+// stream of (id, sequence, [pair_sequence]) for RYpe to consume. The naive
+// approach of issuing two independent SELECTs against the user's
+// sequence_table corrupts the correspondence whenever the two scans see rows
+// in different orders (multi-threaded scans, views, parquet sources,
+// preserve_insertion_order=false). The helpers below materialize the source
+// once into a per-call TEMP table with an explicit id column, then read
+// read_ids and stream sequences from that same table ORDER BY id — the id
+// column is now a stable attribute of the data, not an emergent property of
+// independent scans.
+//
+// Usage pattern (in InitGlobal, on a per-GlobalState sub-Connection):
+//
+//   gstate->tmp_table_name = MaterializeRypeInputTempTable(
+//       conn, table_quoted, id_col_quoted, source_name_for_errors,
+//       has_sequence2, "_rype_classify_", gstate->read_ids,
+//       avg_read_length);
+//   // ... compute batch_size from avg_read_length ...
+//   auto wrapper = BuildRypeArrowInput(conn, gstate->tmp_table_name,
+//                                      /*include_pair_column=*/true,
+//                                      batch_size);
+//   ArrowArrayStream *input_stream = &wrapper->stream;
+//   // hand input_stream to rype_*_arrow(); on success, wrapper.release().
+//
+// The destructor must call DropRypeTempTable(*input_connection,
+// gstate->tmp_table_name) AFTER releasing the RYpe output stream and BEFORE
+// resetting input_connection.
+
+//! Materialize the user's sequence_table into a per-call TEMP table on `conn`,
+//! populate `out_read_ids` from it ordered by the synthetic id, and sample the
+//! average read length for batch-size estimation. Returns the name of the
+//! created TEMP table; the caller must store this and drop it later via
+//! DropRypeTempTable.
+//!
+//! `source_name_for_errors` is the user-facing source-table name (unquoted);
+//! used only in error messages.
+//! `name_prefix` is the per-function debug prefix (e.g. "_rype_classify_").
+inline std::string MaterializeRypeInputTempTable(Connection &conn, const std::string &table_quoted,
+                                                 const std::string &id_col_quoted,
+                                                 const std::string &source_name_for_errors, bool has_sequence2,
+                                                 const std::string &name_prefix, std::vector<std::string> &out_read_ids,
+                                                 size_t &out_avg_read_length) {
+	std::string tmp_table_name = name_prefix + StringUtil::Replace(UUID::ToString(UUID::GenerateRandomUUID()), "-", "");
+	std::string tmp_quoted = KeywordHelper::WriteOptionallyQuoted(tmp_table_name);
+	std::string seq2_proj = has_sequence2 ? "sequence2" : "NULL::BLOB AS sequence2";
+	std::string create_sql = "CREATE TEMP TABLE " + tmp_quoted +
+	                         " AS SELECT (row_number() OVER () - 1)::BIGINT AS id, " + id_col_quoted +
+	                         " AS read_id, sequence1, " + seq2_proj + " FROM " + table_quoted;
+	auto create_result = conn.Query(create_sql);
+	if (create_result->HasError()) {
+		throw InvalidInputException("Failed to materialize sequence table '%s': %s", source_name_for_errors,
+		                            create_result->GetError());
+	}
+
+	std::string id_query = "SELECT read_id FROM " + tmp_quoted + " ORDER BY id";
+	auto id_result = conn.Query(id_query);
+	if (id_result->HasError()) {
+		throw InvalidInputException("Failed to read read_ids from temp table: %s", id_result->GetError());
+	}
+
+	out_read_ids.reserve(id_result->RowCount());
+	auto &id_materialized = id_result->Cast<MaterializedQueryResult>();
+	while (auto chunk = id_materialized.Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			out_read_ids.push_back(chunk->data[0].GetValue(i).ToString());
+		}
+	}
+
+	out_avg_read_length = SampleAvgReadLength(conn, tmp_quoted);
+	return tmp_table_name;
+}
+
+//! Build the Arrow input stream RYpe will consume. Reads (id, sequence1, [sequence2])
+//! from the named TEMP table ordered by id. `include_pair_column` exposes a
+//! pair_sequence column (true for classify/log_ratio, false for extract).
+//!
+//! Caller transfers ownership of the returned wrapper to RYpe by calling
+//! .release() AFTER rype_*_arrow() succeeds; on failure, the unique_ptr's
+//! destructor cleans up the wrapper.
+inline unique_ptr<ResultArrowArrayStreamWrapper>
+BuildRypeArrowInput(Connection &conn, const std::string &tmp_table_name, bool include_pair_column, size_t batch_size) {
+	std::string tmp_quoted = KeywordHelper::WriteOptionallyQuoted(tmp_table_name);
+	std::string select_cols = include_pair_column
+	                              ? std::string("id, sequence1::BLOB AS sequence, sequence2::BLOB AS pair_sequence")
+	                              : std::string("id, sequence1::BLOB AS sequence");
+	std::string query = "SELECT " + select_cols + " FROM " + tmp_quoted + " ORDER BY id";
+	auto query_result = conn.Query(query);
+	if (query_result->HasError()) {
+		throw InvalidInputException("Failed to read from temp table: %s", query_result->GetError());
+	}
+	return make_uniq<ResultArrowArrayStreamWrapper>(std::move(query_result), batch_size);
+}
+
+//! Drop the per-call TEMP table on `conn`. Safe with empty name (no-op) and
+//! with a name that doesn't exist (uses IF EXISTS). Errors are silently
+//! ignored — this runs in destructors where we cannot usefully propagate
+//! failures, and the connection's catalog cleanup will reap the table on
+//! teardown anyway.
+inline void DropRypeTempTable(Connection &conn, const std::string &tmp_table_name) {
+	if (tmp_table_name.empty()) {
+		return;
+	}
+	conn.Query("DROP TABLE IF EXISTS " + KeywordHelper::WriteOptionallyQuoted(tmp_table_name));
 }
 
 } // namespace duckdb

--- a/src/include/rype_extract.hpp
+++ b/src/include/rype_extract.hpp
@@ -50,13 +50,22 @@ struct RypeExtractGlobalState : public GlobalTableFunctionState {
 	// in the destructor AFTER releasing RYpe streams.
 	unique_ptr<Connection> input_connection;
 
+	// Name of the per-call TEMP table that materializes (id, read_id, sequence1)
+	// once on input_connection. Populated by BuildExtractionInputStream; the
+	// destructor drops the table before tearing down input_connection.
+	std::string tmp_table_name;
+
 	// Arrow output stream from RYpe extraction.
 	// OWNERSHIP HIERARCHY (destruction must be in reverse order):
 	// 1. current_chunk (shared_ptr — may outlive gstate via Vector ArrowAuxiliaryData)
 	// 2. arrow_table (holds pointers into output_schema)
 	// 3. output_schema
 	// 4. output_stream
-	// 5. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
+	// 5. tmp_table  - DROPPED via input_connection while it's still alive; the DROP must
+	//                 follow output_stream release so RYpe is no longer consuming the
+	//                 stream-backed QueryResult that references the temp table's catalog state.
+	// 6. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
+	//                       and the DROP TABLE step above.
 	ArrowArrayStream output_stream;
 	ArrowSchema output_schema;
 	ArrowTableSchema arrow_table;

--- a/src/include/rype_extract.hpp
+++ b/src/include/rype_extract.hpp
@@ -60,12 +60,14 @@ struct RypeExtractGlobalState : public GlobalTableFunctionState {
 	// 1. current_chunk (shared_ptr — may outlive gstate via Vector ArrowAuxiliaryData)
 	// 2. arrow_table (holds pointers into output_schema)
 	// 3. output_schema
-	// 4. output_stream
-	// 5. tmp_table  - DROPPED via input_connection while it's still alive; the DROP must
-	//                 follow output_stream release so RYpe is no longer consuming the
-	//                 stream-backed QueryResult that references the temp table's catalog state.
-	// 6. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
-	//                       and the DROP TABLE step above.
+	// 4. output_stream - until released, RYpe may still pull from the input Arrow stream
+	//                    wrapper, which holds a non-owning ClientContext pointer into
+	//                    input_connection — so this must be released before the DROP and
+	//                    before input_connection.reset().
+	// 5. tmp_table - DROPPED on input_connection (which owns the per-call TEMP). Must run
+	//                while input_connection is alive AND after step 4 returns, since
+	//                step 4 can re-enter the connection through RYpe's stream callbacks.
+	// 6. input_connection - reset last; outlives steps 4 and 5.
 	ArrowArrayStream output_stream;
 	ArrowSchema output_schema;
 	ArrowTableSchema arrow_table;

--- a/src/include/rype_log_ratio.hpp
+++ b/src/include/rype_log_ratio.hpp
@@ -69,12 +69,17 @@ public:
 		// 1. current_chunk (shared_ptr — may outlive gstate via Vector ArrowAuxiliaryData)
 		// 2. arrow_table - holds pointers INTO output_schema, clear before releasing schema
 		// 3. output_schema - obtained via get_schema(), separately owned copy, release on destruction
-		// 4. output_stream - returned by rype_classify_arrow_log_ratio(), release on destruction
-		// 5. tmp_table  - DROPPED via input_connection while it's still alive; the DROP must
-		//                 follow output_stream release so RYpe is no longer consuming the
-		//                 stream-backed QueryResult that references the temp table's catalog state.
-		// 6. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
-		//                       and the DROP TABLE step above.
+		// 4. output_stream - returned by rype_classify_arrow_log_ratio(), release on destruction.
+		//                    Until released, RYpe may still pull from the input Arrow stream
+		//                    wrapper, which holds a non-owning ClientContext pointer into
+		//                    input_connection — so this must be released before the DROP and
+		//                    before input_connection.reset().
+		// 4a. numerator_index / denominator_index - rype_index_free; safe any time after
+		//                    output_stream.release returns (RYpe is done with them).
+		// 5. tmp_table - DROPPED on input_connection (which owns the per-call TEMP). Must run
+		//                while input_connection is alive AND after step 4 returns, since
+		//                step 4 can re-enter the connection through RYpe's stream callbacks.
+		// 6. input_connection - reset last; outlives steps 4 and 5.
 		ArrowArrayStream output_stream;
 		ArrowSchema output_schema;
 		ArrowTableSchema arrow_table;

--- a/src/include/rype_log_ratio.hpp
+++ b/src/include/rype_log_ratio.hpp
@@ -59,13 +59,22 @@ public:
 		// in the destructor AFTER releasing RYpe streams.
 		unique_ptr<Connection> input_connection;
 
+		// Name of the per-call TEMP table that materializes (id, read_id, sequence1,
+		// sequence2?) once on input_connection. Populated by InitGlobal; the
+		// destructor drops the table before tearing down input_connection.
+		std::string tmp_table_name;
+
 		// Arrow output stream from RYpe.
 		// OWNERSHIP HIERARCHY (destruction must be in reverse order):
 		// 1. current_chunk (shared_ptr — may outlive gstate via Vector ArrowAuxiliaryData)
 		// 2. arrow_table - holds pointers INTO output_schema, clear before releasing schema
 		// 3. output_schema - obtained via get_schema(), separately owned copy, release on destruction
 		// 4. output_stream - returned by rype_classify_arrow_log_ratio(), release on destruction
-		// 5. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
+		// 5. tmp_table  - DROPPED via input_connection while it's still alive; the DROP must
+		//                 follow output_stream release so RYpe is no longer consuming the
+		//                 stream-backed QueryResult that references the temp table's catalog state.
+		// 6. input_connection - must outlive output_stream (RYpe holds ref to input Arrow stream)
+		//                       and the DROP TABLE step above.
 		ArrowArrayStream output_stream;
 		ArrowSchema output_schema;
 		ArrowTableSchema arrow_table;

--- a/src/rype_classify.cpp
+++ b/src/rype_classify.cpp
@@ -1,6 +1,5 @@
 #include "rype_classify.hpp"
 #include "rype_common.hpp"
-#include "duckdb/common/arrow/result_arrow_wrapper.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/main/config.hpp"
@@ -40,6 +39,14 @@ RypeClassifyTableFunction::GlobalState::~GlobalState() {
 	// Free RYpe index
 	if (index) {
 		rype_index_free(index);
+	}
+
+	// Drop the materialized temp table BEFORE releasing the connection that owns
+	// it. The temp table is per-connection so teardown would clean it up
+	// implicitly, but the explicit drop releases memory sooner. DropRypeTempTable
+	// is a no-op if either is unset (e.g., bind failure).
+	if (input_connection) {
+		DropRypeTempTable(*input_connection, tmp_table_name);
 	}
 
 	// Release sub-connection LAST — RYpe's input stream (released above via
@@ -155,62 +162,29 @@ unique_ptr<GlobalTableFunctionState> RypeClassifyTableFunction::InitGlobal(Clien
 	std::string id_col_quoted = KeywordHelper::WriteOptionallyQuoted(bind_data.id_column);
 	std::string table_quoted = KeywordHelper::WriteOptionallyQuoted(bind_data.sequence_table);
 
-	// First, collect all read_ids in order. We use row indices (0-based) as query_id for RYpe,
-	// so read_ids[i] gives the original identifier for query_id=i.
-	std::string id_query = "SELECT " + id_col_quoted + " FROM " + table_quoted;
-	auto id_result = conn.Query(id_query);
-	if (id_result->HasError()) {
-		throw InvalidInputException("Failed to read from sequence table '%s': %s", bind_data.sequence_table,
-		                            id_result->GetError());
-	}
+	// Materialize the user's sequence_table into a per-call TEMP table with an
+	// explicit id column, then read read_ids and the sequence stream from it.
+	// See rype_common.hpp for the design rationale (row-index ↔ read_id fix).
+	size_t avg_read_length = 0;
+	gstate->tmp_table_name =
+	    MaterializeRypeInputTempTable(conn, table_quoted, id_col_quoted, bind_data.sequence_table,
+	                                  bind_data.has_sequence2, "_rype_classify_", gstate->read_ids, avg_read_length);
 
-	gstate->read_ids.reserve(id_result->RowCount());
-	auto &id_materialized = id_result->Cast<MaterializedQueryResult>();
-	while (auto chunk = id_materialized.Fetch()) {
-		for (idx_t i = 0; i < chunk->size(); i++) {
-			gstate->read_ids.push_back(chunk->data[0].GetValue(i).ToString());
-		}
-	}
-
-	// Step 4: Estimate batch size before the main sequence query.
-	// RYpe processes one batch at a time; using STANDARD_VECTOR_SIZE (2048) causes
-	// shard I/O to dominate. Sample actual average read length for accurate estimation.
-	size_t avg_read_length = SampleAvgReadLength(conn, table_quoted);
+	// Estimate batch size. RYpe processes one batch at a time; using
+	// STANDARD_VECTOR_SIZE (2048) causes shard I/O to dominate.
 	int is_paired = bind_data.has_sequence2 ? 1 : 0;
 	// is_large_binary=1: sub-connection uses arrow_large_buffer_size=true, so DuckDB
 	// exports BLOB as Arrow LargeBinary (i64 offsets) — no 2 GiB per-array limit.
 	size_t batch_size = rype_recommend_batch_size(gstate->index, avg_read_length, is_paired, 0, 1);
 	if (batch_size == 0) {
-		// rype_recommend_batch_size returns 0 on error — log but use safe fallback
 		const char *err = rype_get_last_error();
 		Printer::Print(StringUtil::Format("Warning: rype_recommend_batch_size failed (%s), using default",
 		                                  err ? err : "unknown error"));
 		batch_size = STANDARD_VECTOR_SIZE;
 	}
 
-	// Query sequence data for RYpe with row indices as id
-	// RYpe expects: id (Int64), sequence (Binary), pair_sequence (Binary nullable)
-	std::string query;
-	if (bind_data.has_sequence2) {
-		query = "SELECT (row_number() OVER () - 1)::BIGINT as id, sequence1::BLOB as sequence, "
-		        "sequence2::BLOB as pair_sequence FROM " +
-		        table_quoted;
-	} else {
-		query = "SELECT (row_number() OVER () - 1)::BIGINT as id, sequence1::BLOB as sequence, "
-		        "NULL::BLOB as pair_sequence FROM " +
-		        table_quoted;
-	}
-
-	auto query_result = conn.Query(query);
-	if (query_result->HasError()) {
-		throw InvalidInputException("Failed to read from sequence table '%s': %s", bind_data.sequence_table,
-		                            query_result->GetError());
-	}
-
-	// NOTE: ResultArrowArrayStreamWrapper's release callback (MyStreamRelease) deletes
-	// the wrapper when the stream is released. We create it with make_uniq but then
-	// release ownership after passing to RYpe, so there's no double-free.
-	auto input_wrapper = make_uniq<ResultArrowArrayStreamWrapper>(std::move(query_result), batch_size);
+	// Build the Arrow input stream from the same temp table, ordered by id.
+	auto input_wrapper = BuildRypeArrowInput(conn, gstate->tmp_table_name, /*include_pair_column=*/true, batch_size);
 	ArrowArrayStream *input_stream = &input_wrapper->stream;
 
 	// Step 5: Call RYpe classify

--- a/src/rype_extract.cpp
+++ b/src/rype_extract.cpp
@@ -1,6 +1,5 @@
 #include "rype_extract.hpp"
 #include "rype_common.hpp"
-#include "duckdb/common/arrow/result_arrow_wrapper.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/main/config.hpp"
 #include "duckdb/main/connection.hpp"
@@ -24,6 +23,12 @@ RypeExtractGlobalState::~RypeExtractGlobalState() {
 	}
 	if (output_stream.release) {
 		output_stream.release(&output_stream);
+	}
+
+	// Drop the materialized temp table BEFORE releasing input_connection — see
+	// rype_classify.cpp destructor for rationale.
+	if (input_connection) {
+		DropRypeTempTable(*input_connection, tmp_table_name);
 	}
 
 	// Release sub-connection LAST — see rype_classify.cpp destructor for rationale.
@@ -89,25 +94,18 @@ BuildExtractionInputStream(ClientContext &context, const RypeExtractData &bind_d
 	std::string id_col_quoted = KeywordHelper::WriteOptionallyQuoted(bind_data.id_column);
 	std::string table_quoted = KeywordHelper::WriteOptionallyQuoted(bind_data.sequence_table);
 
-	// Collect read_ids
-	std::string id_query = "SELECT " + id_col_quoted + " FROM " + table_quoted;
-	auto id_result = conn.Query(id_query);
-	if (id_result->HasError()) {
-		throw InvalidInputException("Failed to read from sequence table '%s': %s", bind_data.sequence_table,
-		                            id_result->GetError());
-	}
+	// Materialize the user's sequence_table into a per-call TEMP table with an
+	// explicit id column, then read read_ids and the sequence stream from it.
+	// See rype_common.hpp for the design rationale (row-index ↔ read_id fix).
+	// Extraction is single-sequence; pass has_sequence2=false to keep the temp
+	// table's sequence2 slot NULL, and include_pair_column=false on the stream.
+	size_t avg_read_length = 0;
+	gstate->tmp_table_name =
+	    MaterializeRypeInputTempTable(conn, table_quoted, id_col_quoted, bind_data.sequence_table,
+	                                  /*has_sequence2=*/false, "_rype_extract_", gstate->read_ids, avg_read_length);
 
-	gstate->read_ids.reserve(id_result->RowCount());
-	auto &id_materialized = id_result->Cast<MaterializedQueryResult>();
-	while (auto chunk = id_materialized.Fetch()) {
-		for (idx_t i = 0; i < chunk->size(); i++) {
-			gstate->read_ids.push_back(chunk->data[0].GetValue(i).ToString());
-		}
-	}
-
-	// Estimate batch size before the main sequence query.
-	// Extraction has no index overhead — just sequence data + minimizer lists.
-	size_t avg_read_length = SampleAvgReadLength(conn, table_quoted);
+	// Estimate batch size — extraction has no index overhead, just sequence data
+	// + minimizer lists.
 	size_t minimizers_per_read = (bind_data.w > 0 && avg_read_length > bind_data.k)
 	                                 ? ((avg_read_length - bind_data.k + 1) / bind_data.w + 1)
 	                                 : 1;
@@ -124,18 +122,9 @@ BuildExtractionInputStream(ClientContext &context, const RypeExtractData &bind_d
 		batch_size = STANDARD_VECTOR_SIZE;
 	}
 
-	// Query sequence data — extraction only uses single sequence (no pair_sequence).
-	// RYpe extraction expects: id (Int64), sequence (Binary)
-	std::string query =
-	    "SELECT (row_number() OVER () - 1)::BIGINT as id, sequence1::BLOB as sequence FROM " + table_quoted;
-
-	auto query_result = conn.Query(query);
-	if (query_result->HasError()) {
-		throw InvalidInputException("Failed to read from sequence table '%s': %s", bind_data.sequence_table,
-		                            query_result->GetError());
-	}
-
-	out_wrapper = make_uniq<ResultArrowArrayStreamWrapper>(std::move(query_result), batch_size);
+	// Build the Arrow input stream from the same temp table, ordered by id.
+	// Extraction does not consume pair_sequence.
+	out_wrapper = BuildRypeArrowInput(conn, gstate->tmp_table_name, /*include_pair_column=*/false, batch_size);
 	*out_input_stream = &out_wrapper->stream;
 
 	return gstate;

--- a/src/rype_log_ratio.cpp
+++ b/src/rype_log_ratio.cpp
@@ -1,6 +1,5 @@
 #include "rype_log_ratio.hpp"
 #include "rype_common.hpp"
-#include "duckdb/common/arrow/result_arrow_wrapper.hpp"
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/printer.hpp"
 #include "duckdb/main/config.hpp"
@@ -38,6 +37,12 @@ RypeLogRatioTableFunction::GlobalState::~GlobalState() {
 	}
 	if (numerator_index) {
 		rype_index_free(numerator_index);
+	}
+
+	// Drop the materialized temp table BEFORE releasing input_connection — see
+	// rype_classify.cpp destructor for rationale.
+	if (input_connection) {
+		DropRypeTempTable(*input_connection, tmp_table_name);
 	}
 
 	// Release sub-connection LAST — see rype_classify.cpp destructor for rationale.
@@ -147,27 +152,18 @@ unique_ptr<GlobalTableFunctionState> RypeLogRatioTableFunction::InitGlobal(Clien
 	std::string id_col_quoted = KeywordHelper::WriteOptionallyQuoted(bind_data.id_column);
 	std::string table_quoted = KeywordHelper::WriteOptionallyQuoted(bind_data.sequence_table);
 
-	// Collect all read_ids in order
-	std::string id_query = "SELECT " + id_col_quoted + " FROM " + table_quoted;
-	auto id_result = conn.Query(id_query);
-	if (id_result->HasError()) {
-		throw InvalidInputException("Failed to read from sequence table '%s': %s", bind_data.sequence_table,
-		                            id_result->GetError());
-	}
-
-	gstate->read_ids.reserve(id_result->RowCount());
-	auto &id_materialized = id_result->Cast<MaterializedQueryResult>();
-	while (auto chunk = id_materialized.Fetch()) {
-		for (idx_t i = 0; i < chunk->size(); i++) {
-			gstate->read_ids.push_back(chunk->data[0].GetValue(i).ToString());
-		}
-	}
+	// Materialize the user's sequence_table into a per-call TEMP table with an
+	// explicit id column, then read read_ids and the sequence stream from it.
+	// See rype_common.hpp for the design rationale (row-index ↔ read_id fix).
+	size_t avg_read_length = 0;
+	gstate->tmp_table_name =
+	    MaterializeRypeInputTempTable(conn, table_quoted, id_col_quoted, bind_data.sequence_table,
+	                                  bind_data.has_sequence2, "_rype_log_ratio_", gstate->read_ids, avg_read_length);
 
 	// Step 5: Estimate batch size.
 	// Log-ratio loads shards from BOTH indices per batch, so use whichever index has larger
 	// shards for a conservative memory estimate. rype_recommend_batch_size accounts for shard
 	// size in its memory budget, so the index with larger shards yields a smaller batch size.
-	size_t avg_read_length = SampleAvgReadLength(conn, table_quoted);
 	int is_paired = bind_data.has_sequence2 ? 1 : 0;
 
 	size_t num_shard_bytes = rype_index_largest_shard_bytes(gstate->numerator_index);
@@ -186,25 +182,8 @@ unique_ptr<GlobalTableFunctionState> RypeLogRatioTableFunction::InitGlobal(Clien
 		batch_size = STANDARD_VECTOR_SIZE;
 	}
 
-	// Step 6: Query sequence data for RYpe
-	std::string query;
-	if (bind_data.has_sequence2) {
-		query = "SELECT (row_number() OVER () - 1)::BIGINT as id, sequence1::BLOB as sequence, "
-		        "sequence2::BLOB as pair_sequence FROM " +
-		        table_quoted;
-	} else {
-		query = "SELECT (row_number() OVER () - 1)::BIGINT as id, sequence1::BLOB as sequence, "
-		        "NULL::BLOB as pair_sequence FROM " +
-		        table_quoted;
-	}
-
-	auto query_result = conn.Query(query);
-	if (query_result->HasError()) {
-		throw InvalidInputException("Failed to read from sequence table '%s': %s", bind_data.sequence_table,
-		                            query_result->GetError());
-	}
-
-	auto input_wrapper = make_uniq<ResultArrowArrayStreamWrapper>(std::move(query_result), batch_size);
+	// Step 6: Build the Arrow input stream from the same temp table, ordered by id.
+	auto input_wrapper = BuildRypeArrowInput(conn, gstate->tmp_table_name, /*include_pair_column=*/true, batch_size);
 	ArrowArrayStream *input_stream = &input_wrapper->stream;
 
 	// Step 7: Call RYpe log-ratio classification

--- a/test/sql/rype_row_id_correspondence.test
+++ b/test/sql/rype_row_id_correspondence.test
@@ -1,0 +1,279 @@
+# name: test/sql/rype_row_id_correspondence.test
+# description: Regression test for read_id <-> sequence correspondence in RYpe table functions
+# group: [sql]
+
+#
+# BUG: rype_classify, rype_extract_minimizer_set, rype_extract_strand_minimizers,
+# and rype_log_ratio each issue two independent SQL queries against the user's
+# sequence_table and stitch results together by row index (row_number() OVER ()).
+# DuckDB does not guarantee that two independent scans return rows in the same
+# order, so under multi-threaded scans, view sources, or preserve_insertion_order=false,
+# read_ids can be paired with the wrong sequence's classification.
+#
+# This test pins the invariant that EACH read_id is paired with the classification
+# of ITS OWN sequence content, regardless of scan ordering. The fixture is sized
+# (50K rows, multi-row-group parquet view) and configured
+# (preserve_insertion_order=false) to make the bug fire reliably pre-fix.
+#
+# Note: SET threads = N on this test session does NOT propagate to the
+# sub-connections that the rype functions create internally — those inherit the
+# DatabaseInstance default thread count, which is hardware-dependent. The bug
+# fires anyway because the parquet view + multi-row-group source + independent
+# sub-connection queries are independently sufficient to scramble row order
+# between the two queries the rype helper issues.
+#
+# Sequence content is engineered using the RY-space (purine/pyrimidine) collapse
+# of test.ryxdi:
+#   - ACGT-content matches {alpha, beta, gamma} at threshold 0.05  -> "three_*" reads
+#   - GGGG-content matches {alpha, gamma}        at threshold 0.05  -> "two_*" reads
+# So no "two_*" read may legitimately appear paired with bucket_beta.
+
+require miint
+
+require parquet
+
+# =============================================================================
+# Hostile execution mode for the entire test
+# =============================================================================
+statement ok
+SET preserve_insertion_order = false;
+
+# =============================================================================
+# Adversarial fixture: 50K rows in one parquet file with 10 row groups, view source
+# =============================================================================
+# read_id encodes expected behavior:
+#   "two_NNNNN"   carries GGGGCCCC content -> must classify to exactly {alpha, gamma}
+#   "three_NNNNN" carries ACGTACGT content -> must classify to exactly {alpha, beta, gamma}
+
+statement ok
+COPY (
+    SELECT
+        'two_'   || lpad((i::INTEGER)::VARCHAR, 6, '0') AS read_id,
+        repeat('GGGGCCCC', 7) AS sequence1
+    FROM range(0, 25000) t(i)
+    UNION ALL
+    SELECT
+        'three_' || lpad((i::INTEGER)::VARCHAR, 6, '0') AS read_id,
+        repeat('ACGTACGT', 7) AS sequence1
+    FROM range(0, 25000) t(i)
+) TO '__TEST_DIR__/rype_adv.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 5000);
+
+statement ok
+CREATE OR REPLACE VIEW seqs_view AS SELECT * FROM read_parquet('__TEST_DIR__/rype_adv.parquet');
+
+# Sanity: fixture has the expected row counts
+query II
+SELECT
+    SUM(CASE WHEN read_id LIKE 'two_%'   THEN 1 ELSE 0 END),
+    SUM(CASE WHEN read_id LIKE 'three_%' THEN 1 ELSE 0 END)
+FROM seqs_view;
+----
+25000	25000
+
+# =============================================================================
+# rype_classify: invariant — read_id prefix must match its sequence's bucket set
+# =============================================================================
+# Every "two_*" read must have exactly {alpha, gamma}
+# Every "three_*" read must have exactly {alpha, beta, gamma}
+# Pre-fix: scrambling causes "two_*" reads to inherit "three_*" classifications,
+#          producing rows where read_id LIKE 'two_%' AND bucket_name = 'bucket_beta'.
+
+statement ok
+CREATE TEMP TABLE classify_run AS
+SELECT * FROM rype_classify('data/rype/test.ryxdi', 'seqs_view', threshold := 0.05);
+
+# Hard invariant: no "two_*" read may carry bucket_beta
+query I
+SELECT count(*) FROM classify_run WHERE read_id LIKE 'two_%' AND bucket_name = 'bucket_beta';
+----
+0
+
+# Hard invariant: every "two_*" read has exactly {alpha, gamma}
+query I
+SELECT count(*) FROM (
+    SELECT read_id, list_sort(list(bucket_name)) AS buckets
+    FROM classify_run WHERE read_id LIKE 'two_%' GROUP BY read_id
+) WHERE buckets != ['bucket_alpha', 'bucket_gamma'];
+----
+0
+
+# Hard invariant: every "three_*" read has exactly {alpha, beta, gamma}
+query I
+SELECT count(*) FROM (
+    SELECT read_id, list_sort(list(bucket_name)) AS buckets
+    FROM classify_run WHERE read_id LIKE 'three_%' GROUP BY read_id
+) WHERE buckets != ['bucket_alpha', 'bucket_beta', 'bucket_gamma'];
+----
+0
+
+# Output cardinality sanity: 25000*2 + 25000*3 = 125000
+query I
+SELECT count(*) FROM classify_run;
+----
+125000
+
+# Distinct read_id count: a buggy fix that deduplicated or dropped reads would pass
+# the bucket-shape invariants but fail this one.
+query I
+SELECT count(DISTINCT read_id) FROM classify_run;
+----
+50000
+
+statement ok
+DROP TABLE classify_run;
+
+# =============================================================================
+# rype_classify: determinism across 3 independent runs
+# =============================================================================
+statement ok
+CREATE TEMP TABLE classify_run1 AS
+SELECT * FROM rype_classify('data/rype/test.ryxdi', 'seqs_view', threshold := 0.05);
+
+statement ok
+CREATE TEMP TABLE classify_run2 AS
+SELECT * FROM rype_classify('data/rype/test.ryxdi', 'seqs_view', threshold := 0.05);
+
+statement ok
+CREATE TEMP TABLE classify_run3 AS
+SELECT * FROM rype_classify('data/rype/test.ryxdi', 'seqs_view', threshold := 0.05);
+
+# Symmetric difference across all three runs must be empty.
+# Checking run1<->run2 and run1<->run3 is sufficient: for set equality,
+# (run1 == run2) AND (run1 == run3) implies (run2 == run3) by transitivity,
+# so the run2<->run3 comparison is redundant.
+query I
+SELECT (
+    (SELECT count(*) FROM (SELECT * FROM classify_run1 EXCEPT SELECT * FROM classify_run2)) +
+    (SELECT count(*) FROM (SELECT * FROM classify_run2 EXCEPT SELECT * FROM classify_run1)) +
+    (SELECT count(*) FROM (SELECT * FROM classify_run1 EXCEPT SELECT * FROM classify_run3)) +
+    (SELECT count(*) FROM (SELECT * FROM classify_run3 EXCEPT SELECT * FROM classify_run1))
+);
+----
+0
+
+statement ok
+DROP TABLE classify_run1;
+
+statement ok
+DROP TABLE classify_run2;
+
+statement ok
+DROP TABLE classify_run3;
+
+# =============================================================================
+# rype_extract_minimizer_set: same content -> same minimizer set
+# =============================================================================
+# Within each prefix group, all reads share content, so the minimizer set must
+# be identical across all reads in the group. Pre-fix: scrambling produces
+# different minimizer lists for reads that should be identical.
+
+statement ok
+CREATE TEMP TABLE extract_set_run AS
+SELECT * FROM rype_extract_minimizer_set('seqs_view', 32, 10);
+
+query I
+SELECT count(DISTINCT (fwd_set, rc_set)) FROM extract_set_run WHERE read_id LIKE 'two_%';
+----
+1
+
+query I
+SELECT count(DISTINCT (fwd_set, rc_set)) FROM extract_set_run WHERE read_id LIKE 'three_%';
+----
+1
+
+# The two groups must have DIFFERENT minimizer sets
+query I
+SELECT count(DISTINCT (fwd_set, rc_set)) FROM extract_set_run;
+----
+2
+
+statement ok
+DROP TABLE extract_set_run;
+
+# =============================================================================
+# rype_extract_strand_minimizers: same content -> same hashes/positions
+# =============================================================================
+statement ok
+CREATE TEMP TABLE extract_strand_run AS
+SELECT * FROM rype_extract_strand_minimizers('seqs_view', 32, 10);
+
+query I
+SELECT count(DISTINCT (fwd_hashes, fwd_positions, rc_hashes, rc_positions))
+FROM extract_strand_run WHERE read_id LIKE 'two_%';
+----
+1
+
+query I
+SELECT count(DISTINCT (fwd_hashes, fwd_positions, rc_hashes, rc_positions))
+FROM extract_strand_run WHERE read_id LIKE 'three_%';
+----
+1
+
+statement ok
+DROP TABLE extract_strand_run;
+
+# =============================================================================
+# rype_log_ratio: read_id prefix must match its sequence's score sign
+# =============================================================================
+# Build a separate parquet fixture for log_ratio, since the indices distinguish
+# different content patterns:
+#   "pos_NNNNN" carries GGCCTTAA content -> matches numerator only -> log_ratio > 0
+#   "neg_NNNNN" carries AATTAATT content -> matches denominator only -> log_ratio < 0
+# Pre-fix: scrambling causes "pos_*" reads to inherit "neg_*" log_ratio (and vice versa).
+
+statement ok
+COPY (
+    SELECT
+        'pos_' || lpad((i::INTEGER)::VARCHAR, 6, '0') AS read_id,
+        repeat('GGCCTTAA', 7) AS sequence1
+    FROM range(0, 25000) t(i)
+    UNION ALL
+    SELECT
+        'neg_' || lpad((i::INTEGER)::VARCHAR, 6, '0') AS read_id,
+        repeat('AATTAATT', 7) AS sequence1
+    FROM range(0, 25000) t(i)
+) TO '__TEST_DIR__/rype_adv_lr.parquet' (FORMAT PARQUET, ROW_GROUP_SIZE 5000);
+
+statement ok
+CREATE OR REPLACE VIEW lr_view AS SELECT * FROM read_parquet('__TEST_DIR__/rype_adv_lr.parquet');
+
+statement ok
+CREATE TEMP TABLE lr_run AS
+SELECT * FROM rype_log_ratio(
+    'data/rype/test_numerator.ryxdi', 'data/rype/test_denominator.ryxdi',
+    'lr_view', skip_threshold := 0.0);
+
+# All "pos_*" must have log_ratio > 0 (or +inf), none NaN, none <= 0.
+# `NOT (log_ratio > 0)` evaluates to NULL on NaN, so add an explicit isnan() guard
+# to ensure NaN counts as a violation.
+query I
+SELECT count(*) FROM lr_run
+WHERE read_id LIKE 'pos_%' AND (isnan(log_ratio) OR NOT (log_ratio > 0));
+----
+0
+
+# All "neg_*" must have log_ratio < 0 (or -inf), none NaN, none >= 0.
+query I
+SELECT count(*) FROM lr_run
+WHERE read_id LIKE 'neg_%' AND (isnan(log_ratio) OR NOT (log_ratio < 0));
+----
+0
+
+# Output cardinality: one row per input
+query I
+SELECT count(*) FROM lr_run;
+----
+50000
+
+statement ok
+DROP TABLE lr_run;
+
+# =============================================================================
+# Cleanup — IF EXISTS so a partial-failure rerun on the same DB instance
+# doesn't trip "view already exists".
+# =============================================================================
+statement ok
+DROP VIEW IF EXISTS seqs_view;
+
+statement ok
+DROP VIEW IF EXISTS lr_view;


### PR DESCRIPTION
## Summary

- Fixes a silent data-corruption bug in `rype_classify`, `rype_extract_minimizer_set`, `rype_extract_strand_minimizers`, and `rype_log_ratio`: each issued two independent SELECTs against the user's `sequence_table` and stitched results by row index. Under multi-threaded scans, view sources, or `preserve_insertion_order=false`, DuckDB doesn't guarantee the two scans agree on row order, so `query_id → read_ids[query_id]` resolved to the wrong identifier. Output row counts matched native RYpe but read_id labels were scrambled across classifications.
- Each function now materializes `(id, read_id, sequence1, sequence2?)` once into a per-call TEMP table on its sub-connection, then reads `read_ids` and streams sequences from that same table `ORDER BY id`. The id column is now a stable attribute of the data, not an emergent property of independent scans.
- Shared pipeline lives in `src/include/rype_common.hpp` as three inline helpers (`MaterializeRypeInputTempTable`, `BuildRypeArrowInput`, `DropRypeTempTable`) so future RYpe entrypoints inherit the fix.

## Symptoms (reproduced against a deterministic native RYpe baseline on real data)

- Total row counts match native, but specific reads missing from miint output.
- Some reads paired with bucket-association counts that don't match native — single-bucket reads "inheriting" the buckets of unrelated multi-bucket reads.
- Run-to-run variance under `preserve_insertion_order=false`; native RYpe is deterministic on the same input.

## Test plan

- [x] New regression test `test/sql/rype_row_id_correspondence.test` — adversarial 50K-row parquet view, 10 row groups, `preserve_insertion_order=false`. Encodes expected outcome in the read_id (`two_*` carries GGGG content → must classify to `{alpha, gamma}`; `three_*` carries ACGT content → must classify to `{alpha, beta, gamma}`). Passes 37/37 invariant + determinism + cardinality assertions across all four functions. Pre-fix, this test fails reliably (hundreds to thousands of `two_*` reads paired with `bucket_beta`).
- [x] Existing rype tests still pass — `rype_classify.test` 64/64, `rype_extract.test` 75/75, `rype_log_ratio.test` 56/56.
- [x] Full C++ test suite — 896 passed, 34 skipped (optional deps).
- [x] Full SQL/shell suite — clean.
- [x] `make format-check` — clean.
- [ ] **Real-data parity vs native RYpe (post-merge)**: the original real dataset that surfaced the bug should agree on `(read_id → bucket_set)` after this lands. The adversarial SQL test exercises the bug class; the parity check is the confirmatory follow-up.

## TDD trail and review

Built red/green/refactor on this branch with explicit linus-code-reviewer passes after each phase:

1. **CR-1 (red-phase test)**: 6 issues found and addressed — added `count(DISTINCT read_id)` cardinality guard, NaN-safe `isnan() OR NOT (...)` log_ratio assertions, removed theatrical `SET threads = 8` (sub-connections inherit DB-instance threads, not session value), `IF EXISTS`/`OR REPLACE` on view drops, fixture comment fix, verified `count(DISTINCT (LIST,LIST))` works in DuckDB 1.5.
2. **CR-2 (green-phase, in-place fix)**: no blockers; updated stale `OWNERSHIP HIERARCHY` comments in three headers to document the new DROP TABLE step.
3. **CR-3 (refactor into shared helpers)**: one blocking find — `KeywordHelper::WriteOptionallyQuoted` was being called from `rype_common.hpp` without an explicit `#include "duckdb/parser/keyword_helper.hpp"`; compiled only via fragile transitive includes. Added the explicit include.
4. **CR-4 (full diff)**: approved; doc-only follow-up commit (`82932bc`) clarifies the *why* behind the destructor's DROP-after-output_stream ordering and adds the RYpe API frees as step 4a in `rype_classify.hpp` / `rype_log_ratio.hpp`.

## Plan deviations to acknowledge

- **C++ unit test for `BuildRypeInputViaTempTable` (planned for Phase 3) was descoped.** The miint `tests` binary doesn't link `libduckdb.so` — adding a unit test that uses a live `duckdb::Connection` would require expanding the test binary's link surface beyond this PR's scope. The new SQL adversarial test exercises the helper end-to-end through all four call sites and provides equivalent observable coverage for this bug class.
- **Paired-end (`sequence2`) inputs are not exercised by the new adversarial test** — the fixture is single-end. The paired-end code path is identical (same `MaterializeRypeInputTempTable` + `BuildRypeArrowInput` with `has_sequence2=true` / `include_pair_column=true`) and is covered by the existing `rype_classify.test`. Worth flagging if a future regression test explicitly stresses paired-end ordering.

## Out of scope for this PR (separate tickets)

- **`deblur` and `detect_chimera_uchime_denovo` greedy-bootstrap tiebreaker.** Both order by `count DESC` then run order-sensitive greedy algorithms; ties are not broken deterministically. Not the same bug, but worth a deterministic tiebreaker (`ORDER BY count DESC, read_id ASC`) in a follow-up.
- **`SampleAvgReadLength` non-determinism.** `LIMIT 1000` over the source has no `ORDER BY`; the sample varies between runs. Affects only `batch_size` estimation, not correctness.
- **`ValidateSequenceTable` re-binds views on every call** to inspect column names. Pre-existing minor inefficiency; out of scope.

## Files

```
 src/include/rype_classify.hpp  |  20 ++++--
 src/include/rype_common.hpp    | 113 ++++++++++++++++++++++++++++++++++
 src/include/rype_extract.hpp   |  14 ++--
 src/include/rype_log_ratio.hpp |  18 ++++--
 src/rype_classify.cpp          |  64 +++++--------------
 src/rype_extract.cpp           |  53 ++++++++--------
 src/rype_log_ratio.cpp         |  51 +++++----------
 test/sql/rype_row_id_correspondence.test | 279 +++++++++++++++++++++++++++++++
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)