### PR TITLE
fix: reject NULL inputs to file/accession table functions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,28 @@ bash build.sh         # always use build.sh, not make directly
 ```
 
 ### Formatting
-Pre-commit hook runs `make format-check`. Auto-fix:
+Pre-commit hook (and CI's "Code Quality Check / Format Check" job) runs `make format-check`. CI pins specific versions — match them locally or newer `black` will reformat files differently than CI expects and the check will fail on files you never touched.
+
+Required versions (from `extension-ci-tools/.github/workflows/_extension_code_quality.yml`):
+- `black==24.*`
+- `clang_format==11.0.1`
+- `cmake-format` (any recent version)
+
+One-time setup of a dedicated conda env:
 ```bash
-conda run -n duckdb-143 make format-fix
+conda create -n duckdb-format -c conda-forge python=3.12 pip -y
+conda activate duckdb-format
+pip install 'black==24.*' 'clang_format==11.0.1' cmake-format
 ```
-The `duckdb-143` conda env has the required `clang-format` and `black` tools.
+
+Then to check / auto-fix:
+```bash
+conda activate duckdb-format
+make format-check                  # verify (CI runs this)
+make format-fix                    # auto-fix differences
+```
+
+Note: black ships breaking style changes between major versions — pinning to `24.*` is required, not optional.
 
 ## Testing
 

--- a/src/read_alignments.cpp
+++ b/src/read_alignments.cpp
@@ -19,6 +19,9 @@ unique_ptr<FunctionData> ReadAlignmentsTableFunction::Bind(ClientContext &contex
 
 	std::vector<std::string> sam_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_alignments: first argument cannot be NULL");
+	}
 	// Handle VARCHAR (single path, potentially a glob) or VARCHAR[] (array of literal paths)
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		// Single string - could be a glob pattern
@@ -27,6 +30,9 @@ unique_ptr<FunctionData> ReadAlignmentsTableFunction::Bind(ClientContext &contex
 		// Array of strings - literal paths only (no glob expansion)
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_alignments: file path list cannot contain NULL");
+			}
 			sam_paths.push_back(child.ToString());
 		}
 		if (sam_paths.empty()) {

--- a/src/read_biom.cpp
+++ b/src/read_biom.cpp
@@ -16,6 +16,9 @@ unique_ptr<FunctionData> ReadBIOMTableFunction::Bind(ClientContext &context, Tab
 
 	std::vector<std::string> biom_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_biom: first argument cannot be NULL");
+	}
 	// Handle VARCHAR (single path, potentially a glob) or VARCHAR[] (array of literal paths)
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		// Single string - could be a glob pattern
@@ -24,6 +27,9 @@ unique_ptr<FunctionData> ReadBIOMTableFunction::Bind(ClientContext &context, Tab
 		// Array of strings - literal paths only (no glob expansion)
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_biom: file path list cannot contain NULL");
+			}
 			biom_paths.push_back(child.ToString());
 		}
 		if (biom_paths.empty()) {

--- a/src/read_ena.cpp
+++ b/src/read_ena.cpp
@@ -148,11 +148,17 @@ bool ReadENATableFunction::GlobalState::FetchNextAccession() {
 unique_ptr<FunctionData> ReadENATableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
                                                     vector<LogicalType> &return_types, vector<std::string> &names) {
 	std::vector<std::string> accessions;
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_ena: accession cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		accessions.push_back(input.inputs[0].ToString());
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_ena: accession list cannot contain NULL");
+			}
 			accessions.push_back(child.ToString());
 		}
 	} else {

--- a/src/read_ena_attributes.cpp
+++ b/src/read_ena_attributes.cpp
@@ -320,11 +320,17 @@ unique_ptr<FunctionData> ReadENAAttributesTableFunction::Bind(ClientContext &con
                                                               vector<LogicalType> &return_types,
                                                               vector<std::string> &names) {
 	std::vector<std::string> accessions;
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_ena_attributes: accession cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		accessions.push_back(input.inputs[0].ToString());
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_ena_attributes: accession list cannot contain NULL");
+			}
 			accessions.push_back(child.ToString());
 		}
 	} else {

--- a/src/read_fastx.cpp
+++ b/src/read_fastx.cpp
@@ -25,6 +25,9 @@ unique_ptr<FunctionData> ReadFastxTableFunction::Bind(ClientContext &context, Ta
 		return path == "-" || path == "/dev/stdin" || path == "/dev/fd/0" || path == "/proc/self/fd/0";
 	};
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_fastx: first argument cannot be NULL");
+	}
 	// Handle VARCHAR (single path, potentially a glob) or VARCHAR[] (array of literal paths)
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		// Single string - could be a glob pattern
@@ -35,6 +38,9 @@ unique_ptr<FunctionData> ReadFastxTableFunction::Bind(ClientContext &context, Ta
 		// Array of strings - literal paths only (no glob expansion)
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_fastx: file path list cannot contain NULL");
+			}
 			sequence1_paths.push_back(child.ToString());
 		}
 		if (sequence1_paths.empty()) {
@@ -96,6 +102,9 @@ unique_ptr<FunctionData> ReadFastxTableFunction::Bind(ClientContext &context, Ta
 			// Array of strings - literal paths only
 			auto &list_children = ListValue::GetChildren(path2_value);
 			for (const auto &child : list_children) {
+				if (child.IsNull()) {
+					throw InvalidInputException("read_fastx: sequence2 list cannot contain NULL");
+				}
 				seq2_paths.push_back(child.ToString());
 			}
 		} else {

--- a/src/read_jplace_newick.cpp
+++ b/src/read_jplace_newick.cpp
@@ -113,12 +113,18 @@ unique_ptr<FunctionData> ReadJplaceNewickTableFunction::Bind(ClientContext &cont
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_jplace_newick: first argument cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
 		file_paths = std::move(result.paths);
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_jplace_newick: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/src/read_mzml.cpp
+++ b/src/read_mzml.cpp
@@ -15,12 +15,18 @@ unique_ptr<FunctionData> ReadMzMLTableFunction::Bind(ClientContext &context, Tab
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_mzml: first argument cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
 		file_paths = std::move(result.paths);
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_mzml: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/src/read_mzml_chromatograms.cpp
+++ b/src/read_mzml_chromatograms.cpp
@@ -15,12 +15,18 @@ unique_ptr<FunctionData> ReadMzMLChromatogramsTableFunction::Bind(ClientContext 
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_mzml_chromatograms: first argument cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
 		file_paths = std::move(result.paths);
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_mzml_chromatograms: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/src/read_mzxml.cpp
+++ b/src/read_mzxml.cpp
@@ -15,12 +15,18 @@ unique_ptr<FunctionData> ReadMzXMLTableFunction::Bind(ClientContext &context, Ta
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_mzxml: first argument cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
 		file_paths = std::move(result.paths);
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_mzxml: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/src/read_ncbi.cpp
+++ b/src/read_ncbi.cpp
@@ -58,11 +58,17 @@ unique_ptr<FunctionData> ReadNCBITableFunction::Bind(ClientContext &context, Tab
 	// Parse accession(s) - can be VARCHAR or VARCHAR[]
 	std::vector<std::string> accessions;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_ncbi: accession cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		accessions.push_back(input.inputs[0].ToString());
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_ncbi: accession list cannot contain NULL");
+			}
 			accessions.push_back(child.ToString());
 		}
 	} else {

--- a/src/read_ncbi_annotation.cpp
+++ b/src/read_ncbi_annotation.cpp
@@ -64,11 +64,17 @@ unique_ptr<FunctionData> ReadNCBIAnnotationTableFunction::Bind(ClientContext &co
 	// Parse accession(s) - can be VARCHAR or VARCHAR[]
 	std::vector<std::string> accessions;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_ncbi_annotation: accession cannot be NULL");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		accessions.push_back(input.inputs[0].ToString());
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_ncbi_annotation: accession list cannot contain NULL");
+			}
 			accessions.push_back(child.ToString());
 		}
 	} else {

--- a/src/read_ncbi_fasta.cpp
+++ b/src/read_ncbi_fasta.cpp
@@ -72,11 +72,18 @@ unique_ptr<FunctionData> ReadNCBIFastaTableFunction::Bind(ClientContext &context
 	// Parse accession(s) - can be VARCHAR or VARCHAR[]
 	std::vector<std::string> accessions;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException(
+		    "read_ncbi_fasta: accession cannot be NULL (use a VARCHAR literal or VARCHAR[] list)");
+	}
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		accessions.push_back(input.inputs[0].ToString());
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_ncbi_fasta: accession list cannot contain NULL");
+			}
 			accessions.push_back(child.ToString());
 		}
 	} else {

--- a/src/read_newick.cpp
+++ b/src/read_newick.cpp
@@ -148,6 +148,9 @@ unique_ptr<FunctionData> ReadNewickTableFunction::Bind(ClientContext &context, T
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_newick: first argument cannot be NULL");
+	}
 	// Handle VARCHAR (single path, potentially a glob) or VARCHAR[] (array of literal paths)
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
@@ -155,6 +158,9 @@ unique_ptr<FunctionData> ReadNewickTableFunction::Bind(ClientContext &context, T
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_newick: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/src/read_sequences_sam.cpp
+++ b/src/read_sequences_sam.cpp
@@ -16,6 +16,9 @@ unique_ptr<FunctionData> ReadSequencesSamTableFunction::Bind(ClientContext &cont
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_sequences_sam: first argument cannot be NULL");
+	}
 	// Handle VARCHAR (single path, potentially a glob) or VARCHAR[] (array of literal paths)
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
@@ -23,6 +26,9 @@ unique_ptr<FunctionData> ReadSequencesSamTableFunction::Bind(ClientContext &cont
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_sequences_sam: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/src/read_sequences_sff.cpp
+++ b/src/read_sequences_sff.cpp
@@ -16,6 +16,9 @@ unique_ptr<FunctionData> ReadSequencesSFFTableFunction::Bind(ClientContext &cont
 
 	std::vector<std::string> file_paths;
 
+	if (input.inputs[0].IsNull()) {
+		throw InvalidInputException("read_sequences_sff: first argument cannot be NULL");
+	}
 	// Handle VARCHAR (single path, potentially a glob) or VARCHAR[] (array of literal paths)
 	if (input.inputs[0].type().id() == LogicalTypeId::VARCHAR) {
 		auto result = ExpandGlobPatternWithInfo(fs, context, input.inputs[0].ToString());
@@ -23,6 +26,9 @@ unique_ptr<FunctionData> ReadSequencesSFFTableFunction::Bind(ClientContext &cont
 	} else if (input.inputs[0].type().id() == LogicalTypeId::LIST) {
 		auto &list_children = ListValue::GetChildren(input.inputs[0]);
 		for (const auto &child : list_children) {
+			if (child.IsNull()) {
+				throw InvalidInputException("read_sequences_sff: file path list cannot contain NULL");
+			}
 			file_paths.push_back(child.ToString());
 		}
 		if (file_paths.empty()) {

--- a/test/sql/null_input_guards.test
+++ b/test/sql/null_input_guards.test
@@ -1,8 +1,5 @@
 # name: test/sql/null_input_guards.test
-# description: Regression: every table function that accepts VARCHAR or VARCHAR[]
-#              for its primary positional input must reject NULL with a clean
-#              InvalidInputException, NOT crash with an INTERNAL Error from
-#              ListValue::GetChildren on a NULL value.
+# description: Regression: table functions taking VARCHAR/VARCHAR[] must reject NULL cleanly (not crash on ListValue::GetChildren)
 # group: [sql]
 
 require miint

--- a/test/sql/null_input_guards.test
+++ b/test/sql/null_input_guards.test
@@ -1,0 +1,240 @@
+# name: test/sql/null_input_guards.test
+# description: Regression: every table function that accepts VARCHAR or VARCHAR[]
+#              for its primary positional input must reject NULL with a clean
+#              InvalidInputException, NOT crash with an INTERNAL Error from
+#              ListValue::GetChildren on a NULL value.
+# group: [sql]
+
+require miint
+
+# --- read_fastx ---
+statement error
+SELECT * FROM read_fastx(NULL::VARCHAR);
+----
+read_fastx: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_fastx(NULL::VARCHAR[]);
+----
+read_fastx: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_fastx(['/tmp/a.fa', NULL]);
+----
+read_fastx: file path list cannot contain NULL
+
+# --- read_alignments ---
+statement error
+SELECT * FROM read_alignments(NULL::VARCHAR);
+----
+read_alignments: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_alignments(NULL::VARCHAR[]);
+----
+read_alignments: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_alignments(['/tmp/a.sam', NULL]);
+----
+read_alignments: file path list cannot contain NULL
+
+# --- read_sequences_sam ---
+statement error
+SELECT * FROM read_sequences_sam(NULL::VARCHAR);
+----
+read_sequences_sam: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_sequences_sam(NULL::VARCHAR[]);
+----
+read_sequences_sam: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_sequences_sam(['/tmp/a.sam', NULL]);
+----
+read_sequences_sam: file path list cannot contain NULL
+
+# --- read_sequences_sff ---
+statement error
+SELECT * FROM read_sequences_sff(NULL::VARCHAR);
+----
+read_sequences_sff: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_sequences_sff(NULL::VARCHAR[]);
+----
+read_sequences_sff: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_sequences_sff(['/tmp/a.sff', NULL]);
+----
+read_sequences_sff: file path list cannot contain NULL
+
+# --- read_biom ---
+statement error
+SELECT * FROM read_biom(NULL::VARCHAR);
+----
+read_biom: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_biom(NULL::VARCHAR[]);
+----
+read_biom: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_biom(['/tmp/a.biom', NULL]);
+----
+read_biom: file path list cannot contain NULL
+
+# --- read_newick ---
+statement error
+SELECT * FROM read_newick(NULL::VARCHAR);
+----
+read_newick: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_newick(NULL::VARCHAR[]);
+----
+read_newick: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_newick(['/tmp/a.nwk', NULL]);
+----
+read_newick: file path list cannot contain NULL
+
+# --- read_jplace_newick ---
+statement error
+SELECT * FROM read_jplace_newick(NULL::VARCHAR);
+----
+read_jplace_newick: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_jplace_newick(NULL::VARCHAR[]);
+----
+read_jplace_newick: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_jplace_newick(['/tmp/a.jplace', NULL]);
+----
+read_jplace_newick: file path list cannot contain NULL
+
+# --- read_mzml ---
+statement error
+SELECT * FROM read_mzml(NULL::VARCHAR);
+----
+read_mzml: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_mzml(NULL::VARCHAR[]);
+----
+read_mzml: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_mzml(['/tmp/a.mzML', NULL]);
+----
+read_mzml: file path list cannot contain NULL
+
+# --- read_mzxml ---
+statement error
+SELECT * FROM read_mzxml(NULL::VARCHAR);
+----
+read_mzxml: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_mzxml(NULL::VARCHAR[]);
+----
+read_mzxml: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_mzxml(['/tmp/a.mzXML', NULL]);
+----
+read_mzxml: file path list cannot contain NULL
+
+# --- read_mzml_chromatograms ---
+statement error
+SELECT * FROM read_mzml_chromatograms(NULL::VARCHAR);
+----
+read_mzml_chromatograms: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_mzml_chromatograms(NULL::VARCHAR[]);
+----
+read_mzml_chromatograms: first argument cannot be NULL
+
+statement error
+SELECT * FROM read_mzml_chromatograms(['/tmp/a.mzML', NULL]);
+----
+read_mzml_chromatograms: file path list cannot contain NULL
+
+# --- read_ncbi ---
+statement error
+SELECT * FROM read_ncbi(NULL::VARCHAR);
+----
+read_ncbi: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ncbi(NULL::VARCHAR[]);
+----
+read_ncbi: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ncbi(['NC_001416.1', NULL]);
+----
+read_ncbi: accession list cannot contain NULL
+
+# --- read_ncbi_annotation ---
+statement error
+SELECT * FROM read_ncbi_annotation(NULL::VARCHAR);
+----
+read_ncbi_annotation: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ncbi_annotation(NULL::VARCHAR[]);
+----
+read_ncbi_annotation: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ncbi_annotation(['NC_001416.1', NULL]);
+----
+read_ncbi_annotation: accession list cannot contain NULL
+
+# --- read_ena ---
+statement error
+SELECT * FROM read_ena(NULL::VARCHAR);
+----
+read_ena: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ena(NULL::VARCHAR[]);
+----
+read_ena: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ena(['ERR1234567', NULL]);
+----
+read_ena: accession list cannot contain NULL
+
+# --- read_ena_attributes ---
+statement error
+SELECT * FROM read_ena_attributes(NULL::VARCHAR);
+----
+read_ena_attributes: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ena_attributes(NULL::VARCHAR[]);
+----
+read_ena_attributes: accession cannot be NULL
+
+statement error
+SELECT * FROM read_ena_attributes(['ERR1234567', NULL]);
+----
+read_ena_attributes: accession list cannot contain NULL
+
+# --- read_fastx sequence2 named-parameter NULL element ---
+# Use a real sequence1 file so we exercise the sequence2 list parsing path
+# rather than failing on sequence1 file-existence.
+statement error
+SELECT * FROM read_fastx('data/fastq/foo.r1.fastq.gz', sequence2=>['data/fastq/foo.r2.fastq.gz', NULL]);
+----
+read_fastx: sequence2 list cannot contain NULL

--- a/test/sql/read_ncbi_fasta.test
+++ b/test/sql/read_ncbi_fasta.test
@@ -23,6 +23,24 @@ SELECT * FROM read_ncbi_fasta([]);
 ----
 at least one accession must be provided
 
+# Test error: NULL VARCHAR accession
+statement error
+SELECT * FROM read_ncbi_fasta(NULL::VARCHAR);
+----
+accession cannot be NULL
+
+# Test error: NULL VARCHAR[] accession
+statement error
+SELECT * FROM read_ncbi_fasta(NULL::VARCHAR[]);
+----
+accession cannot be NULL
+
+# Test error: VARCHAR[] containing a NULL element
+statement error
+SELECT * FROM read_ncbi_fasta(['NC_001416.1', NULL]);
+----
+accession list cannot contain NULL
+
 # Test schema - fetch Lambda phage genome (small, stable)
 # NC_001416.1 is Enterobacteria phage lambda, complete genome (48502 bp)
 query IIIIII


### PR DESCRIPTION
## Summary
- Adds NULL guards to 15 table functions that previously crashed with an `INTERNAL Error: Calling ListValue::GetChildren on a NULL value` when given `NULL::VARCHAR[]`.
- Each function now also rejects NULL elements inside a VARCHAR[] list with a clean `Invalid Input Error`.

## Reproducer (before)
```
D set variable foo = NULL::varchar[];
D select * from read_ncbi_fasta(getvariable('foo'));
INTERNAL Error: Calling ListValue::GetChildren on a NULL value
```

After:
```
Invalid Input Error: read_ncbi_fasta: accession cannot be NULL (use a VARCHAR literal or VARCHAR[] list)
```

## Functions fixed
`read_ncbi_fasta`, `read_ncbi`, `read_ncbi_annotation`, `read_ena`, `read_ena_attributes`, `read_fastx` (including `sequence2` named parameter), `read_alignments`, `read_sequences_sam`, `read_sequences_sff`, `read_biom`, `read_newick`, `read_jplace_newick`, `read_mzml`, `read_mzxml`, `read_mzml_chromatograms`.

The pattern matches the existing guard in `read_ena_sequences.cpp`.

## Test plan
- [x] New regression file `test/sql/null_input_guards.test` exercises each function with `NULL::VARCHAR`, `NULL::VARCHAR[]`, and a list containing NULL (43 assertions, all pass)
- [x] Additional NULL cases added to `test/sql/read_ncbi_fasta.test`
- [x] Existing tests still pass: `read_fastx.test` (192), `read_alignments.test` (141), `read_newick.test` (59), `read_sequences_sff.test` (146)
- [x] Local build clean on macOS arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)