### PR TITLE
fix(ena): never throw from inside kseq++ read callbacks

### DIFF
--- a/src/SequenceReader.cpp
+++ b/src/SequenceReader.cpp
@@ -1,6 +1,10 @@
 #include <SequenceReader.hpp>
 #include <algorithm>
 
+#ifdef MIINT_STATIC_BUILD
+#include "duckdb/common/exception.hpp"
+#endif
+
 namespace miint {
 // Helper function to extract base read ID by stripping /[1-9] suffix and comments
 static std::string base_read_id(const std::string &id) {
@@ -43,10 +47,28 @@ static void validate_format_consistency(bool is_fasta1, bool is_fasta2, bool all
 	}
 }
 
-// Read from whichever stream variant is active
+// Read from whichever stream variant is active.
+//
+// Errors that originate in our kseq++ read callbacks (duckdb_seq_read /
+// aspera_seq_read) are reported via the thread-local g_seq_read_error
+// channel: the callback writes a message and returns -1, kseq++ surfaces -1
+// as err()/empty-result, and we raise IOException from here. This keeps the
+// throw out of kseq++'s template-instantiated frames, which previously caused
+// a recursive-terminate abort on the aspera path under some failure modes.
 std::vector<klibpp::KSeq> SequenceReader::read_stream(StreamVar &var, int n) {
-	return std::visit([n](auto &reader) { return reader->read(static_cast<std::vector<klibpp::KSeq>::size_type>(n)); },
-	                  var);
+#ifdef MIINT_STATIC_BUILD
+	g_seq_read_error.clear();
+#endif
+	auto result = std::visit(
+	    [n](auto &reader) { return reader->read(static_cast<std::vector<klibpp::KSeq>::size_type>(n)); }, var);
+#ifdef MIINT_STATIC_BUILD
+	if (!g_seq_read_error.empty()) {
+		std::string msg = std::move(g_seq_read_error);
+		g_seq_read_error.clear();
+		throw duckdb::IOException(msg);
+	}
+#endif
+	return result;
 }
 
 SequenceReader::SequenceReader(const std::string &path1, const std::optional<std::string> &path2,

--- a/src/aspera_stream.cpp
+++ b/src/aspera_stream.cpp
@@ -369,32 +369,40 @@ AsperaSeqStream::~AsperaSeqStream() {
 }
 
 int aspera_seq_read(AsperaSeqStream *stream, void *dst, unsigned int len) {
-	if (!stream->is_gzipped) {
-		int n = stream->process->ReadBounded(dst, len);
-		if (n < 0) {
-			// ascp pipe returned a hard error (not EOF). Throw so the
-			// read_ena_sequences mid-stream catch records the run as truncated
-			// rather than silently treating the empty batch as completion.
-			throw duckdb::IOException("aspera_seq_read: ascp pipe read failed");
+	// On error: set the thread-local error channel and return -1; SequenceReader
+	// picks it up after kseq++ returns and raises IOException. See
+	// g_seq_read_error docs in duckdb_seq_stream.hpp.
+	try {
+		if (!stream->is_gzipped) {
+			int n = stream->process->ReadBounded(dst, len);
+			if (n < 0) {
+				g_seq_read_error = "aspera_seq_read: ascp pipe read failed";
+				return -1;
+			}
+			return n;
 		}
-		return n;
-	}
 
-	auto read_raw = [stream](void *buf, size_t sz) -> int {
-		// ReadBounded already returns -1 on error; propagate so
-		// InflateFromSource can surface it.
-		return stream->process->ReadBounded(buf, sz);
-	};
+		auto read_raw = [stream](void *buf, size_t sz) -> int {
+			return stream->process->ReadBounded(buf, sz);
+		};
 
-	int result = InflateFromSource(stream->zs, stream->compressed_buf, AsperaSeqStream::COMPRESSED_BUF_SIZE,
-	                               stream->compressed_avail, stream->compressed_next, stream->input_eof,
-	                               stream->stream_end, read_raw, dst, len);
-	if (result < 0) {
-		throw duckdb::IOException(stream->stream_end ? "aspera_seq_read: gzip decompression error"
-		                                             : "aspera_seq_read: gzip stream truncated before end marker "
-		                                               "(ascp transfer likely incomplete)");
+		int result = InflateFromSource(stream->zs, stream->compressed_buf, AsperaSeqStream::COMPRESSED_BUF_SIZE,
+		                               stream->compressed_avail, stream->compressed_next, stream->input_eof,
+		                               stream->stream_end, read_raw, dst, len);
+		if (result < 0) {
+			g_seq_read_error = stream->stream_end ? "aspera_seq_read: gzip decompression error"
+			                                      : "aspera_seq_read: gzip stream truncated before end marker "
+			                                        "(ascp transfer likely incomplete)";
+			return -1;
+		}
+		return result;
+	} catch (const std::exception &e) {
+		g_seq_read_error = std::string("aspera_seq_read: ") + e.what();
+		return -1;
+	} catch (...) {
+		g_seq_read_error = "aspera_seq_read: unknown error";
+		return -1;
 	}
-	return result;
 }
 
 int aspera_seq_close(AsperaSeqStream *stream) {

--- a/src/duckdb_seq_stream.cpp
+++ b/src/duckdb_seq_stream.cpp
@@ -1,9 +1,10 @@
 #include "duckdb_seq_stream.hpp"
-#include "duckdb/common/exception.hpp"
 
 #ifdef MIINT_STATIC_BUILD
 
 namespace miint {
+
+thread_local std::string g_seq_read_error;
 
 DuckDBSeqStream::DuckDBSeqStream()
     : is_gzipped(false), zs({}), zs_initialized(false), compressed_avail(0), compressed_next(nullptr), input_eof(false),
@@ -17,40 +18,45 @@ DuckDBSeqStream::~DuckDBSeqStream() {
 }
 
 int duckdb_seq_read(DuckDBSeqStream *stream, void *dst, unsigned int len) {
-	if (!stream->is_gzipped) {
-		auto n = stream->handle->Read(dst, len);
-		if (n < 0) {
-			// Upstream HTTP/file read failed. Throwing here surfaces as a
-			// mid-stream error in read_ena_sequences (loud warning + run
-			// added to skipped_runs), rather than the silent-empty-batch
-			// path that previously hid truncated downloads.
-			throw duckdb::IOException("duckdb_seq_read: upstream read failed");
+	// On any error: write a message to the thread-local error channel and
+	// return -1. SequenceReader::read_stream picks it up after kseq++ returns
+	// and raises IOException from a frame we control. See g_seq_read_error
+	// docs in the header for the rationale.
+	try {
+		if (!stream->is_gzipped) {
+			auto n = stream->handle->Read(dst, len);
+			if (n < 0) {
+				g_seq_read_error = "duckdb_seq_read: upstream read failed";
+				return -1;
+			}
+			return static_cast<int>(n);
 		}
-		return static_cast<int>(n);
-	}
 
-	auto read_raw = [stream](void *buf, size_t sz) -> int {
-		// Propagate negative results so InflateFromSource can return -1 and
-		// the gzip-truncation detection below fires. The previous mask
-		// `(n <= 0) ? 0 : n` actively hid HTTP read errors.
-		auto n = stream->handle->Read(buf, sz);
-		return static_cast<int>(n);
-	};
+		auto read_raw = [stream](void *buf, size_t sz) -> int {
+			auto n = stream->handle->Read(buf, sz);
+			return static_cast<int>(n);
+		};
 
-	int result = InflateFromSource(stream->zs, stream->compressed_buf, DuckDBSeqStream::COMPRESSED_BUF_SIZE,
-	                               stream->compressed_avail, stream->compressed_next, stream->input_eof,
-	                               stream->stream_end, read_raw, dst, len);
-	if (result < 0) {
-		// stream_end is set only when Z_STREAM_END was observed. If it's still
-		// false here, the gzip stream ended without a valid trailer — the
-		// signature of a half-downloaded file. If it's true, decompression
-		// itself failed (corrupt data). Either way: throw so the caller treats
-		// it as a real failure, not a clean EOF.
-		throw duckdb::IOException(stream->stream_end ? "duckdb_seq_read: gzip decompression error"
-		                                             : "duckdb_seq_read: gzip stream truncated before end marker "
-		                                               "(download likely incomplete)");
+		int result = InflateFromSource(stream->zs, stream->compressed_buf, DuckDBSeqStream::COMPRESSED_BUF_SIZE,
+		                               stream->compressed_avail, stream->compressed_next, stream->input_eof,
+		                               stream->stream_end, read_raw, dst, len);
+		if (result < 0) {
+			g_seq_read_error = stream->stream_end ? "duckdb_seq_read: gzip decompression error"
+			                                      : "duckdb_seq_read: gzip stream truncated before end marker "
+			                                        "(download likely incomplete)";
+			return -1;
+		}
+		return result;
+	} catch (const std::exception &e) {
+		// DuckDB's FileHandle::Read can throw on HTTP errors (libcurl
+		// CURLE_RECV_ERROR, etc.). Catch here so the throw never crosses
+		// kseq++'s template machinery.
+		g_seq_read_error = std::string("duckdb_seq_read: ") + e.what();
+		return -1;
+	} catch (...) {
+		g_seq_read_error = "duckdb_seq_read: unknown error";
+		return -1;
 	}
-	return result;
 }
 
 int duckdb_seq_close(DuckDBSeqStream *stream) {

--- a/src/include/aspera_stream.hpp
+++ b/src/include/aspera_stream.hpp
@@ -88,7 +88,9 @@ struct AsperaSeqStream {
 	AsperaSeqStream &operator=(const AsperaSeqStream &) = delete;
 };
 
-// kseq++ callbacks
+// kseq++ callbacks. aspera_seq_read never throws — on error it writes a
+// message to miint::g_seq_read_error and returns -1; SequenceReader inspects
+// the channel after kseq++ returns and raises IOException.
 int aspera_seq_read(AsperaSeqStream *stream, void *dst, unsigned int len);
 int aspera_seq_close(AsperaSeqStream *stream);
 

--- a/src/include/duckdb_seq_stream.hpp
+++ b/src/include/duckdb_seq_stream.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <zlib.h>
 #include <memory>
+#include <string>
 #include <kseq++/kseq++.hpp>
 
 #ifdef MIINT_STATIC_BUILD
@@ -8,6 +9,20 @@
 #endif
 
 namespace miint {
+
+// Per-thread error channel for the kseq++ read callbacks (`duckdb_seq_read`,
+// `aspera_seq_read`). We deliberately avoid throwing from inside those
+// callbacks: they're invoked deep inside kseq++'s template machinery, and
+// throwing across that boundary risked a recursive-terminate abort observed in
+// the field. Instead, on error the callback writes a human-readable message
+// here and returns -1 (which kseq++ tolerates cleanly via its err() flag), and
+// `SequenceReader::read_stream` checks this string after kseq++ returns and
+// raises `duckdb::IOException` from a frame we control.
+//
+// Lifetime: thread_local, so concurrent reads on different threads don't
+// stomp each other. `read_stream` clears it before each kseq call and consumes
+// it afterward.
+extern thread_local std::string g_seq_read_error;
 
 // Shared zlib inflate helper used by both DuckDBSeqStream and AsperaSeqStream.
 // ReadRawFn signature: int(void *dst, size_t len) — returns bytes read (>0), 0=EOF, <0=error.


### PR DESCRIPTION
## Summary

Follow-up to #87. A user hit `terminate called recursively / Aborted (core dumped)` on the aspera path after the truncation-detection fix landed; HTTP was unaffected.

The fix in #87 made `aspera_seq_read` and `duckdb_seq_read` throw `IOException` directly when they detected a truncated stream or upstream read error. Those callbacks are invoked deep inside kseq++'s template machinery (`KStream::refill` → `getc` → `operator>>` → `read`). Throwing across that boundary has proven fragile in the field — the specific interaction with aspera's subprocess teardown (`AsperaProcess` dtor's SIGTERM + waitpid loop) appears to trigger a noexcept violation or recursive terminate that the HTTP path doesn't.

This PR moves the throw site one frame up, into code we control.

## Changes

- **Thread-local error channel** (`miint::g_seq_read_error`, declared in `duckdb_seq_stream.hpp`). Per-thread `std::string`, populated by the read callbacks on error.
- **`duckdb_seq_read` and `aspera_seq_read` no longer throw.** Their bodies are wrapped in `try/catch (...)`. On any error path — upstream read failure, gzip decompression error, EOF before `Z_STREAM_END` — they write a human-readable message to `g_seq_read_error` and return `-1`. kseq++ tolerates `-1` cleanly via its `err()` flag.
- **`SequenceReader::read_stream` clears the channel before the kseq call and inspects it after.** If non-empty, it raises `duckdb::IOException` with the stored message from a frame outside kseq++'s template instantiations.

The truncation-detection logic in `InflateFromSource` (the `Z_STREAM_END` tracking and EOF-before-trailer detection added in #87) is unchanged — only the location of the throw moves.

## Caller-visible behavior

Identical to #87 for the `read_ena_sequences.cpp:396` mid-stream catch:

- Same `IOException` type.
- Same loud `"WARNING: run 'X' failed mid-stream after emitting N read(s)"` message.
- Same `skipped_runs` recording and end-of-scan summary.
- Same queryability via `miint_warnings()`.

## Test plan

- [x] `./build/release/extension/miint/tests "[SequenceReader]"` — 22 cases, 83 assertions pass.
- [x] `./build/release/test/unittest "test/sql/read_fastx.test"` — 192 assertions pass.
- [x] `make format-check` passes (clang-format 11.0.1, black 24.10.0).
- [ ] Reviewer to retry the original failing aspera `COPY` against the same accession set to confirm the abort is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)