### PR TITLE
feat(unifrac): respect DuckDB thread count instead of OpenMP default

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -126,18 +126,21 @@ jobs:
 
       - name: Install tutorial test dependencies
         shell: bash -el {0}
-        # `python3 -m pip` (not bare `pip`) guarantees the install targets the
-        # same interpreter `run_tutorial_tests.sh` invokes below — `pip` on the
-        # runner resolves to system pip (Python 3.12, falls back to user
-        # site-packages because system site is read-only), while `python3`
-        # under `bash -el` resolves to conda base's python3 and would miss
-        # those user-site installs. Keeping pip and the runtime locked to the
-        # same interpreter is what makes `import duckdb` find the package.
-        run: python3 -m pip install duckdb==$(./build/release/duckdb -csv -noheader -c "SELECT ltrim(version(), 'v');") pyarrow pandas matplotlib
+        # Pin BOTH install and runtime to `/usr/bin/python3` (system Python
+        # 3.12). Under `shell: bash -el {0}`, conda-incubator/setup-miniconda
+        # auto-activates a "test" env whose python3 has no pip module
+        # ("No module named pip"), so `python3 -m pip` fails. Meanwhile bare
+        # `pip` resolves to system pip (Python 3.12) and falls back to user
+        # site-packages ("Defaulting to user installation"), but the next
+        # step's `python3` would resolve to conda's and miss those installs.
+        # Using the absolute path `/usr/bin/python3` for both steps sidesteps
+        # the conda env entirely for this Python concern while leaving
+        # bowtie2 / FastTree (conda-installed binaries) untouched on PATH.
+        run: /usr/bin/python3 -m pip install --user duckdb==$(./build/release/duckdb -csv -noheader -c "SELECT ltrim(version(), 'v');") pyarrow pandas matplotlib
 
       - name: Run tutorial tests
         shell: bash -el {0}
-        run: PYTHON=python3 bash onboarding-tutorials/run_tutorial_tests.sh ./build/release/duckdb
+        run: PYTHON=/usr/bin/python3 bash onboarding-tutorials/run_tutorial_tests.sh ./build/release/duckdb
 
   test-wasm-compatible-build:
     name: Test WASM-compatible build (no HDF5/Bowtie2)

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -126,7 +126,14 @@ jobs:
 
       - name: Install tutorial test dependencies
         shell: bash -el {0}
-        run: pip install duckdb==$(./build/release/duckdb -csv -noheader -c "SELECT ltrim(version(), 'v');") pyarrow pandas matplotlib
+        # `python3 -m pip` (not bare `pip`) guarantees the install targets the
+        # same interpreter `run_tutorial_tests.sh` invokes below — `pip` on the
+        # runner resolves to system pip (Python 3.12, falls back to user
+        # site-packages because system site is read-only), while `python3`
+        # under `bash -el` resolves to conda base's python3 and would miss
+        # those user-site installs. Keeping pip and the runtime locked to the
+        # same interpreter is what makes `import duckdb` find the package.
+        run: python3 -m pip install duckdb==$(./build/release/duckdb -csv -noheader -c "SELECT ltrim(version(), 'v');") pyarrow pandas matplotlib
 
       - name: Run tutorial tests
         shell: bash -el {0}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1103,6 +1103,7 @@ if(MIINT_ENABLE_UNIFRAC)
         src/unifrac_bptree.cpp
         src/unifrac_metadata.cpp
         src/unifrac_distance.cpp
+        src/unifrac_omp_scope.cpp
         src/unifrac_subsample_bridge.cpp
         src/unifrac_function_common.cpp
         src/unifrac_pcoa_function.cpp
@@ -1493,6 +1494,7 @@ if(MIINT_ENABLE_UNIFRAC)
         src/unifrac_bptree.cpp
         src/unifrac_metadata.cpp
         src/unifrac_distance.cpp
+        src/unifrac_omp_scope.cpp
         src/unifrac_subsample_bridge.cpp
         test/cpp/test_UnifracSupportBiom.cpp
         test/cpp/test_UnifracBptree.cpp

--- a/src/include/unifrac_distance.hpp
+++ b/src/include/unifrac_distance.hpp
@@ -26,16 +26,21 @@ namespace miint::unifrac {
 // size. Always trust these values, never the pre-subsample
 // `ordered_sample_ids` from the input biom view.
 //
-// Thread safety: Compute() takes the process-wide libssu RNG mutex
-// internally — callers don't need to. The mutex is held only across
-// ssu_set_random_seed + one_off_matrix_inmem_fp32_v3, not for the
-// caller's downstream work on the returned matrix.
+// Thread safety: Compute() takes the process-wide libssu/OpenMP mutex
+// (via OmpThreadScope) internally — callers don't need to. The mutex is
+// held only across ssu_set_random_seed + one_off_matrix_inmem_fp32_v3,
+// not for the caller's downstream work on the returned matrix.
+//
+// `n_threads` pins the libssu OpenMP fan-out (must be >= 1). Callers
+// should resolve from DuckDB's TaskScheduler::NumberOfThreads() via
+// ResolveThreadsParameter; unit tests pass 1 to keep test wall time
+// independent of host core count.
 class UnifracDistanceMatrix {
 public:
 	static UnifracDistanceMatrix Compute(const UnifracSupportBiomView &biom_view, const UnifracBptreeView &bptree_view,
 	                                     const std::string &variant_fp32, bool variance_adjust, double alpha,
 	                                     bool bypass_tips, bool normalize_sample_counts, uint32_t subsample_depth,
-	                                     bool subsample_with_replacement, int seed);
+	                                     bool subsample_with_replacement, int seed, int n_threads);
 
 	~UnifracDistanceMatrix();
 	UnifracDistanceMatrix(UnifracDistanceMatrix &&other) noexcept;

--- a/src/include/unifrac_function_common.hpp
+++ b/src/include/unifrac_function_common.hpp
@@ -51,4 +51,21 @@ inline std::string AcceptedVariantList() {
 std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, const std::string &table_name,
                                                      const std::string &caller_name);
 
+// Resolve the user-supplied `threads` named parameter into a concrete count
+// that the libssu / scikit-bio-binaries OpenMP regions will run with.
+//
+// Convention:
+//   * `user_value == 0` (unset or explicit 0) → fall back to DuckDB's
+//     TaskScheduler::NumberOfThreads(). We never fall back to OpenMP's
+//     default (all cores) — duckdb-miint always pins thread count to
+//     DuckDB's understanding of the system.
+//   * `user_value > 0`                        → use as-is.
+//   * `user_value < 0`                        → BinderException via caller_name.
+//
+// `caller_name` is the SQL function name used in the error message
+// (e.g., "unifrac_pcoa").
+//
+// Returns a positive int suitable for OmpThreadScope.
+int ResolveThreadsParameter(ClientContext &context, int32_t user_value, const std::string &caller_name);
+
 } // namespace duckdb::unifrac_internal

--- a/src/include/unifrac_omp_scope.hpp
+++ b/src/include/unifrac_omp_scope.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <mutex>
+
+namespace miint::unifrac {
+
+// RAII scope that pins libssu / scikit-bio-binaries OpenMP fan-out to a
+// caller-chosen thread count for the duration of one upstream compute call.
+//
+// libssu and skbb both use raw `#pragma omp parallel for` (see api.cpp:34-36
+// upstream: "Threading is now full controlled by OpenMP. Any threads variable
+// is really referring to n_substeps."). Without explicit control, OpenMP
+// defaults to all detected cores and ignores DuckDB's `SET threads = N`.
+// The duckdb-miint contract is the opposite: every compute call honors
+// DuckDB's TaskScheduler thread count (or a per-call override).
+//
+// Thread safety: `omp_set_num_threads` mutates a process-global setting, so
+// concurrent libssu/skbb calls from different DuckDB queries would race.
+// This class holds a process-wide static mutex for its entire lifetime —
+// callers therefore also get the serialization that libssu's RNG state
+// requires (this scope replaces the previous standalone GlobalRngMutex in
+// unifrac_distance.cpp).
+//
+// Construction sets the OpenMP thread count to `n_threads` after saving the
+// previous value; destruction restores it. `n_threads` must be >= 1.
+class OmpThreadScope {
+public:
+	explicit OmpThreadScope(int n_threads);
+	~OmpThreadScope();
+
+	OmpThreadScope(const OmpThreadScope &) = delete;
+	OmpThreadScope &operator=(const OmpThreadScope &) = delete;
+	OmpThreadScope(OmpThreadScope &&) = delete;
+	OmpThreadScope &operator=(OmpThreadScope &&) = delete;
+
+private:
+	std::unique_lock<std::mutex> lock_;
+	int prev_threads_;
+};
+
+} // namespace miint::unifrac

--- a/src/unifrac_distance.cpp
+++ b/src/unifrac_distance.cpp
@@ -1,24 +1,13 @@
 #include "unifrac_distance.hpp"
 
-#include <mutex>
 #include <stdexcept>
 #include <string>
+
+#include "unifrac_omp_scope.hpp"
 
 namespace miint::unifrac {
 
 namespace {
-
-// Process-wide serialization for libssu calls that touch the global skbb
-// RNG. one_off_matrix_inmem_fp32_v3 with subsample_depth > 0 reads the
-// RNG state set by ssu_set_random_seed; concurrent invocations from
-// multiple DuckDB connections would otherwise interleave seed updates.
-// We always hold the mutex around the libssu call even when
-// subsample_depth == 0 — uniform call site, negligible cost relative to
-// the distance computation itself.
-std::mutex &GlobalRngMutex() {
-	static std::mutex m;
-	return m;
-}
 
 const char *ComputeStatusName(ComputeStatus s) {
 	switch (s) {
@@ -51,10 +40,14 @@ UnifracDistanceMatrix UnifracDistanceMatrix::Compute(const UnifracSupportBiomVie
                                                      const std::string &variant_fp32, bool variance_adjust,
                                                      double alpha, bool bypass_tips, bool normalize_sample_counts,
                                                      uint32_t subsample_depth, bool subsample_with_replacement,
-                                                     int seed) {
+                                                     int seed, int n_threads) {
 	mat_full_fp32_t *mat = nullptr;
 	{
-		std::lock_guard<std::mutex> lock(GlobalRngMutex());
+		// OmpThreadScope holds the process-wide libssu/OpenMP mutex for its
+		// lifetime, so it also covers ssu_set_random_seed's global RNG state
+		// (concurrent invocations from multiple DuckDB connections would
+		// otherwise interleave seed updates).
+		OmpThreadScope omp_scope(n_threads);
 		if (seed >= 0) {
 			ssu_set_random_seed(static_cast<unsigned int>(seed));
 		}

--- a/src/unifrac_faith_pd_function.cpp
+++ b/src/unifrac_faith_pd_function.cpp
@@ -12,6 +12,7 @@
 #include "unifrac_bptree.hpp"
 #include "unifrac_function_common.hpp"
 #include "unifrac_libssu.hpp"
+#include "unifrac_omp_scope.hpp"
 #include "unifrac_subsample_bridge.hpp"
 #include "unifrac_support_biom.hpp"
 
@@ -27,6 +28,7 @@ namespace duckdb {
 namespace {
 
 using unifrac_internal::ReadFeatureTable;
+using unifrac_internal::ResolveThreadsParameter;
 
 struct FaithPdRow {
 	int32_t iteration;
@@ -90,10 +92,17 @@ private:
 // downstream SQL queries should ORDER BY sample_id regardless rather than
 // rely on this implementation detail.
 void RunFaithPd(const miint::unifrac::UnifracSupportBiomView &biom_view,
-                const miint::unifrac::UnifracBptreeView &bptree_view, int32_t iteration_index,
+                const miint::unifrac::UnifracBptreeView &bptree_view, int n_threads, int32_t iteration_index,
                 std::vector<FaithPdRow> &out_rows) {
 	ResultsVecHandle result;
-	ComputeStatus status = faith_pd_inmem(biom_view.support_biom(), bptree_view.support_bptree(), result.out());
+	ComputeStatus status;
+	{
+		// faith_pd_inmem internally uses libssu's OpenMP-parallel tree
+		// traversal; pin its fan-out to n_threads under the process-wide
+		// libssu/OpenMP mutex so concurrent queries can't race.
+		miint::unifrac::OmpThreadScope omp_scope(n_threads);
+		status = faith_pd_inmem(biom_view.support_biom(), bptree_view.support_bptree(), result.out());
+	}
 	if (status != okay) {
 		throw InvalidInputException("unifrac_faith_pd: libssu faith_pd_inmem returned status %d",
 		                            static_cast<int>(status));
@@ -124,6 +133,7 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 	bool subsample_with_replacement = false;
 	int32_t n_subsamples = 1;
 	int32_t seed = -1;
+	int32_t threads = 0; // 0 = follow DuckDB's TaskScheduler::NumberOfThreads()
 	for (const auto &kv : input.named_parameters) {
 		const auto key = StringUtil::Lower(kv.first);
 		if (key == "subsample_depth") {
@@ -134,8 +144,11 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 			n_subsamples = kv.second.GetValue<int32_t>();
 		} else if (key == "seed") {
 			seed = kv.second.GetValue<int32_t>();
+		} else if (key == "threads") {
+			threads = kv.second.GetValue<int32_t>();
 		}
 	}
+	const int n_threads = ResolveThreadsParameter(context, threads, "unifrac_faith_pd");
 
 	if (n_subsamples < 1) {
 		throw BinderException("unifrac_faith_pd: n_subsamples must be >= 1 (got %d)", n_subsamples);
@@ -188,7 +201,7 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 	if (subsample_depth == 0) {
 		// No subsampling: n_subsamples > 1 is already rejected above, so this
 		// branch always runs exactly once with iteration_index=0.
-		RunFaithPd(biom_view, bptree_view, /*iteration_index*/ 0, data->rows);
+		RunFaithPd(biom_view, bptree_view, n_threads, /*iteration_index*/ 0, data->rows);
 	} else {
 		const auto depth = static_cast<uint32_t>(subsample_depth);
 		for (int32_t i = 0; i < n_subsamples; ++i) {
@@ -203,7 +216,7 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 					throw InvalidInputException("unifrac_faith_pd: %s", e.what());
 				}
 			}();
-			RunFaithPd(sub, bptree_view, i, data->rows);
+			RunFaithPd(sub, bptree_view, n_threads, i, data->rows);
 		}
 	}
 
@@ -258,6 +271,7 @@ void RegisterUnifracFaithPD(ExtensionLoader &loader) {
 	fn.named_parameters["subsample_with_replacement"] = LogicalType::BOOLEAN;
 	fn.named_parameters["n_subsamples"] = LogicalType::INTEGER;
 	fn.named_parameters["seed"] = LogicalType::INTEGER;
+	fn.named_parameters["threads"] = LogicalType::INTEGER;
 	loader.RegisterFunction(fn);
 }
 

--- a/src/unifrac_function_common.cpp
+++ b/src/unifrac_function_common.cpp
@@ -3,11 +3,13 @@
 #include <cmath>
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/query_result.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 namespace duckdb::unifrac_internal {
 
@@ -61,6 +63,19 @@ std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, con
 		}
 	}
 	return rows;
+}
+
+int ResolveThreadsParameter(ClientContext &context, int32_t user_value, const std::string &caller_name) {
+	if (user_value < 0) {
+		throw BinderException("%s: threads must be >= 0 (got %d; use 0 to follow DuckDB's thread count)", caller_name,
+		                      user_value);
+	}
+	if (user_value > 0) {
+		return static_cast<int>(user_value);
+	}
+	// user_value == 0 → follow DuckDB. NumberOfThreads() is always >= 1.
+	const auto db_threads = TaskScheduler::GetScheduler(context).NumberOfThreads();
+	return NumericCast<int>(db_threads);
 }
 
 } // namespace duckdb::unifrac_internal

--- a/src/unifrac_omp_scope.cpp
+++ b/src/unifrac_omp_scope.cpp
@@ -1,0 +1,29 @@
+#include "unifrac_omp_scope.hpp"
+
+#include <stdexcept>
+
+#include <omp.h>
+
+namespace miint::unifrac {
+
+namespace {
+
+std::mutex &GlobalLibssuMutex() {
+	static std::mutex m;
+	return m;
+}
+
+} // namespace
+
+OmpThreadScope::OmpThreadScope(int n_threads) : lock_(GlobalLibssuMutex()), prev_threads_(omp_get_max_threads()) {
+	if (n_threads < 1) {
+		throw std::invalid_argument("OmpThreadScope: n_threads must be >= 1");
+	}
+	omp_set_num_threads(n_threads);
+}
+
+OmpThreadScope::~OmpThreadScope() {
+	omp_set_num_threads(prev_threads_);
+}
+
+} // namespace miint::unifrac

--- a/src/unifrac_pcoa_function.cpp
+++ b/src/unifrac_pcoa_function.cpp
@@ -12,6 +12,7 @@
 #include "unifrac_bptree.hpp"
 #include "unifrac_distance.hpp"
 #include "unifrac_function_common.hpp"
+#include "unifrac_omp_scope.hpp"
 #include "unifrac_support_biom.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -31,6 +32,7 @@ namespace {
 using unifrac_internal::AcceptedVariantList;
 using unifrac_internal::IsValidVariant;
 using unifrac_internal::ReadFeatureTable;
+using unifrac_internal::ResolveThreadsParameter;
 
 struct PcoaRow {
 	int32_t iteration;
@@ -66,7 +68,7 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
                          const miint::unifrac::UnifracBptreeView &bptree_view, const std::string &variant_fp32,
                          bool variance_adjust, double alpha, bool bypass_tips, bool normalize_sample_counts,
                          uint32_t subsample_depth, bool subsample_with_replacement, int seed_iter, uint32_t n_dims,
-                         int32_t iteration_index, std::vector<PcoaRow> &out_rows) {
+                         int n_threads, int32_t iteration_index, std::vector<PcoaRow> &out_rows) {
 	// UnifracDistanceMatrix::Compute throws std::runtime_error on libssu
 	// errors (unknown_method, table_empty, table_and_tree_do_not_overlap,
 	// output_error). The tree/feature mismatch case is already caught
@@ -76,7 +78,7 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
 		try {
 			return miint::unifrac::UnifracDistanceMatrix::Compute(
 			    biom_view, bptree_view, variant_fp32, variance_adjust, alpha, bypass_tips, normalize_sample_counts,
-			    subsample_depth, subsample_with_replacement, seed_iter);
+			    subsample_depth, subsample_with_replacement, seed_iter, n_threads);
 		} catch (const std::runtime_error &e) {
 			throw InvalidInputException("unifrac_pcoa: %s", e.what());
 		}
@@ -97,9 +99,15 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
 	std::vector<float> samples(static_cast<size_t>(actual_n_samples) * n_dims);
 	std::vector<float> prop(n_dims);
 
-	// skbb_pcoa_fsvd_fp32 uses its own per-call seed; no libssu mutex needed.
-	skbb_pcoa_fsvd_fp32(actual_n_samples, dist.matrix(), n_dims, seed_iter, eigvals.data(), samples.data(),
-	                    prop.data());
+	// skbb_pcoa_fsvd_fp32 uses its own per-call seed for randomization, but its
+	// `#pragma omp parallel for` regions (principal_coordinate_analysis.cpp)
+	// still need the process-wide OpenMP serialization so concurrent queries
+	// don't race on omp_set_num_threads.
+	{
+		miint::unifrac::OmpThreadScope omp_scope(n_threads);
+		skbb_pcoa_fsvd_fp32(actual_n_samples, dist.matrix(), n_dims, seed_iter, eigvals.data(), samples.data(),
+		                    prop.data());
+	}
 
 	// samples is laid out (actual_n_samples × n_dims), sample-major. The header
 	// comment in ordination.h reads "(n_eighs × n_dims)" but the actual
@@ -145,6 +153,7 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 	bool subsample_with_replacement = false;
 	int32_t n_subsamples = 1;
 	int32_t seed = -1;
+	int32_t threads = 0; // 0 = follow DuckDB's TaskScheduler::NumberOfThreads()
 	for (const auto &kv : input.named_parameters) {
 		const auto key = StringUtil::Lower(kv.first);
 		if (key == "variant") {
@@ -167,8 +176,11 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 			n_subsamples = kv.second.GetValue<int32_t>();
 		} else if (key == "seed") {
 			seed = kv.second.GetValue<int32_t>();
+		} else if (key == "threads") {
+			threads = kv.second.GetValue<int32_t>();
 		}
 	}
+	const int n_threads = ResolveThreadsParameter(context, threads, "unifrac_pcoa");
 
 	if (!IsValidVariant(variant)) {
 		throw BinderException("unifrac_pcoa: variant '%s' is not valid. Accepted variants: %s", variant,
@@ -249,7 +261,7 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 		const int seed_iter = (seed >= 0) ? (seed + i) : -1;
 		ComputeOneIteration(biom_view, bptree_view, variant_fp32, variance_adjust, alpha, bypass_tips,
 		                    normalize_sample_counts, static_cast<uint32_t>(subsample_depth), subsample_with_replacement,
-		                    seed_iter, static_cast<uint32_t>(n_dims), i, data->rows);
+		                    seed_iter, static_cast<uint32_t>(n_dims), n_threads, i, data->rows);
 	}
 
 	names.emplace_back("iteration");
@@ -322,6 +334,7 @@ void RegisterUnifracPcoa(ExtensionLoader &loader) {
 	fn.named_parameters["subsample_with_replacement"] = LogicalType::BOOLEAN;
 	fn.named_parameters["n_subsamples"] = LogicalType::INTEGER;
 	fn.named_parameters["seed"] = LogicalType::INTEGER;
+	fn.named_parameters["threads"] = LogicalType::INTEGER;
 	loader.RegisterFunction(fn);
 }
 

--- a/src/unifrac_permanova_function.cpp
+++ b/src/unifrac_permanova_function.cpp
@@ -14,6 +14,7 @@
 #include "unifrac_distance.hpp"
 #include "unifrac_function_common.hpp"
 #include "unifrac_metadata.hpp"
+#include "unifrac_omp_scope.hpp"
 #include "unifrac_support_biom.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -36,6 +37,7 @@ namespace {
 using unifrac_internal::AcceptedVariantList;
 using unifrac_internal::IsValidVariant;
 using unifrac_internal::ReadFeatureTable;
+using unifrac_internal::ResolveThreadsParameter;
 
 struct PermanovaRow {
 	int32_t iteration;
@@ -185,7 +187,7 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
                          uint32_t subsample_depth, bool subsample_with_replacement,
                          const std::vector<miint::unifrac::MetadataRow> &metadata_rows,
                          const std::vector<std::string> &requested_variables, int seed_iter, uint32_t n_permutations,
-                         int32_t iteration_index, std::vector<PermanovaRow> &out_rows) {
+                         int n_threads, int32_t iteration_index, std::vector<PermanovaRow> &out_rows) {
 	// UnifracDistanceMatrix::Compute throws std::runtime_error on libssu
 	// errors. The tree/feature mismatch case is already caught upstream by
 	// ValidateTreeCoversFeatures, so anything reaching here is a libssu
@@ -194,7 +196,7 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
 		try {
 			return miint::unifrac::UnifracDistanceMatrix::Compute(
 			    biom_view, bptree_view, variant_fp32, variance_adjust, alpha, bypass_tips, normalize_sample_counts,
-			    subsample_depth, subsample_with_replacement, seed_iter);
+			    subsample_depth, subsample_with_replacement, seed_iter, n_threads);
 		} catch (const std::runtime_error &e) {
 			throw InvalidInputException("unifrac_permanova: %s", e.what());
 		}
@@ -209,14 +211,20 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
 
 	const uint32_t n_samples = dist.n_samples();
 	for (const auto &grouping : groupings) {
-		// skbb_permanova_fp32 takes its own per-call seed (no libssu mutex
-		// needed). Using seed_iter across all variables in an iteration
-		// guarantees the Rule-7 invariant: identical groupings under the
-		// same distance matrix produce identical pseudo-F.
+		// skbb_permanova_fp32 takes its own per-call seed for randomization,
+		// but its `#pragma omp parallel for` regions (permanova.cpp) still
+		// need the process-wide OpenMP serialization so concurrent queries
+		// don't race on omp_set_num_threads. Using seed_iter across all
+		// variables in an iteration guarantees the Rule-7 invariant:
+		// identical groupings under the same distance matrix produce
+		// identical pseudo-F.
 		float f_stat = 0.0f;
 		float p_value = 0.0f;
-		skbb_permanova_fp32(n_samples, dist.matrix(), grouping.labels.data(), n_permutations, seed_iter, &f_stat,
-		                    &p_value);
+		{
+			miint::unifrac::OmpThreadScope omp_scope(n_threads);
+			skbb_permanova_fp32(n_samples, dist.matrix(), grouping.labels.data(), n_permutations, seed_iter, &f_stat,
+			                    &p_value);
+		}
 		PermanovaRow row;
 		row.iteration = iteration_index;
 		row.variable = grouping.variable;
@@ -252,6 +260,7 @@ unique_ptr<FunctionData> UnifracPermanovaBind(ClientContext &context, TableFunct
 	bool subsample_with_replacement = false;
 	int32_t n_subsamples = 1;
 	int32_t seed = -1;
+	int32_t threads = 0; // 0 = follow DuckDB's TaskScheduler::NumberOfThreads()
 	for (const auto &kv : input.named_parameters) {
 		const auto key = StringUtil::Lower(kv.first);
 		if (key == "variant") {
@@ -280,8 +289,11 @@ unique_ptr<FunctionData> UnifracPermanovaBind(ClientContext &context, TableFunct
 			n_subsamples = kv.second.GetValue<int32_t>();
 		} else if (key == "seed") {
 			seed = kv.second.GetValue<int32_t>();
+		} else if (key == "threads") {
+			threads = kv.second.GetValue<int32_t>();
 		}
 	}
+	const int n_threads = ResolveThreadsParameter(context, threads, "unifrac_permanova");
 
 	if (!IsValidVariant(variant)) {
 		throw BinderException("unifrac_permanova: variant '%s' is not valid. Accepted variants: %s", variant,
@@ -357,8 +369,8 @@ unique_ptr<FunctionData> UnifracPermanovaBind(ClientContext &context, TableFunct
 		const int seed_iter = (seed >= 0) ? (seed + i) : -1;
 		ComputeOneIteration(biom_view, bptree_view, variant_fp32, variance_adjust, alpha, bypass_tips,
 		                    normalize_sample_counts, static_cast<uint32_t>(subsample_depth), subsample_with_replacement,
-		                    metadata.rows, metadata.column_names, seed_iter, static_cast<uint32_t>(n_permutations), i,
-		                    data->rows);
+		                    metadata.rows, metadata.column_names, seed_iter, static_cast<uint32_t>(n_permutations),
+		                    n_threads, i, data->rows);
 	}
 
 	names.emplace_back("iteration");
@@ -431,6 +443,7 @@ void RegisterUnifracPermanova(ExtensionLoader &loader) {
 	fn.named_parameters["subsample_with_replacement"] = LogicalType::BOOLEAN;
 	fn.named_parameters["n_subsamples"] = LogicalType::INTEGER;
 	fn.named_parameters["seed"] = LogicalType::INTEGER;
+	fn.named_parameters["threads"] = LogicalType::INTEGER;
 	loader.RegisterFunction(fn);
 }
 

--- a/test/cpp/test_UnifracDistance.cpp
+++ b/test/cpp/test_UnifracDistance.cpp
@@ -50,7 +50,7 @@ TEST_CASE("UnifracDistanceMatrix computes a symmetric matrix with zero diagonal"
 	                                           /*variance_adjust*/ false, /*alpha*/ 1.0,
 	                                           /*bypass_tips*/ false, /*normalize_sample_counts*/ true,
 	                                           /*subsample_depth*/ 0, /*subsample_with_replacement*/ false,
-	                                           /*seed*/ 42);
+	                                           /*seed*/ 42, /*n_threads*/ 1);
 
 	REQUIRE(dist.n_samples() == 4);
 	REQUIRE(dist.sample_ids().size() == 4);
@@ -86,7 +86,7 @@ TEST_CASE("UnifracDistanceMatrix subsample_depth drops samples whose total count
 	                                           /*variance_adjust*/ false, /*alpha*/ 1.0,
 	                                           /*bypass_tips*/ false, /*normalize_sample_counts*/ true,
 	                                           /*subsample_depth*/ 2, /*subsample_with_replacement*/ false,
-	                                           /*seed*/ 42);
+	                                           /*seed*/ 42, /*n_threads*/ 1);
 
 	REQUIRE(dist.n_samples() == 3);
 	REQUIRE(dist.sample_ids().size() == 3);
@@ -101,7 +101,7 @@ TEST_CASE("UnifracDistanceMatrix is move-only and transfers ownership cleanly", 
 	// to be airtight so that destroy_mat_full_fp32 is called exactly once.
 	auto fixture = MakeLiveFixture();
 	auto dist = UnifracDistanceMatrix::Compute(fixture.biom, fixture.bptree, "weighted_normalized_fp32", false, 1.0,
-	                                           false, true, 0, false, 42);
+	                                           false, true, 0, false, 42, /*n_threads*/ 1);
 	const float *original_matrix = dist.matrix();
 	const uint32_t original_n = dist.n_samples();
 	REQUIRE(original_n == 4);
@@ -116,8 +116,9 @@ TEST_CASE("UnifracDistanceMatrix is move-only and transfers ownership cleanly", 
 
 	// Move assignment: a second target steals from the first; destructor
 	// of the first must NOT double-free the libssu pointer.
-	UnifracDistanceMatrix second = UnifracDistanceMatrix::Compute(
-	    fixture.biom, fixture.bptree, "weighted_normalized_fp32", false, 1.0, false, true, 0, false, 42);
+	UnifracDistanceMatrix second =
+	    UnifracDistanceMatrix::Compute(fixture.biom, fixture.bptree, "weighted_normalized_fp32", false, 1.0, false,
+	                                   true, 0, false, 42, /*n_threads*/ 1);
 	REQUIRE(second.matrix() != nullptr);
 	second = std::move(moved);
 	REQUIRE(second.n_samples() == 4);
@@ -134,6 +135,7 @@ TEST_CASE("UnifracDistanceMatrix surfaces libssu errors via std::runtime_error",
 	                                                 /*variance_adjust*/ false, /*alpha*/ 1.0,
 	                                                 /*bypass_tips*/ false, /*normalize_sample_counts*/ true,
 	                                                 /*subsample_depth*/ 0,
-	                                                 /*subsample_with_replacement*/ false, /*seed*/ -1),
+	                                                 /*subsample_with_replacement*/ false, /*seed*/ -1,
+	                                                 /*n_threads*/ 1),
 	                  std::runtime_error);
 }


### PR DESCRIPTION
## Summary

- `unifrac_pcoa`, `unifrac_permanova`, `unifrac_faith_pd`, and the underlying `UnifracDistanceMatrix::Compute` now pin libssu / scikit-bio-binaries OpenMP fan-out to DuckDB's `TaskScheduler::NumberOfThreads()` (or a per-call override). Adds a `threads` INTEGER named parameter: `0` = follow DuckDB, `>0` = explicit, `<0` = `BinderException`. Never falls back to OpenMP's default-all-cores.
- New `OmpThreadScope` RAII (`src/unifrac_omp_scope.{hpp,cpp}`) holds a process-wide static mutex for its lifetime and save/restores `omp_set_num_threads`. Subsumes the previous `GlobalRngMutex` in `unifrac_distance.cpp` — libssu RNG state rides on the same lock.
- New `unifrac_internal::ResolveThreadsParameter` helper validates and resolves the user value at bind time.

## Why

libssu and scikit-bio-binaries use raw `#pragma omp parallel for` with no thread-count parameter (upstream comment in `unifrac-binaries/src/api.cpp:34-36`: *"Threading is now full controlled by OpenMP. Any threads variable is really referring to n_substeps."*). Without intervention OpenMP defaults to every detected core, so `SET threads = 4; SELECT * FROM unifrac_pcoa(...)` silently fanned out to the full machine. After this change it honors `threads = 4`.

## Behavior change worth flagging

Users who today get the full machine when running unifrac will now be capped at DuckDB's thread count. To restore old behavior, pass `threads=<num_cores>` explicitly.

## Test plan

- [x] `bash build.sh` clean
- [x] `./build/release/extension/miint/tests "[unifrac]"` — 194 assertions, 37 cases pass
- [x] `UNIFRAC_AVAILABLE=1 ./build/release/test/unittest test/sql/unifrac_pcoa.test` — pass
- [x] `UNIFRAC_AVAILABLE=1 ./build/release/test/unittest test/sql/unifrac_permanova.test` — pass
- [x] `UNIFRAC_AVAILABLE=1 ./build/release/test/unittest test/sql/unifrac_faith_pd.test` — pass
- [x] `UNIFRAC_AVAILABLE=1 ./build/release/test/unittest test/sql/unifrac_available.test` — pass
- [x] `make format-check` passes (clang-format 11.0.1, black 24.10.0, cmake-format)
- [x] `duckdb_functions()` shows `threads` registered on all three table functions
- [x] `threads=-1` rejected at bind: `Binder Error: unifrac_pcoa: threads must be >= 0 (got -1; use 0 to follow DuckDB's thread count)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)