### PR TITLE
feat(align_minimap2): accept BIGINT read_id columns

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1065,7 +1065,8 @@ set(EXTENSION_SOURCES
     src/hfile_duckdb.cpp
     src/deblur.cpp
     src/deblur_table_function.cpp
-    src/per_sample_table_function.cpp)
+    src/per_sample_table_function.cpp
+    src/id_column_codec.cpp)
 
 if(MIINT_ENABLE_VSEARCH)
     list(APPEND EXTENSION_SOURCES
@@ -1452,6 +1453,8 @@ set(TEST_SOURCES
     test/cpp/test_hfile_duckdb.cpp
     src/deblur.cpp
     test/cpp/test_deblur.cpp
+    src/id_column_codec.cpp
+    test/cpp/test_id_column_codec.cpp
 )
 if(MIINT_ENABLE_HDF5 AND HDF5_FOUND)
     list(APPEND TEST_SOURCES src/BIOMTable.cpp src/BIOMReader.cpp

--- a/docs/copy-formats.md
+++ b/docs/copy-formats.md
@@ -94,15 +94,21 @@ TO 'output.fasta.gz' (FORMAT FASTA, INCLUDE_COMMENT true);
 Write query results to SAM or BAM format files. Requires all mandatory SAM columns from `read_alignments` output.
 
 **Required columns:**
-- `read_id` (VARCHAR): Query template name
+- `read_id` (VARCHAR or BIGINT): Query template name
 - `flags` (USMALLINT): Bitwise flags
-- `reference` (VARCHAR): Reference sequence name
+- `reference` (VARCHAR or BIGINT): Reference sequence name
 - `position` (BIGINT): 1-based leftmost mapping position
 - `mapq` (UTINYINT): Mapping quality
 - `cigar` (VARCHAR): CIGAR string
-- `mate_reference` (VARCHAR): Reference name of mate/next read
+- `mate_reference` (VARCHAR or BIGINT): Reference name of mate/next read
 - `mate_position` (BIGINT): Position of mate/next read
 - `template_length` (BIGINT): Observed template length
+
+**Identifier-column types (`read_id`, `reference`, `mate_reference`):**
+- Each column is independently `VARCHAR` or `BIGINT`. The three need not match. Other numeric types are rejected at bind time with the message `Column '<name>' must be VARCHAR or BIGINT`.
+- `BIGINT` values are stringified to decimal on write — the on-disk SAM/BAM record always carries text. NULL `BIGINT` values are written as the SAM `*` sentinel.
+- Round-trip through `read_alignments` / `read_sam` returns these columns as `VARCHAR` regardless of how they were written; the BIGINT type is not preserved on disk.
+- HTSlib normalises `RNEXT` to `=` when it equals `RNAME` at the reference-tid level. This applies to both VARCHAR and BIGINT writes — a `BIGINT` mate_reference that matches `reference` still appears as `=` when the file is read back.
 
 **Optional columns:**
 - `tag_as`, `tag_xs`, `tag_ys`, `tag_xn`, `tag_xm`, `tag_xo`, `tag_xg`, `tag_nm` (BIGINT): Optional integer tags

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -123,6 +123,20 @@ SAM alignments compute `stop_position` using HTSlib's `bam_endpos()`:
 - Coverage length = `stop_position - position` (no `+1`)
 - Critical for interval operations and coverage analysis
 
+### Identifier-column Codec (`id_column_codec` / `id_column_utils`)
+Functions that accept user-supplied identifier columns (`read_id`, `reference`, `mate_reference`) may opt in to BIGINT in addition to VARCHAR. The pattern is split across two layers:
+
+- `src/include/id_column_codec.hpp` / `src/id_column_codec.cpp` — pure C++ (`miint::ParseIdAsInt64`, `miint::FormatIdFromInt64`). No DuckDB types, so the `tests` C++ binary can link it directly without pulling in DuckDB.
+- `src/include/id_column_utils.hpp` — DuckDB-aware inline header (`duckdb::IsAllowedIdType`, `ExtractIdColumnAsStrings`, `EmitIdColumnFromStrings`). Wraps the codec and handles `Vector` / `DataChunk` / `LogicalType` plumbing.
+
+In-memory carriers (e.g. `SequenceRecordBatch::read_ids`, `SAMRecordBatch::read_ids`/`references`/`mate_references`) always store `std::vector<std::string>` — BIGINT inputs are stringified at the ingress boundary and parsed back at the egress boundary. This keeps the alignment hot loop type-agnostic.
+
+Dispatch is opt-in. Schema validators take an `allow_bigint` flag (default `false`); a caller that doesn't pass `true` keeps the historical VARCHAR-only contract. The captured `LogicalType` is threaded through the bind data so the emit side knows which output type to materialise. Default-constructed `LogicalType` is `INVALID`, so any path that forgets to capture the type fails loud at the helper dispatch rather than silently producing garbage.
+
+Sentinel rules (BIGINT egress): empty string and the SAM `*` sentinel both decode to NULL. The SAM `=` mate-reference sentinel has no BIGINT encoding and is the caller's responsibility to resolve to a real reference value before invoking the codec — `ParseIdAsInt64` throws on `=` to surface that contract. VARCHAR sentinels pass through unchanged.
+
+Currently used by `align_minimap2` + `save_minimap2_index` (both sides) and `copy_sam` (write side, decimal stringification only). The sharded paths (`align_minimap2_sharded`, `align_bowtie2_sharded`) are deliberately VARCHAR-only; the `read_to_shard` mapping table and the per-shard temp tables both assume VARCHAR. Other VARCHAR-only callers — sortmerna, bowtie2, search, cluster, uchime, mafft — pass `allow_bigint=false` for the same reason. Future extensions that want BIGINT support (e.g. `search_sequences`) should reuse these helpers rather than re-implementing dispatch.
+
 ## Code Style and Conventions
 
 - **C++ Standard**: C++20 (required for kseq++)

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -1601,8 +1601,8 @@ Align query sequences to subject sequences using minimap2. This function enables
 **Performance:** For large reference databases (e.g., human genome), use pre-built indexes via `index_path` for 10-30x faster alignment. Build indexes once with `save_minimap2_index`, then reuse them across multiple queries.
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2)
-- `subject_table` (VARCHAR, optional): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). **Either `subject_table` OR `index_path` must be provided, but not both.**
+- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR` or `BIGINT` (see *Identifier-column types* below).
+- `subject_table` (VARCHAR, optional): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR` or `BIGINT`. **Either `subject_table` OR `index_path` must be provided, but not both.**
 - `index_path` (VARCHAR, optional): Path to pre-built minimap2 index file (.mmi). Use `save_minimap2_index()` to create index files. **Either `subject_table` OR `index_path` must be provided, but not both.**
 - `per_subject_database` (BOOLEAN, default: false): Build separate index for each subject sequence (only valid with `subject_table`, not with `index_path`)
   - `false` (default): Build single index from all subjects, align all queries once (efficient for many subjects)
@@ -1619,14 +1619,14 @@ Align query sequences to subject sequences using minimap2. This function enables
 
 **Output schema:**
 Returns the same schema as `read_alignments` (21 columns):
-- `read_id` (VARCHAR): Query sequence identifier
+- `read_id` (VARCHAR or BIGINT — mirrors `query_table.read_id`): Query sequence identifier
 - `flags` (USMALLINT): SAM alignment flags
-- `reference` (VARCHAR): Subject sequence identifier
+- `reference` (VARCHAR or BIGINT — mirrors `subject_table.read_id`; always VARCHAR when using `index_path`): Subject sequence identifier
 - `position` (BIGINT): 1-based start position on reference
 - `stop_position` (BIGINT): 1-based stop position on reference
 - `mapq` (UTINYINT): Mapping quality
 - `cigar` (VARCHAR): CIGAR string (with =/X by default)
-- `mate_reference` (VARCHAR): Mate reference (for paired-end)
+- `mate_reference` (VARCHAR or BIGINT — same type as `reference`): Mate reference (for paired-end)
 - `mate_position` (BIGINT): Mate position (for paired-end)
 - `template_length` (BIGINT): Template length (for paired-end)
 - `tag_as` (BIGINT): Alignment score
@@ -1640,6 +1640,12 @@ Returns the same schema as `read_alignments` (21 columns):
 - `tag_yt` (VARCHAR): Pair type (UU/CP/DP/UP)
 - `tag_md` (VARCHAR): MD tag string
 - `tag_sa` (VARCHAR): Supplementary alignment info
+
+**Identifier-column types (`read_id`, `reference`, `mate_reference`):**
+- The input columns may be `VARCHAR` or `BIGINT`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column '<name>' in table '<table>' must be VARCHAR or BIGINT`.
+- The output `read_id` column type mirrors the query side. The output `reference` and `mate_reference` types mirror the subject side, **except when using `index_path`** — subject names stored in a `.mmi` file are opaque bytes, so both default to `VARCHAR` regardless of what the source table looked like when the index was built.
+- For `BIGINT` subjects, the SAM `=` mate-reference sentinel (which has no BIGINT encoding) is resolved to the primary reference value before being emitted; downstream consumers see the resolved numeric id, never `'='`.
+- For `BIGINT` columns, NULL input values and the SAM `'*'` unmapped sentinel are both surfaced as SQL NULL in the output. VARCHAR sentinels (`'*'`, `'='`) pass through verbatim, preserving pre-existing behaviour.
 
 **Behavior:**
 - Subject sequences are loaded into memory at bind time (must fit in RAM)
@@ -1753,7 +1759,7 @@ Build and save a minimap2 index to disk for reuse. This provides 10-30x performa
 **Use case:** Build indexes once for large reference databases (e.g., WoLr2 phylogenetic markers, RefSeq genomes, custom OGU databases), then use them repeatedly with `align_minimap2(..., index_path='file.mmi')` instead of rebuilding the index each time.
 
 **Parameters:**
-- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent)
+- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR` or `BIGINT`; `BIGINT` ids are stringified to decimal before being written into the index. When the index is later loaded via `align_minimap2(..., index_path=...)`, the recovered subject names are always `VARCHAR` (see *Identifier-column types* in `align_minimap2`).
 - `output_path` (VARCHAR): Path where the index file (.mmi) will be saved
 - `preset` (VARCHAR, default: 'sr'): Minimap2 preset (same options as `align_minimap2`)
 - `k` (INTEGER, optional): K-mer size (overrides preset default if specified)
@@ -1850,7 +1856,7 @@ SELECT * FROM save_minimap2_index('marker_genes', 'markers.mmi');
 Align query sequences against multiple pre-built minimap2 index shards in parallel. Each shard is a separate `.mmi` index file, and a mapping table specifies which reads should be aligned against which shard. This is designed for large-scale metagenomic workflows where the reference database is split across multiple shards and reads have been pre-assigned to shards (e.g., by a prior classification step).
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2)
+- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column **must be VARCHAR** in sharded mode — BIGINT `read_id` is supported by `align_minimap2` but not by the sharded variant.
 - `shard_directory` (VARCHAR, required): Path to directory containing pre-built minimap2 index files. Each shard's index is expected at `<shard_directory>/<shard_name>.mmi`
 - `read_to_shard` (VARCHAR, required): Name of table or view that maps reads to shards. Must have columns:
   - `read_id` (VARCHAR): Read identifier (must match read_id in query_table)

--- a/src/align_minimap2.cpp
+++ b/src/align_minimap2.cpp
@@ -44,8 +44,8 @@ unique_ptr<FunctionData> AlignMinimap2TableFunction::Bind(ClientContext &context
 		    "Use subject_table to build index from sequences, or index_path to load pre-built index.");
 	}
 
-	// Validate query table/view exists
-	data->query_schema = ValidateSequenceTableSchema(context, data->query_table);
+	// Validate query table/view exists (BIGINT read_id is opt-in for PR 1).
+	data->query_schema = ValidateSequenceTableSchema(context, data->query_table, /*allow_bigint=*/true);
 
 	// Parse optional named parameters
 	auto per_subject_param = input.named_parameters.find("per_subject_database");
@@ -83,12 +83,22 @@ unique_ptr<FunctionData> AlignMinimap2TableFunction::Bind(ClientContext &context
 		}
 
 		// Note: subjects vector remains empty in this mode
+		// Subject names in the .mmi file are opaque bytes — default to VARCHAR.
+		data->subject_id_type = LogicalType::VARCHAR;
 	} else {
-		// Traditional mode: load subjects (ReadSubjectTable validates internally)
-		data->subjects = ReadSubjectTable(context, data->subject_table);
+		// Traditional mode: validate subject schema, then load subjects.
+		// The subject schema's id_type drives the subject-side BIGINT/VARCHAR
+		// dispatch in ReadSubjectTable AND the output `reference` /
+		// `mate_reference` column types.
+		auto subject_schema = ValidateSequenceTableSchema(context, data->subject_table, /*allow_bigint=*/true);
+		data->subject_id_type = subject_schema.id_type;
+		data->subjects = ReadSubjectTable(context, data->subject_table, subject_schema);
 	}
 
-	// Set output schema
+	// Output schema: read_id mirrors the query column type; reference and
+	// mate_reference mirror the subject side.
+	data->types = GetAlignmentOutputTypes(data->query_schema.id_type, data->subject_id_type);
+
 	for (const auto &name : data->names) {
 		names.emplace_back(name);
 	}
@@ -223,7 +233,8 @@ static void ExecutePerSubject(ClientContext &context, const AlignMinimap2TableFu
 	}
 
 	idx_t output_count = std::min(available, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-	OutputSAMRecordBatch(output, ps.result_buffer, ps.buffer_offset, output_count);
+	OutputSAMRecordBatch(output, ps.result_buffer, ps.buffer_offset, output_count, bind_data.query_schema.id_type,
+	                     bind_data.subject_id_type);
 	ps.buffer_offset += output_count;
 }
 
@@ -238,7 +249,8 @@ static void ExecuteStandard(ClientContext &context, const AlignMinimap2TableFunc
 		idx_t available = lstate.result_buffer.size() - lstate.buffer_offset;
 		if (available > 0) {
 			idx_t output_count = std::min(available, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputSAMRecordBatch(output, lstate.result_buffer, lstate.buffer_offset, output_count);
+			OutputSAMRecordBatch(output, lstate.result_buffer, lstate.buffer_offset, output_count,
+			                     bind_data.query_schema.id_type, bind_data.subject_id_type);
 			lstate.buffer_offset += output_count;
 			return;
 		}

--- a/src/align_minimap2_sharded.cpp
+++ b/src/align_minimap2_sharded.cpp
@@ -74,7 +74,10 @@ unique_ptr<FunctionData> AlignMinimap2ShardedTableFunction::Bind(ClientContext &
 		throw BinderException("Shard directory does not exist: %s", data->shard_directory);
 	}
 
-	// Validate query table/view exists
+	// Validate query table/view exists. BIGINT read_id is NOT supported in
+	// sharded mode (PR 1): ReadShardIds + ReadBatchByIds + the read_to_shard
+	// temp table still assume VARCHAR. Leaving allow_bigint=false rejects
+	// BIGINT at bind with a clear "must be VARCHAR" error.
 	data->query_schema = ValidateSequenceTableSchema(context, data->query_table);
 
 	// Validate read_to_shard table schema
@@ -364,9 +367,11 @@ void AlignMinimap2ShardedTableFunction::Execute(ClientContext &context, TableFun
 		idx_t available = local_state.result_buffer.size() - local_state.buffer_offset;
 
 		if (available > 0) {
-			// Output up to STANDARD_VECTOR_SIZE results
+			// Output up to STANDARD_VECTOR_SIZE results.
+			// Sharded mode is VARCHAR-only in PR 1 — see Data() ctor comment.
 			idx_t output_count = std::min(available, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputSAMRecordBatch(output, local_state.result_buffer, local_state.buffer_offset, output_count);
+			OutputSAMRecordBatch(output, local_state.result_buffer, local_state.buffer_offset, output_count,
+			                     LogicalType::VARCHAR, LogicalType::VARCHAR);
 			if (bind_data.include_shard_name) {
 				auto shard_col_idx = output.ColumnCount() - 1;
 				auto &shard_vec = output.data[shard_col_idx];

--- a/src/copy_sam.cpp
+++ b/src/copy_sam.cpp
@@ -1,4 +1,6 @@
 #include "copy_sam.hpp"
+#include "id_column_codec.hpp"
+#include "id_column_utils.hpp"
 #include "reference_table_reader.hpp"
 #include "sequence_data_reader.hpp"
 #include "sequence_utils.hpp"
@@ -141,6 +143,13 @@ struct SAMCopyBindData : public FunctionData {
 	std::optional<string> sequence_data_table;
 	SAMColumnIndices indices; // Cached column indices
 
+	// Captured types of the three identifier columns. Each may be VARCHAR or
+	// BIGINT (validated at bind). Default-constructed LogicalType is INVALID so
+	// any path that forgets to set them fails loud at the Sink dispatch.
+	LogicalType read_id_type;
+	LogicalType reference_type;
+	LogicalType mate_reference_type;
+
 	unique_ptr<FunctionData> Copy() const override {
 		auto result = make_uniq<SAMCopyBindData>();
 		result->include_header = include_header;
@@ -152,6 +161,9 @@ struct SAMCopyBindData : public FunctionData {
 		result->reference_lengths_table = reference_lengths_table;
 		result->sequence_data_table = sequence_data_table;
 		result->indices = indices;
+		result->read_id_type = read_id_type;
+		result->reference_type = reference_type;
+		result->mate_reference_type = mate_reference_type;
 		return std::move(result);
 	}
 
@@ -209,14 +221,14 @@ static unique_ptr<FunctionData> SAMCopyBindInternal(ClientContext &context, Copy
 	}
 
 	// Validate column types
-	if (sql_types[indices.read_id_idx].id() != LogicalTypeId::VARCHAR) {
-		throw BinderException("Column 'read_id' must be VARCHAR");
+	if (!IsAllowedIdType(sql_types[indices.read_id_idx])) {
+		throw BinderException("Column 'read_id' must be VARCHAR or BIGINT");
 	}
 	if (sql_types[indices.flags_idx].id() != LogicalTypeId::USMALLINT) {
 		throw BinderException("Column 'flags' must be USMALLINT");
 	}
-	if (sql_types[indices.reference_idx].id() != LogicalTypeId::VARCHAR) {
-		throw BinderException("Column 'reference' must be VARCHAR");
+	if (!IsAllowedIdType(sql_types[indices.reference_idx])) {
+		throw BinderException("Column 'reference' must be VARCHAR or BIGINT");
 	}
 	if (sql_types[indices.position_idx].id() != LogicalTypeId::BIGINT) {
 		throw BinderException("Column 'position' must be BIGINT");
@@ -227,9 +239,14 @@ static unique_ptr<FunctionData> SAMCopyBindInternal(ClientContext &context, Copy
 	if (sql_types[indices.cigar_idx].id() != LogicalTypeId::VARCHAR) {
 		throw BinderException("Column 'cigar' must be VARCHAR");
 	}
-	if (sql_types[indices.mate_reference_idx].id() != LogicalTypeId::VARCHAR) {
-		throw BinderException("Column 'mate_reference' must be VARCHAR");
+	if (!IsAllowedIdType(sql_types[indices.mate_reference_idx])) {
+		throw BinderException("Column 'mate_reference' must be VARCHAR or BIGINT");
 	}
+
+	// Capture id-column types for the Sink's per-row dispatch.
+	result->read_id_type = sql_types[indices.read_id_idx];
+	result->reference_type = sql_types[indices.reference_idx];
+	result->mate_reference_type = sql_types[indices.mate_reference_idx];
 	if (sql_types[indices.mate_position_idx].id() != LogicalTypeId::BIGINT) {
 		throw BinderException("Column 'mate_position' must be BIGINT");
 	}
@@ -612,6 +629,28 @@ static void PrepareSeqQual(const SequenceDataMap &seq_data, const std::string &r
 }
 
 //===--------------------------------------------------------------------===//
+// Identifier-column dispatch (read_id, reference, mate_reference)
+//===--------------------------------------------------------------------===//
+// Returns the SAM textual representation of an identifier-column cell.
+// - VARCHAR: bytes verbatim. Validity is intentionally not consulted: NULL
+//   VARCHAR slots pass through as whatever string_t::GetString() yields, not
+//   as SAM '*'. Callers producing nullable VARCHAR identifier columns are
+//   responsible for pre-filtering.
+// - BIGINT:  decimal stringification; NULL → SAM '*' sentinel.
+static inline string ExtractSamIdField(const UnifiedVectorFormat &fmt, idx_t row_idx, const LogicalType &id_type) {
+	auto idx = fmt.sel->get_index(row_idx);
+	if (id_type.id() == LogicalTypeId::BIGINT) {
+		if (!fmt.validity.RowIsValid(idx)) {
+			return "*";
+		}
+		auto data = UnifiedVectorFormat::GetData<int64_t>(fmt);
+		return miint::FormatIdFromInt64(data[idx]);
+	}
+	auto data = UnifiedVectorFormat::GetData<string_t>(fmt);
+	return data[idx].GetString();
+}
+
+//===--------------------------------------------------------------------===//
 // Sink
 //===--------------------------------------------------------------------===//
 static void SAMCopySink(ExecutionContext &context, FunctionData &bind_data, GlobalFunctionData &gstate_p,
@@ -674,13 +713,12 @@ static void SAMCopySink(ExecutionContext &context, FunctionData &bind_data, Glob
 		input.data[indices.tag_sa_idx].ToUnifiedFormat(input.size(), tag_sa_data);
 	}
 
-	auto read_id_ptr = UnifiedVectorFormat::GetData<string_t>(read_id_data);
+	// read_id, reference, mate_reference dispatch on bind-captured types
+	// (VARCHAR or BIGINT) via ExtractSamIdField; no top-level pointer needed.
 	auto flags_ptr = UnifiedVectorFormat::GetData<uint16_t>(flags_data);
-	auto reference_ptr = UnifiedVectorFormat::GetData<string_t>(reference_data);
 	auto position_ptr = UnifiedVectorFormat::GetData<int64_t>(position_data);
 	auto mapq_ptr = UnifiedVectorFormat::GetData<uint8_t>(mapq_data);
 	auto cigar_ptr = UnifiedVectorFormat::GetData<string_t>(cigar_data);
-	auto mate_reference_ptr = UnifiedVectorFormat::GetData<string_t>(mate_reference_data);
 	auto mate_position_ptr = UnifiedVectorFormat::GetData<int64_t>(mate_position_data);
 	auto template_length_ptr = UnifiedVectorFormat::GetData<int64_t>(template_length_data);
 
@@ -722,23 +760,20 @@ static void SAMCopySink(ExecutionContext &context, FunctionData &bind_data, Glob
 
 	// Process each row
 	for (idx_t i = 0; i < input.size(); i++) {
-		auto read_id_idx = read_id_data.sel->get_index(i);
 		auto flags_idx = flags_data.sel->get_index(i);
-		auto reference_idx = reference_data.sel->get_index(i);
 		auto position_idx = position_data.sel->get_index(i);
 		auto mapq_idx = mapq_data.sel->get_index(i);
 		auto cigar_idx = cigar_data.sel->get_index(i);
-		auto mate_reference_idx = mate_reference_data.sel->get_index(i);
 		auto mate_position_idx = mate_position_data.sel->get_index(i);
 		auto template_length_idx = template_length_data.sel->get_index(i);
 
-		string read_id = read_id_ptr[read_id_idx].GetString();
+		string read_id = ExtractSamIdField(read_id_data, i, fdata.read_id_type);
 		uint16_t flags = flags_ptr[flags_idx];
-		string reference = reference_ptr[reference_idx].GetString();
+		string reference = ExtractSamIdField(reference_data, i, fdata.reference_type);
 		int64_t position = position_ptr[position_idx];
 		uint8_t mapq = mapq_ptr[mapq_idx];
 		string cigar_str = cigar_ptr[cigar_idx].GetString();
-		string mate_reference = mate_reference_ptr[mate_reference_idx].GetString();
+		string mate_reference = ExtractSamIdField(mate_reference_data, i, fdata.mate_reference_type);
 		int64_t mate_position = mate_position_ptr[mate_position_idx];
 		int64_t template_length = template_length_ptr[template_length_idx];
 

--- a/src/id_column_codec.cpp
+++ b/src/id_column_codec.cpp
@@ -1,0 +1,37 @@
+#include "id_column_codec.hpp"
+
+#include <charconv>
+#include <stdexcept>
+#include <string>
+#include <system_error>
+
+namespace miint {
+
+std::optional<int64_t> ParseIdAsInt64(const std::string &s) {
+	if (s.empty() || s == "*") {
+		return std::nullopt;
+	}
+	// std::from_chars is locale-independent and strict: it rejects leading
+	// whitespace, '+' sign, and float-like input. Together with the trailing
+	// check below this gives us exactly the round-trip contract we want.
+	const char *begin = s.data();
+	const char *end = begin + s.size();
+	int64_t v = 0;
+	auto [ptr, ec] = std::from_chars(begin, end, v);
+	if (ec == std::errc::invalid_argument) {
+		throw std::invalid_argument("ParseIdAsInt64: not a decimal integer: '" + s + "'");
+	}
+	if (ec == std::errc::result_out_of_range) {
+		throw std::out_of_range("ParseIdAsInt64: out of int64 range: '" + s + "'");
+	}
+	if (ptr != end) {
+		throw std::invalid_argument("ParseIdAsInt64: trailing characters in '" + s + "'");
+	}
+	return v;
+}
+
+std::string FormatIdFromInt64(int64_t v) {
+	return std::to_string(v);
+}
+
+} // namespace miint

--- a/src/include/align_common.hpp
+++ b/src/include/align_common.hpp
@@ -9,6 +9,7 @@
 #include "Minimap2Aligner.hpp"
 #include "SAMRecord.hpp"
 #include "align_result_utils.hpp"
+#include "id_column_utils.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
@@ -34,16 +35,20 @@ inline std::vector<std::string> GetAlignmentOutputNames() {
 	        "tag_xm",         "tag_xo",        "tag_xg",          "tag_nm",   "tag_yt",        "tag_md", "tag_sa"};
 }
 
-// Get the standard alignment output column types
-inline std::vector<LogicalType> GetAlignmentOutputTypes() {
-	return {LogicalType::VARCHAR,   // read_id
+// Get the standard alignment output column types.
+// `query_id_type` drives `read_id`; `subject_id_type` drives `reference` and
+// `mate_reference`. Both must be VARCHAR or BIGINT. No default arguments —
+// every caller must make the choice explicit so the audit can't slip.
+inline std::vector<LogicalType> GetAlignmentOutputTypes(const LogicalType &query_id_type,
+                                                        const LogicalType &subject_id_type) {
+	return {query_id_type,          // read_id (mirrors query)
 	        LogicalType::USMALLINT, // flags
-	        LogicalType::VARCHAR,   // reference
+	        subject_id_type,        // reference (mirrors subject)
 	        LogicalType::BIGINT,    // position
 	        LogicalType::BIGINT,    // stop_position
 	        LogicalType::UTINYINT,  // mapq
 	        LogicalType::VARCHAR,   // cigar
-	        LogicalType::VARCHAR,   // mate_reference
+	        subject_id_type,        // mate_reference (mirrors subject)
 	        LogicalType::BIGINT,    // mate_position
 	        LogicalType::BIGINT,    // template_length
 	        LogicalType::BIGINT,    // tag_as
@@ -105,18 +110,41 @@ inline void ParseMinimap2ConfigParams(const named_parameter_map_t &params, miint
 	}
 }
 
-// Output SAMRecordBatch to DataChunk using standard alignment schema
-// Returns the number of records output
-inline idx_t OutputSAMRecordBatch(DataChunk &output, const miint::SAMRecordBatch &batch, idx_t offset, idx_t count) {
+// Output SAMRecordBatch to DataChunk using the standard alignment schema.
+// `query_id_type` and `subject_id_type` drive the three id columns
+// (read_id / reference / mate_reference). Both must be VARCHAR or BIGINT.
+// For BIGINT subject output, the SAM "=" sentinel in mate_reference is
+// resolved to the row's `reference` value before emit (the literal "="
+// has no BIGINT encoding). VARCHAR output preserves "=" as-is, matching
+// pre-existing user-observable behavior.
+// Returns the number of records output.
+inline idx_t OutputSAMRecordBatch(DataChunk &output, const miint::SAMRecordBatch &batch, idx_t offset, idx_t count,
+                                  const LogicalType &query_id_type, const LogicalType &subject_id_type) {
 	idx_t field_idx = 0;
-	SetAlignResultString(output.data[field_idx++], batch.read_ids, offset, count);
+	EmitIdColumnFromStrings(output.data[field_idx++], batch.read_ids, offset, count, query_id_type);
 	SetAlignResultUInt16(output.data[field_idx++], batch.flags, offset, count);
-	SetAlignResultString(output.data[field_idx++], batch.references, offset, count);
+	EmitIdColumnFromStrings(output.data[field_idx++], batch.references, offset, count, subject_id_type);
 	SetAlignResultInt64(output.data[field_idx++], batch.positions, offset, count);
 	SetAlignResultInt64(output.data[field_idx++], batch.stop_positions, offset, count);
 	SetAlignResultUInt8(output.data[field_idx++], batch.mapqs, offset, count);
 	SetAlignResultString(output.data[field_idx++], batch.cigars, offset, count);
-	SetAlignResultString(output.data[field_idx++], batch.mate_references, offset, count);
+
+	// Emit mate_reference. For BIGINT subjects, resolve any "=" sentinel
+	// (mate maps to same reference as primary) into the row's reference
+	// value via a local copy — the codec rejects "=" for BIGINT and there
+	// is no in-band way to encode it.
+	if (subject_id_type.id() == LogicalTypeId::BIGINT) {
+		std::vector<std::string> resolved_mate_refs;
+		resolved_mate_refs.reserve(count);
+		for (idx_t j = 0; j < count; j++) {
+			const auto &mr = batch.mate_references[offset + j];
+			resolved_mate_refs.push_back(mr == "=" ? batch.references[offset + j] : mr);
+		}
+		EmitIdColumnFromStrings(output.data[field_idx++], resolved_mate_refs, 0, count, subject_id_type);
+	} else {
+		EmitIdColumnFromStrings(output.data[field_idx++], batch.mate_references, offset, count, subject_id_type);
+	}
+
 	SetAlignResultInt64(output.data[field_idx++], batch.mate_positions, offset, count);
 	SetAlignResultInt64(output.data[field_idx++], batch.template_lengths, offset, count);
 	SetAlignResultInt64Nullable(output.data[field_idx++], batch.tag_as_values, offset, count);

--- a/src/include/align_minimap2.hpp
+++ b/src/include/align_minimap2.hpp
@@ -29,18 +29,31 @@ public:
 		SequenceTableSchema query_schema;
 		std::vector<miint::AlignmentSubject> subjects; // Pre-loaded at bind time (empty if using index_path)
 
+		// Subject-side id type. Drives output `reference` + `mate_reference`.
+		// Defaults to INVALID so a Bind path that forgets to set it fails loud
+		// at the helper dispatch in id_column_utils.hpp rather than silently
+		// producing wrong-typed output. Bind sets it explicitly: subject_table
+		// mode pulls from the subject schema's id_type; index_path mode sets
+		// VARCHAR (the .mmi file stores subject names as opaque bytes).
+		LogicalType subject_id_type = LogicalType(LogicalTypeId::INVALID);
+
 		// Helper to check if using pre-built index
 		bool using_prebuilt_index() const {
 			return !index_path.empty();
 		}
 
-		// Output schema (shared with align_minimap2_sharded)
+		// Output schema. Names are constant; types are mutated by Bind once
+		// the query and subject id types are known.
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
 		bool debug = false;
 
-		Data() : per_subject_database(false), names(GetAlignmentOutputNames()), types(GetAlignmentOutputTypes()) {
+		// types is rebuilt by Bind once the actual query/subject id types are
+		// known; the placeholder VARCHAR/VARCHAR here is never observed.
+		Data()
+		    : per_subject_database(false), names(GetAlignmentOutputNames()),
+		      types(GetAlignmentOutputTypes(LogicalType::VARCHAR, LogicalType::VARCHAR)) {
 		}
 	};
 

--- a/src/include/align_minimap2_sharded.hpp
+++ b/src/include/align_minimap2_sharded.hpp
@@ -60,7 +60,12 @@ public:
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
-		Data() : names(GetAlignmentOutputNames()), types(GetAlignmentOutputTypes()) {
+		// Sharded mode is VARCHAR-only for read_id / reference / mate_reference
+		// in PR 1. BIGINT support requires the helpers to reach ReadShardIds
+		// and ReadBatchByIds (out of scope here); see findings doc.
+		Data()
+		    : names(GetAlignmentOutputNames()),
+		      types(GetAlignmentOutputTypes(LogicalType::VARCHAR, LogicalType::VARCHAR)) {
 		}
 	};
 

--- a/src/include/align_sortmerna.hpp
+++ b/src/include/align_sortmerna.hpp
@@ -27,7 +27,12 @@ public:
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
-		Data() : names(GetAlignmentOutputNames()), types(GetAlignmentOutputTypes()) {
+		// SortMeRNA is VARCHAR-only for read_id / reference / mate_reference
+		// in PR 1. BIGINT support requires updating the sortmerna emit helper
+		// (out of scope here); see findings doc.
+		Data()
+		    : names(GetAlignmentOutputNames()),
+		      types(GetAlignmentOutputTypes(LogicalType::VARCHAR, LogicalType::VARCHAR)) {
 		}
 	};
 

--- a/src/include/id_column_codec.hpp
+++ b/src/include/id_column_codec.hpp
@@ -1,0 +1,35 @@
+#pragma once
+//
+// Pure codec for the BIGINT side of id-column round-tripping.
+//
+// duckdb-miint stores identifier columns as `std::vector<std::string>` in its
+// in-memory carriers (SequenceRecordBatch::read_ids, SAMRecordBatch::read_ids,
+// references, mate_references), regardless of whether the user's SQL-level
+// column is VARCHAR or BIGINT. When the column is BIGINT, the values are
+// stringified on ingress and parsed back on egress. These two functions
+// encode that contract.
+//
+// Kept header-light (no DuckDB types) so the unit-test target can link it
+// directly. The DuckDB-aware wrappers live in id_column_utils.{hpp,cpp}.
+
+#include <cstdint>
+#include <optional>
+#include <string>
+
+namespace miint {
+
+// Parse a stringified id back to int64. Locale-independent (uses std::from_chars).
+// Returns std::nullopt for empty string and for the SAM-unmapped sentinel "*"
+// — both encode NULL in the output column.
+// Throws std::invalid_argument on any other unparseable input (including the
+// SAM same-as-primary sentinel "=", which is the caller's responsibility to
+// resolve to a real reference value before invoking the codec).
+// Throws std::out_of_range on overflow.
+// Note: zero-prefixed and "-0" inputs are accepted but the round-trip through
+// FormatIdFromInt64 will canonicalise them ("01" -> 1 -> "1"; "-0" -> 0 -> "0").
+std::optional<int64_t> ParseIdAsInt64(const std::string &s);
+
+// Format an int64 id as a decimal string for embedding in the carrier.
+std::string FormatIdFromInt64(int64_t v);
+
+} // namespace miint

--- a/src/include/id_column_utils.hpp
+++ b/src/include/id_column_utils.hpp
@@ -1,0 +1,123 @@
+#pragma once
+//
+// DuckDB-aware wrappers around the id-column codec.
+//
+// duckdb-miint accepts identifier columns of type VARCHAR or BIGINT and keeps
+// them as `std::vector<std::string>` in its in-memory carriers, regardless of
+// the SQL-level type. These helpers handle the translation at the ingress
+// (DataChunk -> vector<string>) and egress (vector<string> -> Vector)
+// boundaries.
+//
+// Pure parse/format logic lives in id_column_codec.hpp so the unit-test
+// target can link it without the duckdb library.
+
+#include "id_column_codec.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/vector.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// True for the set of column types accepted as an identifier column.
+inline bool IsAllowedIdType(const LogicalType &t) {
+	return t.id() == LogicalTypeId::VARCHAR || t.id() == LogicalTypeId::BIGINT;
+}
+
+// Extract `chunk.data[col_idx]` as strings, dispatching on `id_type`.
+// Always resizes `out_values` and `out_nulls` to `chunk.size()`.
+// NULL rows get an empty string in `out_values` and `true` in `out_nulls`.
+// VARCHAR ingress copies the bytes; BIGINT ingress stringifies via the codec.
+// Caller is responsible for ensuring `id_type.id()` matches the column's
+// storage type — typically by capturing the type at bind time via
+// ValidateSequenceTableSchema and threading it through.
+inline void ExtractIdColumnAsStrings(DataChunk &chunk, idx_t col_idx, const LogicalType &id_type,
+                                     std::vector<std::string> &out_values, std::vector<bool> &out_nulls) {
+	const idx_t n = chunk.size();
+	out_values.clear();
+	out_values.resize(n);
+	out_nulls.clear();
+	out_nulls.resize(n, false);
+
+	UnifiedVectorFormat fmt;
+	chunk.data[col_idx].ToUnifiedFormat(n, fmt);
+
+	if (id_type.id() == LogicalTypeId::VARCHAR) {
+		auto data = UnifiedVectorFormat::GetData<string_t>(fmt);
+		for (idx_t i = 0; i < n; i++) {
+			auto idx = fmt.sel->get_index(i);
+			if (!fmt.validity.RowIsValid(idx)) {
+				out_nulls[i] = true;
+				continue;
+			}
+			out_values[i] = data[idx].GetString();
+		}
+	} else if (id_type.id() == LogicalTypeId::BIGINT) {
+		auto data = UnifiedVectorFormat::GetData<int64_t>(fmt);
+		for (idx_t i = 0; i < n; i++) {
+			auto idx = fmt.sel->get_index(i);
+			if (!fmt.validity.RowIsValid(idx)) {
+				out_nulls[i] = true;
+				continue;
+			}
+			out_values[i] = miint::FormatIdFromInt64(data[idx]);
+		}
+	} else {
+		throw InternalException("ExtractIdColumnAsStrings: unsupported id type '%s' (must be VARCHAR or BIGINT)",
+		                        id_type.ToString());
+	}
+}
+
+// Emit `ids[offset..offset+count)` into `out`, dispatching on `id_type`.
+// VARCHAR: emits bytes verbatim (empty string passes through; validity is
+//          reset to all-valid since VARCHAR ingress doesn't carry a NULL
+//          encoding here).
+// BIGINT:  parses each string via ParseIdAsInt64; empty string and "*" become
+//          NULL; any other unparseable value throws InvalidInputException.
+// The caller must resolve SAM sentinels (e.g. "=" for mate_reference) before
+// invoking — the codec deliberately fails loud on "=" to surface that contract.
+// Precondition: `out` is a FlatVector sized for at least `count` rows. Both
+// branches set the validity mask explicitly so reusing the vector is safe.
+inline void EmitIdColumnFromStrings(Vector &out, const std::vector<std::string> &ids, idx_t offset, idx_t count,
+                                    const LogicalType &id_type) {
+	if (id_type.id() == LogicalTypeId::VARCHAR) {
+		auto out_data = FlatVector::GetData<string_t>(out);
+		FlatVector::Validity(out).SetAllValid(count);
+		for (idx_t j = 0; j < count; j++) {
+			out_data[j] = StringVector::AddString(out, ids[offset + j]);
+		}
+		return;
+	}
+	if (id_type.id() == LogicalTypeId::BIGINT) {
+		auto out_data = FlatVector::GetData<int64_t>(out);
+		auto &validity = FlatVector::Validity(out);
+		validity.SetAllInvalid(count);
+		for (idx_t j = 0; j < count; j++) {
+			const auto &s = ids[offset + j];
+			try {
+				auto parsed = miint::ParseIdAsInt64(s);
+				if (parsed.has_value()) {
+					out_data[j] = *parsed;
+					validity.SetValid(j);
+				} else {
+					out_data[j] = 0;
+				}
+			} catch (const std::exception &e) {
+				throw InvalidInputException(
+				    "EmitIdColumnFromStrings: cannot parse value '%s' at row %llu as BIGINT: %s", s,
+				    static_cast<unsigned long long>(offset + j), e.what());
+			}
+		}
+		return;
+	}
+	throw InternalException("EmitIdColumnFromStrings: unsupported id type '%s' (must be VARCHAR or BIGINT)",
+	                        id_type.ToString());
+}
+
+} // namespace duckdb

--- a/src/include/sequence_table_reader.hpp
+++ b/src/include/sequence_table_reader.hpp
@@ -2,6 +2,7 @@
 
 #include "Minimap2Aligner.hpp"
 #include "SequenceRecord.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "duckdb/main/connection.hpp"
@@ -18,17 +19,31 @@ struct SequenceTableSchema {
 	bool has_qual1 = false;        // True if quality scores present
 	bool has_qual2 = false;        // True if quality scores present for second read
 	bool is_physical_table = true; // True if physical table (has rowid), false if view
+	// Storage type of the read_id column (VARCHAR or BIGINT). Defaults to
+	// INVALID so any code path that constructs SequenceTableSchema without
+	// going through ValidateSequenceTableSchema fails loud at the helper
+	// dispatch in id_column_utils.hpp rather than silently misreading data.
+	LogicalType id_type = LogicalType(LogicalTypeId::INVALID);
 };
 
 // Validate that a table/view has required columns for sequence data.
 // Returns schema information about what optional columns are present.
 // Throws BinderException if required columns are missing or have wrong types.
-SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const std::string &table_name);
+// `allow_bigint`: if true, accepts both VARCHAR and BIGINT for `read_id` and
+// records the discovered type on `schema.id_type`. If false (default), only
+// VARCHAR is accepted — preserves backward-compatible behavior for callers
+// that haven't yet been audited for BIGINT support.
+SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const std::string &table_name,
+                                                bool allow_bigint = false);
 
 // Read all subjects from a table/view into memory.
 // Subjects cannot be paired-end (sequence2 must be NULL for all rows).
 // Throws InvalidInputException if sequence2 contains non-NULL values.
-std::vector<miint::AlignmentSubject> ReadSubjectTable(ClientContext &context, const std::string &table_name);
+// The schema (in particular `id_type`) governs how the read_id column is
+// extracted — VARCHAR rows pass through as strings; BIGINT rows are
+// stringified into the carrier so the aligner sees a uniform string contract.
+std::vector<miint::AlignmentSubject> ReadSubjectTable(ClientContext &context, const std::string &table_name,
+                                                      const SequenceTableSchema &schema);
 
 // Read a batch of query sequences from a table/view.
 // Returns true if there are more rows to read, false if done.

--- a/src/save_minimap2_index.cpp
+++ b/src/save_minimap2_index.cpp
@@ -18,8 +18,9 @@ unique_ptr<FunctionData> SaveMinimap2IndexTableFunction::Bind(ClientContext &con
 	data->subject_table = input.inputs[0].ToString();
 	data->output_path = input.inputs[1].ToString();
 
-	// Validate subject table exists and has correct schema
-	ValidateSequenceTableSchema(context, data->subject_table);
+	// Validate subject table exists and has correct schema; capture for the
+	// reader (subject id_type drives VARCHAR/BIGINT dispatch).
+	auto subject_schema = ValidateSequenceTableSchema(context, data->subject_table, /*allow_bigint=*/true);
 
 	// Parse optional named parameters (same as align_minimap2)
 	auto preset_param = input.named_parameters.find("preset");
@@ -43,7 +44,7 @@ unique_ptr<FunctionData> SaveMinimap2IndexTableFunction::Bind(ClientContext &con
 	}
 
 	// Load subjects at bind time
-	data->subjects = ReadSubjectTable(context, data->subject_table);
+	data->subjects = ReadSubjectTable(context, data->subject_table, subject_schema);
 
 	if (data->subjects.empty()) {
 		throw BinderException("Subject table '%s' is empty. Cannot save index for empty subject set.",

--- a/src/sequence_table_reader.cpp
+++ b/src/sequence_table_reader.cpp
@@ -1,5 +1,6 @@
 #include "sequence_table_reader.hpp"
 #include "catalog_utils.hpp"
+#include "id_column_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/main/appender.hpp"
 #include "duckdb/main/connection.hpp"
@@ -9,7 +10,8 @@
 
 namespace duckdb {
 
-SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const std::string &table_name) {
+SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const std::string &table_name,
+                                                bool allow_bigint) {
 	auto info = GetTableOrViewColumns(context, table_name, "Sequence table");
 	auto &col_names = info.names;
 	auto &col_types = info.types;
@@ -48,9 +50,20 @@ SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const st
 		return true;
 	};
 
-	// Required columns: read_id, sequence1
-	check_column("read_id", {LogicalTypeId::VARCHAR}, "VARCHAR", true);
+	// Required columns: read_id (VARCHAR; or BIGINT if allow_bigint), sequence1 (VARCHAR)
+	if (allow_bigint) {
+		check_column("read_id", {LogicalTypeId::VARCHAR, LogicalTypeId::BIGINT}, "VARCHAR or BIGINT", true);
+	} else {
+		check_column("read_id", {LogicalTypeId::VARCHAR}, "VARCHAR", true);
+	}
 	check_column("sequence1", {LogicalTypeId::VARCHAR}, "VARCHAR", true);
+
+	// Record the read_id column's storage type so downstream readers can
+	// stringify on ingress and the bind layer can mirror the type on output.
+	{
+		auto it = name_to_idx.find("read_id");
+		schema.id_type = col_types[it->second];
+	}
 
 	// Optional columns: sequence2, qual1, qual2
 	schema.has_sequence2 = check_column("sequence2", {LogicalTypeId::VARCHAR}, "VARCHAR", false);
@@ -60,7 +73,8 @@ SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const st
 	return schema;
 }
 
-std::vector<miint::AlignmentSubject> ReadSubjectTable(ClientContext &context, const std::string &table_name) {
+std::vector<miint::AlignmentSubject> ReadSubjectTable(ClientContext &context, const std::string &table_name,
+                                                      const SequenceTableSchema &schema) {
 	std::vector<miint::AlignmentSubject> result;
 
 	// Create a new connection to avoid deadlocking
@@ -85,33 +99,35 @@ std::vector<miint::AlignmentSubject> ReadSubjectTable(ClientContext &context, co
 	auto &materialized = query_result->Cast<MaterializedQueryResult>();
 	idx_t row_number = 0;
 
+	// Reusable buffers across chunks — populated by ExtractIdColumnAsStrings.
+	std::vector<std::string> id_strings;
+	std::vector<bool> id_nulls;
+
 	while (true) {
 		auto chunk = materialized.Fetch();
 		if (!chunk || chunk->size() == 0) {
 			break;
 		}
 
-		auto &read_id_vec = chunk->data[0];
+		ExtractIdColumnAsStrings(*chunk, /*col_idx=*/0, schema.id_type, id_strings, id_nulls);
+
 		auto &seq1_vec = chunk->data[1];
 		auto &seq2_vec = chunk->data[2];
 
-		UnifiedVectorFormat read_id_data, seq1_data, seq2_data;
-		read_id_vec.ToUnifiedFormat(chunk->size(), read_id_data);
+		UnifiedVectorFormat seq1_data, seq2_data;
 		seq1_vec.ToUnifiedFormat(chunk->size(), seq1_data);
 		seq2_vec.ToUnifiedFormat(chunk->size(), seq2_data);
 
-		auto read_ids = UnifiedVectorFormat::GetData<string_t>(read_id_data);
 		auto sequences1 = UnifiedVectorFormat::GetData<string_t>(seq1_data);
 
 		for (idx_t i = 0; i < chunk->size(); i++) {
 			row_number++;
 
-			auto rid_idx = read_id_data.sel->get_index(i);
 			auto seq1_idx = seq1_data.sel->get_index(i);
 			auto seq2_idx = seq2_data.sel->get_index(i);
 
 			// Skip rows with NULL read_id or sequence1
-			if (!read_id_data.validity.RowIsValid(rid_idx)) {
+			if (id_nulls[i]) {
 				continue;
 			}
 			if (!seq1_data.validity.RowIsValid(seq1_idx)) {
@@ -126,7 +142,7 @@ std::vector<miint::AlignmentSubject> ReadSubjectTable(ClientContext &context, co
 			}
 
 			miint::AlignmentSubject subject;
-			subject.read_id = read_ids[rid_idx].GetString();
+			subject.read_id = std::move(id_strings[i]);
 			subject.sequence = sequences1[seq1_idx].GetString();
 
 			result.push_back(std::move(subject));
@@ -202,12 +218,17 @@ static void ProcessSingleChunk(DataChunk &chunk, const SequenceTableSchema &sche
 		qual2_col = next_col++;
 	}
 
-	// Prepare unified formats
-	UnifiedVectorFormat read_id_data, seq1_data;
-	chunk.data[read_id_col].ToUnifiedFormat(chunk.size(), read_id_data);
+	// Pre-extract column 0 (read_id) as strings, dispatching on the captured
+	// id_type. This is the single point where VARCHAR-vs-BIGINT ingress
+	// branching lives — every downstream consumer sees a uniform string id.
+	std::vector<std::string> chunk_id_strings;
+	std::vector<bool> chunk_id_nulls;
+	ExtractIdColumnAsStrings(chunk, read_id_col, schema.id_type, chunk_id_strings, chunk_id_nulls);
+
+	// Prepare unified formats for the remaining columns
+	UnifiedVectorFormat seq1_data;
 	chunk.data[seq1_col].ToUnifiedFormat(chunk.size(), seq1_data);
 
-	auto read_ids = UnifiedVectorFormat::GetData<string_t>(read_id_data);
 	auto sequences1 = UnifiedVectorFormat::GetData<string_t>(seq1_data);
 
 	UnifiedVectorFormat seq2_data, qual1_data, qual2_data;
@@ -231,17 +252,16 @@ static void ProcessSingleChunk(DataChunk &chunk, const SequenceTableSchema &sche
 	temp_seq2.clear();
 
 	for (idx_t i = 0; i < chunk.size(); i++) {
-		auto rid_idx = read_id_data.sel->get_index(i);
 		auto seq1_idx = seq1_data.sel->get_index(i);
 
-		if (!read_id_data.validity.RowIsValid(rid_idx)) {
+		if (chunk_id_nulls[i]) {
 			continue;
 		}
 		if (!seq1_data.validity.RowIsValid(seq1_idx)) {
 			continue;
 		}
 
-		temp_read_ids.push_back(read_ids[rid_idx].GetString());
+		temp_read_ids.push_back(std::move(chunk_id_strings[i]));
 		temp_seq1.push_back(sequences1[seq1_idx].GetString());
 
 		if (output.is_paired && schema.has_sequence2 && sequences2) {
@@ -259,10 +279,9 @@ static void ProcessSingleChunk(DataChunk &chunk, const SequenceTableSchema &sche
 	// Now process the extracted strings and quality scores
 	idx_t batch_idx = 0;
 	for (idx_t i = 0; i < chunk.size(); i++) {
-		auto rid_idx = read_id_data.sel->get_index(i);
 		auto seq1_idx = seq1_data.sel->get_index(i);
 
-		if (!read_id_data.validity.RowIsValid(rid_idx)) {
+		if (chunk_id_nulls[i]) {
 			continue;
 		}
 		if (!seq1_data.validity.RowIsValid(seq1_idx)) {

--- a/test/cpp/test_id_column_codec.cpp
+++ b/test/cpp/test_id_column_codec.cpp
@@ -1,0 +1,159 @@
+// Unit tests for the pure codec used by id-column ingress/egress.
+//
+// These cover the BIGINT-side semantics that drive output emission when the
+// caller's id column is BIGINT-typed. The DuckDB-aware wrappers
+// (ExtractIdColumnAsStrings, EmitIdColumnFromStrings) live in
+// id_column_utils.{hpp,cpp} and are covered by SQL integration tests because
+// the unit-test binary does not link against the duckdb library.
+
+#include "id_column_codec.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+using miint::FormatIdFromInt64;
+using miint::ParseIdAsInt64;
+
+TEST_CASE("ParseIdAsInt64 happy path", "[id_codec]") {
+	SECTION("plain positive integer") {
+		auto v = ParseIdAsInt64("123");
+		REQUIRE(v.has_value());
+		CHECK(*v == 123);
+	}
+
+	SECTION("zero") {
+		auto v = ParseIdAsInt64("0");
+		REQUIRE(v.has_value());
+		CHECK(*v == 0);
+	}
+
+	SECTION("negative integer") {
+		auto v = ParseIdAsInt64("-456");
+		REQUIRE(v.has_value());
+		CHECK(*v == -456);
+	}
+
+	SECTION("INT64_MAX boundary") {
+		auto v = ParseIdAsInt64("9223372036854775807");
+		REQUIRE(v.has_value());
+		CHECK(*v == std::numeric_limits<int64_t>::max());
+	}
+
+	SECTION("INT64_MIN boundary") {
+		auto v = ParseIdAsInt64("-9223372036854775808");
+		REQUIRE(v.has_value());
+		CHECK(*v == std::numeric_limits<int64_t>::min());
+	}
+}
+
+TEST_CASE("ParseIdAsInt64 NULL sentinels", "[id_codec]") {
+	SECTION("empty string returns nullopt (NULL)") {
+		auto v = ParseIdAsInt64("");
+		CHECK_FALSE(v.has_value());
+	}
+
+	SECTION("SAM unmapped sentinel '*' returns nullopt (NULL)") {
+		auto v = ParseIdAsInt64("*");
+		CHECK_FALSE(v.has_value());
+	}
+}
+
+TEST_CASE("ParseIdAsInt64 invalid input throws", "[id_codec]") {
+	SECTION("non-numeric string throws") {
+		CHECK_THROWS_AS(ParseIdAsInt64("abc"), std::invalid_argument);
+	}
+
+	SECTION("float-like string throws (no implicit truncation)") {
+		CHECK_THROWS_AS(ParseIdAsInt64("1.5"), std::invalid_argument);
+	}
+
+	SECTION("trailing garbage throws (no partial parse)") {
+		CHECK_THROWS_AS(ParseIdAsInt64("123abc"), std::invalid_argument);
+	}
+
+	SECTION("leading whitespace throws (caller must clean input)") {
+		CHECK_THROWS_AS(ParseIdAsInt64(" 123"), std::invalid_argument);
+	}
+
+	SECTION("overflow throws") {
+		CHECK_THROWS_AS(ParseIdAsInt64("99999999999999999999"), std::out_of_range);
+	}
+
+	SECTION("SAM same-as-primary sentinel '=' throws (caller responsibility)") {
+		// '=' must be resolved to the row's reference value by the caller
+		// before invoking the codec. Failing loud here surfaces that contract.
+		CHECK_THROWS_AS(ParseIdAsInt64("="), std::invalid_argument);
+	}
+}
+
+TEST_CASE("FormatIdFromInt64", "[id_codec]") {
+	SECTION("zero") {
+		CHECK(FormatIdFromInt64(0) == "0");
+	}
+
+	SECTION("positive integer") {
+		CHECK(FormatIdFromInt64(42) == "42");
+	}
+
+	SECTION("negative integer") {
+		CHECK(FormatIdFromInt64(-1) == "-1");
+	}
+
+	SECTION("INT64_MAX") {
+		CHECK(FormatIdFromInt64(std::numeric_limits<int64_t>::max()) == "9223372036854775807");
+	}
+
+	SECTION("INT64_MIN") {
+		CHECK(FormatIdFromInt64(std::numeric_limits<int64_t>::min()) == "-9223372036854775808");
+	}
+}
+
+TEST_CASE("ParseIdAsInt64 documented non-canonical inputs", "[id_codec]") {
+	// These are accepted by from_chars but lose information through the
+	// FormatIdFromInt64 round-trip. Asserting the behaviour explicitly so the
+	// API contract is documented in code, not just folklore.
+	SECTION("leading zeros: '01' parses to 1; round-trip canonicalises to '1'") {
+		auto v = ParseIdAsInt64("01");
+		REQUIRE(v.has_value());
+		CHECK(*v == 1);
+		CHECK(FormatIdFromInt64(*v) == "1");
+	}
+
+	SECTION("'-0' parses to 0; round-trip canonicalises to '0'") {
+		auto v = ParseIdAsInt64("-0");
+		REQUIRE(v.has_value());
+		CHECK(*v == 0);
+		CHECK(FormatIdFromInt64(*v) == "0");
+	}
+
+	SECTION("embedded NUL throws (no partial parse)") {
+		// std::string with explicit length to preserve the embedded NUL.
+		std::string s("12\x00"
+		              "3",
+		              4);
+		REQUIRE(s.size() == 4);
+		CHECK_THROWS_AS(ParseIdAsInt64(s), std::invalid_argument);
+	}
+}
+
+TEST_CASE("ParseIdAsInt64 / FormatIdFromInt64 round-trip", "[id_codec]") {
+	const int64_t values[] = {0,
+	                          1,
+	                          -1,
+	                          42,
+	                          -42,
+	                          1'000'000'000'000LL,
+	                          std::numeric_limits<int64_t>::max(),
+	                          std::numeric_limits<int64_t>::min()};
+	for (auto v : values) {
+		auto round = ParseIdAsInt64(FormatIdFromInt64(v));
+		REQUIRE(round.has_value());
+		CHECK(*round == v);
+	}
+}

--- a/test/sql/align_minimap2_bigint.test
+++ b/test/sql/align_minimap2_bigint.test
@@ -1,0 +1,209 @@
+# name: test/sql/align_minimap2_bigint.test
+# description: align_minimap2 accepts BIGINT read_id columns.
+# group: [sql]
+
+#   The output read_id mirrors the query input type and the output reference /
+#   mate_reference mirror the subject input type. VARCHAR remains the default
+#   for any caller that does not pass a BIGINT-typed column. Edge cases
+#   (HUGEINT reject, empty subjects, per_subject_database, prebuilt-index
+#   asymmetry) live in align_minimap2_bigint_edge.test.
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Setup: tables with both VARCHAR and BIGINT read_id storage
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_bigint VALUES
+    (1001, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (1002, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+statement ok
+CREATE TABLE subjects_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO subjects_bigint VALUES
+    (2001, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC'),
+    (2002, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAA');
+
+# Mixed sides — stringified projections from the BIGINT tables
+statement ok
+CREATE TABLE queries_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM queries_bigint;
+
+statement ok
+CREATE TABLE subjects_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM subjects_bigint;
+
+# ---------------------------------------------------------------------------
+# Happy path: BIGINT/BIGINT — both ids round-trip with output types matching
+# the corresponding input table's read_id type.
+# ---------------------------------------------------------------------------
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('queries_bigint', subject_table='subjects_bigint', max_secondary=0)
+ORDER BY read_id;
+----
+1001	2001
+1002	2002
+
+# Output column types mirror input: query read_id → output read_id (BIGINT),
+# subject read_id → output reference + mate_reference (BIGINT).
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('queries_bigint', subject_table='subjects_bigint', max_secondary=0)
+LIMIT 1;
+----
+BIGINT	BIGINT	BIGINT
+
+# Single-end queries: mate_reference is always NULL for BIGINT subjects
+# (minimap2 emits "*" which the codec maps to NULL).
+query I
+SELECT COUNT(*) FILTER (WHERE mate_reference IS NOT NULL)
+FROM align_minimap2('queries_bigint', subject_table='subjects_bigint', max_secondary=0);
+----
+0
+
+# ---------------------------------------------------------------------------
+# Paired-end: mate_reference "=" sentinel must be resolved for BIGINT subjects
+# (the literal "=" has no BIGINT encoding). VARCHAR subjects preserve "="
+# verbatim — that's tested via the existing align_minimap2.test surface.
+# ---------------------------------------------------------------------------
+
+# A longer subject so paired reads have somewhere to land.
+statement ok
+CREATE TABLE paired_subjects_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO paired_subjects_bigint VALUES
+    (4001, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+statement ok
+CREATE TABLE paired_queries_bigint (read_id BIGINT, sequence1 VARCHAR, sequence2 VARCHAR);
+
+# R1 maps to the start of subject 4001; R2 is the reverse complement of a
+# region further along — both should align to the same reference.
+statement ok
+INSERT INTO paired_queries_bigint VALUES
+    (6001, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+# For BIGINT subjects with paired reads to the same reference, the "="
+# sentinel must be resolved at emit — mate_reference should equal reference,
+# never literally "=". A SUM over `mate_reference = reference` confirms the
+# resolution; if "=" leaked through, the BIGINT parse would have thrown.
+query II
+SELECT
+    SUM(CASE WHEN mate_reference IS NOT NULL AND mate_reference = reference THEN 1 ELSE 0 END) > 0 AS any_resolved,
+    SUM(CASE WHEN mate_reference IS NOT NULL AND mate_reference != reference THEN 1 ELSE 0 END) AS unexpected_diff
+FROM align_minimap2('paired_queries_bigint', subject_table='paired_subjects_bigint', max_secondary=0);
+----
+true	0
+
+# ---------------------------------------------------------------------------
+# Mixed: BIGINT queries, VARCHAR subjects — output is asymmetric
+# (read_id BIGINT, reference/mate_reference VARCHAR)
+# ---------------------------------------------------------------------------
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('queries_bigint', subject_table='subjects_varchar', max_secondary=0)
+ORDER BY read_id;
+----
+1001	2001
+1002	2002
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('queries_bigint', subject_table='subjects_varchar', max_secondary=0)
+LIMIT 1;
+----
+BIGINT	VARCHAR	VARCHAR
+
+# ---------------------------------------------------------------------------
+# Mixed: VARCHAR queries, BIGINT subjects — other direction asymmetry
+# ---------------------------------------------------------------------------
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('queries_varchar', subject_table='subjects_bigint', max_secondary=0)
+ORDER BY read_id;
+----
+1001	2001
+1002	2002
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('queries_varchar', subject_table='subjects_bigint', max_secondary=0)
+LIMIT 1;
+----
+VARCHAR	BIGINT	BIGINT
+
+# ---------------------------------------------------------------------------
+# NULL read_id rows are skipped (existing convention for VARCHAR carries
+# through to BIGINT — the reader's null-aware path handles both)
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_with_null_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_with_null_bigint VALUES
+    (3001, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (NULL, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA'),
+    (3003, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+# Only the two non-NULL rows reach the aligner; output is a subset
+query II
+SELECT read_id, reference
+FROM align_minimap2('queries_with_null_bigint', subject_table='subjects_bigint', max_secondary=0)
+ORDER BY read_id;
+----
+3001	2001
+3003	2001
+
+# ---------------------------------------------------------------------------
+# Rejected types — INTEGER, DOUBLE, UBIGINT must all fail with a clear
+# bind-time error that names both accepted types
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_int (read_id INTEGER, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_int VALUES (1, 'ACGT');
+
+statement error
+SELECT * FROM align_minimap2('queries_int', subject_table='subjects_bigint');
+----
+must be VARCHAR or BIGINT
+
+statement ok
+CREATE TABLE queries_double (read_id DOUBLE, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_double VALUES (1.5, 'ACGT');
+
+statement error
+SELECT * FROM align_minimap2('queries_double', subject_table='subjects_bigint');
+----
+must be VARCHAR or BIGINT
+
+statement ok
+CREATE TABLE queries_ubigint (read_id UBIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_ubigint VALUES (1, 'ACGT');
+
+statement error
+SELECT * FROM align_minimap2('queries_ubigint', subject_table='subjects_bigint');
+----
+must be VARCHAR or BIGINT
+
+# Rejected subject-side too
+statement error
+SELECT * FROM align_minimap2('queries_bigint', subject_table='queries_int');
+----
+must be VARCHAR or BIGINT

--- a/test/sql/align_minimap2_bigint_edge.test
+++ b/test/sql/align_minimap2_bigint_edge.test
@@ -1,0 +1,123 @@
+# name: test/sql/align_minimap2_bigint_edge.test
+# description: Edge case matrix for BIGINT read_id in align_minimap2 (PR 1, Cycle 5).
+# group: [sql]
+
+#   Companion to align_minimap2_bigint.test — covers paths that aren't the
+#   happy-path of the BIGINT bind/emit machinery:
+#     1. Empty BIGINT subject table  -> existing "is empty" error unchanged
+#     2. HUGEINT read_id / subject   -> rejected with VARCHAR-or-BIGINT error
+#     3. per_subject_database=true   -> output types and values correct
+#     4. Prebuilt index asymmetry    -> BIGINT queries, VARCHAR refs in output
+#                                       (subject names in .mmi are opaque)
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Reusable fixtures: 1-row BIGINT query and 1-row BIGINT subject. The subject
+# contains a stretch that the query maps into, so the happy paths produce a
+# single mapped row.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE bq_queries AS SELECT
+    1001::BIGINT AS read_id,
+    'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT' AS sequence1;
+
+statement ok
+CREATE TABLE bq_subjects AS SELECT
+    2001::BIGINT AS read_id,
+    'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC' AS sequence1;
+
+# VARCHAR projection of the subject table — for the prebuilt-index asymmetry
+# test (build index from VARCHAR subjects, query with BIGINT).
+statement ok
+CREATE TABLE bq_subjects_varchar AS
+SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM bq_subjects;
+
+# ---------------------------------------------------------------------------
+# 1. Empty BIGINT subject table — pre-existing "is empty" error path
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE empty_subjects_bigint AS
+SELECT 0::BIGINT AS read_id, 'A' AS sequence1 WHERE FALSE;
+
+statement error
+SELECT * FROM align_minimap2('bq_queries', subject_table='empty_subjects_bigint');
+----
+empty_subjects_bigint
+
+# ---------------------------------------------------------------------------
+# 2. HUGEINT for either side is rejected with the named-types error
+#    (existing align_minimap2_bigint.test covers INTEGER, DOUBLE, UBIGINT;
+#    HUGEINT specifically rounds out the unsigned/wider-int matrix.)
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequence1;
+
+statement error
+SELECT * FROM align_minimap2('queries_hugeint', subject_table='bq_subjects');
+----
+must be VARCHAR or BIGINT
+
+statement ok
+CREATE TABLE subjects_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequence1;
+
+statement error
+SELECT * FROM align_minimap2('bq_queries', subject_table='subjects_hugeint');
+----
+must be VARCHAR or BIGINT
+
+# ---------------------------------------------------------------------------
+# 3. per_subject_database=true with BIGINT — exercises ExecutePerSubject,
+#    which threads bind_data id types into OutputSAMRecordBatch identically
+#    to the standard path. This is the first end-to-end SQL test for
+#    per_subject_database mode in either type regime.
+# ---------------------------------------------------------------------------
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('bq_queries', subject_table='bq_subjects', per_subject_database=true, max_secondary=0)
+LIMIT 1;
+----
+BIGINT	BIGINT	BIGINT
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('bq_queries', subject_table='bq_subjects', per_subject_database=true, max_secondary=0)
+ORDER BY read_id;
+----
+1001	2001
+
+# ---------------------------------------------------------------------------
+# 4. Prebuilt index asymmetry: queries are BIGINT, the index was built from a
+#    VARCHAR subject table. Subject names in the .mmi file are opaque bytes
+#    that miint defaults to VARCHAR on the output side (see
+#    align_minimap2.cpp ~line 87), so the output schema is asymmetric:
+#      read_id        BIGINT  (from query column)
+#      reference      VARCHAR (from prebuilt-index default)
+#      mate_reference VARCHAR (from prebuilt-index default)
+# ---------------------------------------------------------------------------
+
+# Build the index. save_minimap2_index also accepts BIGINT but here we use
+# VARCHAR specifically to make the asymmetry visible.
+query III
+SELECT success, num_subjects > 0, index_path LIKE '%bigint_edge_index.mmi%'
+FROM save_minimap2_index('bq_subjects_varchar', 'bigint_edge_index.mmi', k := 5);
+----
+true	true	true
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('bq_queries', index_path='bigint_edge_index.mmi', max_secondary=0)
+LIMIT 1;
+----
+BIGINT	VARCHAR	VARCHAR
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('bq_queries', index_path='bigint_edge_index.mmi', max_secondary=0)
+ORDER BY read_id;
+----
+1001	2001

--- a/test/sql/copy_sam_bigint.test
+++ b/test/sql/copy_sam_bigint.test
@@ -1,0 +1,205 @@
+# name: test/sql/copy_sam_bigint.test
+# description: COPY FORMAT SAM/BAM accepts BIGINT for read_id, reference, mate_reference (PR 1, Cycle 4).
+# group: [sql]
+
+#   COPY FORMAT SAM previously required VARCHAR for the three identifier columns
+#   (read_id, reference, mate_reference). Cycle 4 of the BIGINT-id work relaxes
+#   that to accept either VARCHAR or BIGINT, with BIGINT values stringified to
+#   decimal on write and NULL → SAM '*' sentinel. Round-trip via read_sam
+#   produces VARCHAR (type loss is documented).
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Common setup: a reference-lengths table addressable by the BIGINT decimal
+# stringification of subject identifiers (2001, 2002).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE ref_bigint_lengths AS
+SELECT '2001' AS name, 10000 AS length
+UNION ALL SELECT '2002', 10000;
+
+# ---------------------------------------------------------------------------
+# Test 1: All three id columns BIGINT — happy path. Use distinct reference and
+# mate_reference values so the BIGINT decimal stringification of mate_reference
+# is observable in the round-trip. (HTSlib normalises RNEXT to '=' when it
+# matches RNAME at the tid level — that's identical for VARCHAR and BIGINT
+# inputs and is covered separately below.)
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE result_all_bigint AS SELECT
+    1001::BIGINT AS read_id,
+    0::USMALLINT AS flags,
+    2001::BIGINT AS reference,
+    1::BIGINT AS position,
+    51::BIGINT AS stop_position,
+    60::UTINYINT AS mapq,
+    '50M' AS cigar,
+    2002::BIGINT AS mate_reference,
+    150::BIGINT AS mate_position,
+    200::BIGINT AS template_length,
+    NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
+    NULL::BIGINT AS tag_xn, NULL::BIGINT AS tag_xm, NULL::BIGINT AS tag_xo,
+    NULL::BIGINT AS tag_xg, NULL::BIGINT AS tag_nm,
+    NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
+
+statement ok
+COPY result_all_bigint TO '__TEST_DIR__/all_bigint.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+
+# Decimal stringification on write, VARCHAR on read-back.
+query III
+SELECT read_id, reference, mate_reference
+FROM read_sam('__TEST_DIR__/all_bigint.sam');
+----
+1001	2001	2002
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM read_sam('__TEST_DIR__/all_bigint.sam')
+LIMIT 1;
+----
+VARCHAR	VARCHAR	VARCHAR
+
+# ---------------------------------------------------------------------------
+# Test 1b: HTSlib '=' normalisation for BIGINT inputs when mate_reference
+# equals reference — parity with the VARCHAR path (see copy_sam.test test 9).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE result_bigint_eq AS SELECT
+    1002::BIGINT AS read_id,
+    0::USMALLINT AS flags,
+    2001::BIGINT AS reference,
+    1::BIGINT AS position,
+    51::BIGINT AS stop_position,
+    60::UTINYINT AS mapq,
+    '50M' AS cigar,
+    2001::BIGINT AS mate_reference,
+    150::BIGINT AS mate_position,
+    200::BIGINT AS template_length,
+    NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
+    NULL::BIGINT AS tag_xn, NULL::BIGINT AS tag_xm, NULL::BIGINT AS tag_xo,
+    NULL::BIGINT AS tag_xg, NULL::BIGINT AS tag_nm,
+    NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
+
+statement ok
+COPY result_bigint_eq TO '__TEST_DIR__/bigint_eq.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+
+query III
+SELECT read_id, reference, mate_reference
+FROM read_sam('__TEST_DIR__/bigint_eq.sam');
+----
+1002	2001	=
+
+# ---------------------------------------------------------------------------
+# Test 2: NULL BIGINT id values → SAM '*' on disk
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE result_null_ids AS SELECT
+    NULL::BIGINT AS read_id,
+    4::USMALLINT AS flags,
+    NULL::BIGINT AS reference,
+    0::BIGINT AS position,
+    0::BIGINT AS stop_position,
+    0::UTINYINT AS mapq,
+    '*' AS cigar,
+    NULL::BIGINT AS mate_reference,
+    0::BIGINT AS mate_position,
+    0::BIGINT AS template_length,
+    NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
+    NULL::BIGINT AS tag_xn, NULL::BIGINT AS tag_xm, NULL::BIGINT AS tag_xo,
+    NULL::BIGINT AS tag_xg, NULL::BIGINT AS tag_nm,
+    NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
+
+statement ok
+CREATE TABLE ref_dummy AS SELECT 'dummy' AS name, 1000 AS length;
+
+statement ok
+COPY result_null_ids TO '__TEST_DIR__/null_bigint_ids.sam'
+(FORMAT SAM, INCLUDE_HEADER false, REFERENCE_LENGTHS 'ref_dummy');
+
+query III
+SELECT read_id, reference, mate_reference
+FROM read_sam('__TEST_DIR__/null_bigint_ids.sam', reference_lengths='ref_dummy');
+----
+*	*	*
+
+# ---------------------------------------------------------------------------
+# Test 3: Mixed — read_id VARCHAR, reference/mate_reference BIGINT
+# (independent type acceptance per column)
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE result_mixed AS SELECT
+    'read-mixed-1' AS read_id,
+    0::USMALLINT AS flags,
+    2002::BIGINT AS reference,
+    1::BIGINT AS position,
+    51::BIGINT AS stop_position,
+    60::UTINYINT AS mapq,
+    '50M' AS cigar,
+    2001::BIGINT AS mate_reference,
+    150::BIGINT AS mate_position,
+    200::BIGINT AS template_length,
+    NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
+    NULL::BIGINT AS tag_xn, NULL::BIGINT AS tag_xm, NULL::BIGINT AS tag_xo,
+    NULL::BIGINT AS tag_xg, NULL::BIGINT AS tag_nm,
+    NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
+
+statement ok
+COPY result_mixed TO '__TEST_DIR__/mixed.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+
+query III
+SELECT read_id, reference, mate_reference FROM read_sam('__TEST_DIR__/mixed.sam');
+----
+read-mixed-1	2002	2001
+
+# ---------------------------------------------------------------------------
+# Test 4: BAM output with BIGINT ids — same write path, binary container
+# ---------------------------------------------------------------------------
+
+statement ok
+COPY result_all_bigint TO '__TEST_DIR__/all_bigint.bam'
+(FORMAT BAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+
+query III
+SELECT read_id, reference, mate_reference FROM read_sam('__TEST_DIR__/all_bigint.bam');
+----
+1001	2001	2002
+
+# ---------------------------------------------------------------------------
+# Test 5: Unsupported id types still rejected with a clear error
+# ---------------------------------------------------------------------------
+
+statement error
+COPY (SELECT
+    1::INTEGER AS read_id, 0::USMALLINT AS flags, 'r' AS reference, 1::BIGINT AS position,
+    1::BIGINT AS stop_position, 0::UTINYINT AS mapq, '*' AS cigar, '*' AS mate_reference,
+    0::BIGINT AS mate_position, 0::BIGINT AS template_length
+) TO '__TEST_DIR__/bad_read_id.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
+----
+Column 'read_id' must be VARCHAR or BIGINT
+
+statement error
+COPY (SELECT
+    'r' AS read_id, 0::USMALLINT AS flags, 1::INTEGER AS reference, 1::BIGINT AS position,
+    1::BIGINT AS stop_position, 0::UTINYINT AS mapq, '*' AS cigar, '*' AS mate_reference,
+    0::BIGINT AS mate_position, 0::BIGINT AS template_length
+) TO '__TEST_DIR__/bad_reference.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
+----
+Column 'reference' must be VARCHAR or BIGINT
+
+statement error
+COPY (SELECT
+    'r' AS read_id, 0::USMALLINT AS flags, 'r' AS reference, 1::BIGINT AS position,
+    1::BIGINT AS stop_position, 0::UTINYINT AS mapq, '*' AS cigar, 1::DOUBLE AS mate_reference,
+    0::BIGINT AS mate_position, 0::BIGINT AS template_length
+) TO '__TEST_DIR__/bad_mate.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
+----
+Column 'mate_reference' must be VARCHAR or BIGINT


### PR DESCRIPTION
## Summary

- Enables `BIGINT read_id` as a first-class input to `align_minimap2`, with the output's `read_id` mirroring the query input type and `reference` / `mate_reference` mirroring the subject input type (or VARCHAR fallback for prebuilt indexes).
- Introduces a two-layer id-column codec under `src/include/id_column_codec.{hpp,cpp}` (pure C++, unit-testable) and `src/include/id_column_utils.hpp` (DuckDB-aware wrappers). Adoption is opt-in via `ValidateSequenceTableSchema(..., allow_bigint=true)`; only `align_minimap2` + `save_minimap2_index` + `copy_sam` adopt in this PR. All other callers (sharded, sortmerna, bowtie2, search, cluster, uchime, mafft) keep the historical VARCHAR-only contract.
- Relaxes `COPY FORMAT SAM` / `FORMAT BAM` to accept VARCHAR or BIGINT for `read_id`, `reference`, `mate_reference`. BIGINT values are stringified to decimal on write; NULL BIGINT becomes the SAM `*` sentinel. On-disk format is text, so round-trip via `read_alignments` returns VARCHAR (documented type loss).
- Sentinel rules at egress: empty / `*` → NULL for BIGINT. The SAM `=` mate-reference sentinel has no BIGINT encoding and is resolved to the primary reference value before invoking the codec.

## Test plan

- [x] 47 C++ codec assertions in `test/cpp/test_id_column_codec.cpp`
- [x] 50 SQL assertions in `test/sql/align_minimap2_bigint.test`
- [x] 22 SQL assertions in `test/sql/align_minimap2_bigint_edge.test` (HUGEINT reject, empty subject, per_subject_database BIGINT, prebuilt-index VARCHAR fallback)
- [x] 32 SQL assertions in `test/sql/copy_sam_bigint.test` (BIGINT for all 3 id cols, HTSlib `=` normalisation parity, NULL BIGINT → `*`, BAM container, type rejects)
- [x] Full SQL suite green (modulo the 4 documented env-only failures: bowtie2 + fasttree binaries missing on this dev box)
- [x] C++ tests 11964/11965 (1 known gpl-boundary daemon env failure)
- [x] `make format-check` passes

## Docs

- `docs/table-functions.md`: `align_minimap2`, `align_minimap2_sharded`, `save_minimap2_index` sections updated. New "Identifier-column types" subsection in `align_minimap2`.
- `docs/copy-formats.md`: COPY SAM/BAM section updated with BIGINT acceptance, decimal stringification, NULL → `*`, round-trip type-loss, HTSlib `=` normalisation parity.
- `docs/internals/architecture.md`: new "Identifier-column Codec" subsection covering the two-layer split, opt-in flag, fail-loud INVALID defaults, current call-site list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)