### PR TITLE
Process-wide HDF5 mutex to prevent concurrent read_biom segfault

### DIFF
--- a/src/BIOMReader.cpp
+++ b/src/BIOMReader.cpp
@@ -4,6 +4,10 @@
 
 namespace miint {
 
+// Storage for the process-wide HDF5 mutex declared in BIOMReader.hpp.
+// See the header for the contract and rationale.
+std::mutex g_hdf5_mutex;
+
 BIOMReader::BIOMReader(const std::string &path) {
 	// Check if file exists and get size
 	struct stat st;

--- a/src/include/BIOMReader.hpp
+++ b/src/include/BIOMReader.hpp
@@ -3,10 +3,27 @@
 #include <vector>
 #include <string>
 #include <memory>
+#include <mutex>
 #include "BIOMTable.hpp"
 #include <hdf5.h>
 
 namespace miint {
+
+//! Process-wide mutex serializing every HDF5 call from miint.
+//!
+//! HDF5 (vcpkg build: features cpp/zlib/szip, no `threadsafe`) has global
+//! library state — initialization, type system, error stack, dataset caches
+//! — that races under concurrent access. Two read_biom() table-function
+//! instances each have their own GlobalState, so a per-state mutex does
+//! NOT serialize cross-instance calls. Mirrors `g_mafft_mutex` in
+//! MafftAligner.cpp.
+//!
+//! Acquire around every HDF5 entry point: H5Fopen, H5Dopen2, H5Dread,
+//! H5Fclose, H5Dclose, plus the BIOMReader / BIOMTable scope that drives
+//! them — including the BIOMReader destructor so file/dataset handles are
+//! closed under the lock.
+extern std::mutex g_hdf5_mutex;
+
 
 /* datasets defined by the BIOM 2.x spec */
 static constexpr const char *OBS_INDPTR = "/observation/matrix/indptr";

--- a/src/include/BIOMReader.hpp
+++ b/src/include/BIOMReader.hpp
@@ -24,7 +24,6 @@ namespace miint {
 //! closed under the lock.
 extern std::mutex g_hdf5_mutex;
 
-
 /* datasets defined by the BIOM 2.x spec */
 static constexpr const char *OBS_INDPTR = "/observation/matrix/indptr";
 static constexpr const char *OBS_INDICES = "/observation/matrix/indices";

--- a/src/include/read_biom.hpp
+++ b/src/include/read_biom.hpp
@@ -36,7 +36,7 @@ public:
 	};
 
 	struct GlobalState : public GlobalTableFunctionState {
-		mutex lock;                            // Guards current_file_idx for the work-claim cursor
+		mutex lock; // Guards current_file_idx for the work-claim cursor
 		// HDF5 serialization lives in miint::g_hdf5_mutex (BIOMReader.hpp) so it
 		// covers cross-query races; a per-state mutex only serialized within
 		// one read_biom() instance and missed the segfault path from issue #72.

--- a/src/include/read_biom.hpp
+++ b/src/include/read_biom.hpp
@@ -36,8 +36,10 @@ public:
 	};
 
 	struct GlobalState : public GlobalTableFunctionState {
-		mutex lock;
-		mutex hdf5_lock;                       // Serialize HDF5 operations (HDF5 is not thread-safe)
+		mutex lock;                            // Guards current_file_idx for the work-claim cursor
+		// HDF5 serialization lives in miint::g_hdf5_mutex (BIOMReader.hpp) so it
+		// covers cross-query races; a per-state mutex only serialized within
+		// one read_biom() instance and missed the segfault path from issue #72.
 		std::vector<std::string> filepaths;    // Original paths (for include_filepath)
 		std::vector<std::string> local_paths;  // Resolved local paths (for BIOMReader)
 		miint::ResolvedFileSet resolved_files; // RAII cleanup for temp files
@@ -80,13 +82,16 @@ public:
 				global_state.current_file_idx++;
 			}
 
-			// Serialize HDF5 operations since HDF5 is not thread-safe
+			// Serialize HDF5 calls against every other reader in the process —
+			// see miint::g_hdf5_mutex doc in BIOMReader.hpp. The inner scope
+			// keeps the BIOMReader destructor (H5Fclose / H5Dclose) inside
+			// the lock; releasing earlier would race with another thread's
+			// H5Fopen.
 			{
-				std::lock_guard<std::mutex> hdf5_guard(global_state.hdf5_lock);
+				std::lock_guard<std::mutex> hdf5_guard(miint::g_hdf5_mutex);
 				{
 					auto reader = miint::BIOMReader(local_path);
 					table = reader.read();
-					// Explicit scope ensures reader destructor runs while holding hdf5_lock
 				}
 			}
 

--- a/src/read_biom.cpp
+++ b/src/read_biom.cpp
@@ -39,12 +39,15 @@ unique_ptr<FunctionData> ReadBIOMTableFunction::Bind(ClientContext &context, Tab
 		throw InvalidInputException("read_biom: first argument must be VARCHAR or VARCHAR[]");
 	}
 
-	// Validate all files exist and are BIOM (skip remote paths - validated at read time)
+	// Validate all files exist and are BIOM (skip remote paths - validated at read time).
+	// IsBIOM is a HDF5 entry point — serialize against the process-wide HDF5 mutex
+	// since Bind can run concurrently when multiple queries reach the planner at once.
 	for (const auto &path : biom_paths) {
 		if (!miint::RemoteFileHelper::IsRemotePath(path)) {
 			if (!fs.FileExists(path)) {
 				throw IOException("File not found: " + path);
 			}
+			std::lock_guard<std::mutex> hdf5_guard(miint::g_hdf5_mutex);
 			if (!miint::BIOMReader::IsBIOM(path)) {
 				throw IOException("File is not a BIOM file: " + path);
 			}

--- a/test/sql/read_biom.test
+++ b/test/sql/read_biom.test
@@ -181,3 +181,23 @@ S3	7.0
 S4	6.0
 S5	10.0
 S6	14.0
+
+# Regression test for issue #72: read_biom must not segfault when two
+# concurrent reads target the same BIOM file. Two views over the same file,
+# UNION'd, force the planner to schedule both scans before consuming either.
+# Without the process-wide g_hdf5_mutex (see BIOMReader.hpp) the two scans
+# race on HDF5's global library state and segfault. UNION (not UNION ALL)
+# also dedups, so the count over file1's 5 rows is 5.
+statement ok
+SET preserve_insertion_order = false;
+
+statement ok
+CREATE OR REPLACE VIEW view_a AS FROM read_biom('data/biom/file1.biom');
+
+statement ok
+CREATE OR REPLACE VIEW view_b AS FROM read_biom('data/biom/file1.biom');
+
+query I
+SELECT count(*) FROM (SELECT * FROM view_a UNION SELECT * FROM view_b);
+----
+5


### PR DESCRIPTION
Fixes #72: read_biom segfaults on concurrent reads.

Two views over the same BIOM file crashes because DuckDB runs the two reads on different threads, and the HDF5 library underneath isn't thread-safe — our vcpkg build uses features cpp / zlib / szip, not threadsafe, so HDF5 has no internal locking and its process-wide state (library init, type system, error stack, dataset caches) corrupts under concurrent access. There was an existing hdf5_lock but it lived on read_biom's GlobalState, meaning each separate read_biom() call got its own private copy and they didn't serialize against each other. This fix promotes the mutex to a process-wide miint::g_hdf5_mutex declared in BIOMReader.hpp and acquires it around every HDF5 entry point — same pattern as MafftAligner.cpp already uses for MAFFT, which is non-thread-safe for the same reasons. Also added a regression test (the issue's exact reproducer with preserve_insertion_order = false) that segfaults without the fix and passes deterministically with it.