### PR TITLE
fix(read_ena_sequences): gate skipped-runs summary on runs_completed

### DIFF
--- a/src/read_ena_sequences.cpp
+++ b/src/read_ena_sequences.cpp
@@ -332,8 +332,20 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 			} // Lock released before I/O or warning output
 
 			if (all_claimed) {
-				// Print skipped-runs warning exactly once across all threads
-				if (!global_state.skipped_warned.exchange(true, std::memory_order_acq_rel)) {
+				// Only emit the summary once every claimed run has been finalized.
+				// "next_run_idx exhausted" alone is not sufficient: other workers
+				// may still be processing runs they claimed earlier, and a failure
+				// on one of those would append to skipped_runs *after* this thread
+				// snapshotted the list — producing a stale summary followed by an
+				// orphan per-run warning. The acquire load pairs with the release
+				// fetch_add on runs_completed in the failure paths below; once we
+				// observe total_runs, all skipped_runs.push_back's are visible.
+				//
+				// Workers that lose this check just return empty; the worker that
+				// posts the final fetch_add will be the one to come back through
+				// here, pass the gate, and emit the (now complete) summary.
+				if (global_state.runs_completed.load(std::memory_order_acquire) == global_state.total_runs &&
+				    !global_state.skipped_warned.exchange(true, std::memory_order_acq_rel)) {
 					// Build the message under skipped_lock, then drop the lock
 					// before EmitWarning acquires LogManager::lock. Avoids
 					// establishing a skipped_lock → LogManager::lock ordering
@@ -382,7 +394,9 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 						global_state.skipped_runs.push_back(run.run_accession);
 					}
 					global_state.bytes_completed.fetch_add(run.total_bytes, std::memory_order_relaxed);
-					global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
+					// release: publishes skipped_runs.push_back above to the summary
+					// thread's acquire load on runs_completed (see all_claimed branch).
+					global_state.runs_completed.fetch_add(1, std::memory_order_release);
 					local_state.has_run = false;
 					continue;
 				}
@@ -421,7 +435,9 @@ void ReadENASequencesTableFunction::Execute(ClientContext &context, TableFunctio
 				global_state.skipped_runs.push_back(run.run_accession);
 			}
 			global_state.bytes_completed.fetch_add(run.total_bytes, std::memory_order_relaxed);
-			global_state.runs_completed.fetch_add(1, std::memory_order_relaxed);
+			// release: publishes skipped_runs.push_back above to the summary
+			// thread's acquire load on runs_completed (see all_claimed branch).
+			global_state.runs_completed.fetch_add(1, std::memory_order_release);
 			local_state.has_run = false;
 			continue;
 		}


### PR DESCRIPTION
## Summary
- Fixes a race in the parallel `Execute()` of `read_ena_sequences` where the end-of-scan "N run(s) skipped" summary could be emitted before all in-flight workers had finalized their claimed runs, producing a stale list followed by an "orphan" per-run warning for a later failure.
- Adds a second gate (`runs_completed == total_runs`) before emitting the summary. Workers that lose the gate return empty; the worker that posts the final `fetch_add` walks back through the loop and emits the (now complete) summary. The existing `skipped_warned` exchange still guarantees single emission.
- Upgrades the two failure-path `runs_completed.fetch_add` calls from `relaxed` to `release` so they synchronize with the new acquire load — when the summary thread observes `total_runs`, the preceding `skipped_runs.push_back` is guaranteed visible. The success-path increment stays `relaxed` (no skipped state to publish).
- Lateral `ExecuteInOut` path is unaffected (no batched summary).

## Why
Users saw output like:

```
read_ena_sequences: WARNING: 2 run(s) skipped due to download errors: ERR_A ERR_B
read_ena_sequences: WARNING: run 'ERR_C' failed mid-stream after emitting 1234 read(s) ...
```

`ERR_C` was missing from the summary because the summary thread snapshotted `skipped_runs` while another worker was still processing `ERR_C`. The new gate ensures the summary thread only fires once every claimed run has reached a terminal state.

## Test plan
- [x] `bash build.sh` — clean build
- [x] `bash run_tests.sh` — full SQL/shell suite, no failures
- [x] `./build/release/extension/miint/tests` — 1032 passed, 1 skipped (unrelated `MZXML_REAL_DATA` guard)
- [ ] Reviewer: spot-check that no existing test pinned the old "summary appears as soon as queue drains" timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)