### PR TITLE
feat(blast): add blast() table function for remote NCBI BLAST searches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,6 +997,9 @@ set(EXTENSION_SOURCES
     src/save_minimap2_index.cpp
     src/ncbi_parser.cpp
     src/ncbi_client.cpp
+    src/blast_parser.cpp
+    src/blast_client.cpp
+    src/blast_search.cpp
     src/zip_utils.cpp
     src/read_ncbi_fasta.cpp
     src/read_ncbi.cpp
@@ -1400,6 +1403,8 @@ set(TEST_SOURCES
     src/zip_utils.cpp
     duckdb/third_party/miniz/miniz.cpp  # For ExtractFromZip tests
     test/cpp/test_ncbi_client.cpp
+    src/blast_parser.cpp
+    test/cpp/test_blast_parser.cpp
     src/ena_parser.cpp
     src/ena_run_info_extractor.cpp
     src/ena_resolver_cache.cpp

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -15,6 +15,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`read_ncbi`](#read_ncbiaccession-api_key-batch_size500) - NCBI accession metadata
 - [`read_ncbi_fasta`](#read_ncbi_fastaaccession-api_key-include_filepathfalse-batch_size500) - NCBI FASTA sequences
 - [`read_ncbi_annotation`](#read_ncbi_annotationaccession-api_key-include_filepathfalse) - NCBI genome annotations
+- [`blast`](#blastquery_table-options) - Remote NCBI BLAST sequence search
 - [`read_ena`](#read_enaaccession-resultread_run-fields) - EBI/ENA metadata queries
 - [`read_ena_attributes`](#read_ena_attributesaccession) - EBI/ENA custom sample attributes
 - [`ena_searchable_fields`](#ena_searchable_fieldsresult_type) - Enumerate ENA structured-search fields per result type
@@ -888,6 +889,100 @@ COPY (
 - Complex feature locations (join, complement) emit a warning and use outer bounds only
 - The `phase` column is set from the `codon_start` qualifier for CDS features
 - Source is detected from accession prefix: NC_/NM_/NP_ -> 'RefSeq', others -> 'GenBank' or 'NCBI'
+
+## `blast(query_table, [options])`
+
+Search sequences against NCBI's remote BLAST databases. Sends query sequences to the NCBI BLAST web API and returns tabular hit results (equivalent to outfmt 6). Supports all BLAST programs: `blastn`, `blastp`, `blastx`, `tblastn`, `tblastx`.
+
+**Requirements:**
+- Requires the `httpfs` extension (automatically loaded)
+- Network access to NCBI BLAST servers (blast.ncbi.nlm.nih.gov)
+
+**Parameters:**
+- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns. TEMP tables are not supported — use persistent tables.
+- `program` (VARCHAR, optional, default `'blastn'`): BLAST program. One of: `blastn`, `blastp`, `blastx`, `tblastn`, `tblastx`.
+- `database` (VARCHAR, optional, default `'nt'`): Target database (e.g., `'nt'`, `'nr'`, `'refseq_rna'`, `'swissprot'`).
+- `evalue` (DOUBLE, optional, default 10.0): E-value threshold. Only hits with e-value at or below this threshold are returned.
+- `max_targets` (INTEGER, optional, default 500): Maximum number of target sequences to report per query (HITLIST_SIZE).
+- `megablast` (BOOLEAN, optional, default true): Enable megablast mode for faster nucleotide searches. Only valid with `program='blastn'`.
+- `api_key` (VARCHAR, optional): NCBI API key for higher rate limits (10 req/s vs 3 req/s).
+
+**Output schema:**
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `query_id` | VARCHAR | Query sequence identifier (from `read_id` column) |
+| `subject_id` | VARCHAR | Subject (hit) accession |
+| `pct_identity` | DOUBLE | Percentage of identical matches |
+| `alignment_length` | INTEGER | Alignment length |
+| `mismatches` | INTEGER | Number of mismatches |
+| `gap_opens` | INTEGER | Number of gap openings |
+| `query_start` | BIGINT | Start of alignment in query (1-based) |
+| `query_end` | BIGINT | End of alignment in query |
+| `subject_start` | BIGINT | Start of alignment in subject |
+| `subject_end` | BIGINT | End of alignment in subject |
+| `evalue` | DOUBLE | Expect value |
+| `bit_score` | DOUBLE | Bit score |
+
+**Behavior:**
+- Loads all sequences from the query table into memory, then submits them to NCBI BLAST as FASTA
+- Large query sets (> 4 MB of FASTA data) are automatically split into multiple submissions
+- Each submission is a blocking operation: the function submits, polls until completion, and retrieves results before processing the next batch
+- Poll interval is 15 seconds; maximum wait time per submission is 60 minutes
+- Rate-limited to respect NCBI guidelines (3 req/s without key, 10 req/s with key)
+- Retry logic for transient failures (408, 429, 500, 502, 503, 504) with exponential backoff up to 6 retries
+- NCBI BLAST jobs that return `UNKNOWN` status are retried up to 3 times before failing
+- Progress messages are printed to stderr during polling
+- Returns zero rows (not an error) if no significant hits are found
+
+**Examples:**
+```sql
+-- Create a table with sequences to search
+CREATE TABLE my_sequences (read_id VARCHAR, sequence1 VARCHAR);
+INSERT INTO my_sequences VALUES
+    ('seq1', 'GGGCGGCGACCTCGCGGGTTTTCGCTATTTATGAAAATTTTCCGGTTTAAGGCGTTTCCG'),
+    ('seq2', 'ATGAAAGCAATTTTCGTACTGAAACATCTTAATCATGCTAAGGAGGTTTTCTAATG');
+
+-- Basic blastn search against nt
+SELECT * FROM blast('my_sequences');
+
+-- Search with custom parameters
+SELECT query_id, subject_id, pct_identity, evalue
+FROM blast('my_sequences',
+           program := 'blastn',
+           database := 'nt',
+           evalue := 1e-10,
+           max_targets := 10);
+
+-- Protein BLAST search
+CREATE TABLE my_proteins (read_id VARCHAR, sequence1 VARCHAR);
+INSERT INTO my_proteins VALUES
+    ('insulin_b', 'FVNQHLCGSHLVEALYLVCGERGFFYTPKT');
+
+SELECT query_id, subject_id, pct_identity, evalue, bit_score
+FROM blast('my_proteins', program := 'blastp', database := 'nr', megablast := false);
+
+-- Find top hit per query
+SELECT DISTINCT ON (query_id) query_id, subject_id, pct_identity, evalue
+FROM blast('my_sequences', max_targets := 50)
+ORDER BY query_id, evalue ASC;
+
+-- Filter for high-confidence hits
+SELECT * FROM blast('my_sequences')
+WHERE pct_identity >= 95.0 AND evalue < 1e-20;
+
+-- Use API key for higher rate limits on large queries
+SELECT * FROM blast('my_sequences', api_key := 'your_ncbi_api_key');
+```
+
+**Notes:**
+- TEMP tables are not supported because the function loads sequences through a separate database connection. Use persistent tables or views.
+- The `megablast` parameter is only valid with `program='blastn'`. Specifying it with other programs raises a bind error.
+- For large-scale searches, use `api_key` to increase the rate limit from 3 to 10 requests per second.
+- BLAST queries can take 30 seconds to several minutes depending on database size and query count. The function blocks until results are ready.
+- Batch splitting (for queries exceeding 4 MB FASTA) is reported via `miint_warnings()`.
+
+---
 
 ## `read_ena(accession, [result='read_run'], [fields])`
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -177,6 +177,13 @@ else
     echo "Warning: moderate FastTree oracle: $ft_moderate_status; rerun with MIINT_FASTTREE_REGENERATE=1 to refresh"
 fi
 
+# NCBI BLAST network reachability. Probes the BLAST CGI endpoint so
+# live blast tests can skip gracefully in offline CI.
+if curl -sSf --max-time 5 -o /dev/null \
+        "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi" 2>/dev/null; then
+    export BLAST_LIVE_AVAILABLE=1
+fi
+
 # ENA network reachability. Probes the Portal API with a cheap HEAD-ish call
 # so tests that need live ENA access can skip gracefully in offline CI.
 # Timeout is tight (3s) to avoid slowing down the common case.

--- a/src/blast_client.cpp
+++ b/src/blast_client.cpp
@@ -84,8 +84,7 @@ std::string BlastClient::MakePostRequest(const std::string &url, const std::stri
 		if (response->HasRequestError()) {
 			throw duckdb::IOException("blast: POST failed: %s (URL: %s)", response->GetRequestError(), url);
 		}
-		throw duckdb::HTTPException(*response, "blast: POST failed with HTTP %d (URL: %s)", int(response->status),
-		                            url);
+		throw duckdb::HTTPException(*response, "blast: POST failed with HTTP %d (URL: %s)", int(response->status), url);
 	}
 	throw duckdb::IOException("blast: POST failed after %d retries (URL: %s)", MAX_RETRIES, url);
 }
@@ -158,7 +157,8 @@ void BlastClient::WaitForCompletion(const std::string &rid, int rtoe_hint) {
 
 	throw duckdb::IOException("blast: timed out after %d poll attempts (~%d minutes) for RID %s. "
 	                          "Check status at: %s?CMD=Get&RID=%s",
-	                          MAX_POLL_ATTEMPTS, (MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS) / 60, rid, BLAST_BASE, rid);
+	                          MAX_POLL_ATTEMPTS, (MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS) / 60, rid, BLAST_BASE,
+	                          rid);
 }
 
 std::string BlastClient::RetrieveResults(const std::string &rid, int max_targets) {

--- a/src/blast_client.cpp
+++ b/src/blast_client.cpp
@@ -1,0 +1,172 @@
+#include "blast_client.hpp"
+#include "duckdb/common/exception/http_exception.hpp"
+#include "duckdb/common/printer.hpp"
+#include <sstream>
+#include <thread>
+
+namespace miint {
+
+BlastClient::BlastClient(duckdb::DatabaseInstance &db, const std::string &api_key)
+    : db_(db), api_key_(api_key), last_request_time_(std::chrono::steady_clock::now() - std::chrono::seconds(1)) {
+}
+
+double BlastClient::GetRateLimit() const {
+	return api_key_.empty() ? RATE_LIMIT_NO_KEY : RATE_LIMIT_WITH_KEY;
+}
+
+void BlastClient::RespectRateLimit() {
+	std::lock_guard<std::mutex> lock(rate_limit_mutex_);
+	auto now = std::chrono::steady_clock::now();
+	auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(now - last_request_time_);
+	auto min_interval = std::chrono::milliseconds(static_cast<int>(1000.0 / GetRateLimit()));
+	if (elapsed < min_interval) {
+		std::this_thread::sleep_for(min_interval - elapsed);
+	}
+	last_request_time_ = std::chrono::steady_clock::now();
+}
+
+bool BlastClient::IsRetryableStatus(int status) {
+	return status == 408 || status == 429 || status == 500 || status == 502 || status == 503 || status == 504;
+}
+
+std::string BlastClient::MakeGetRequest(const std::string &url) {
+	duckdb::HTTPHeaders headers(db_);
+	auto &http_util = duckdb::HTTPUtil::Get(db_);
+	auto params = http_util.InitializeParameters(db_, url);
+	duckdb::GetRequestInfo get_request(url, headers, *params, nullptr, nullptr);
+	get_request.try_request = true;
+
+	int retry_delay_ms = INITIAL_RETRY_DELAY_MS;
+	for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		RespectRateLimit();
+		auto response = http_util.Request(get_request);
+		if (response->Success()) {
+			return response->body;
+		}
+		if (attempt < MAX_RETRIES && !response->HasRequestError() && IsRetryableStatus(int(response->status))) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
+			retry_delay_ms *= 2;
+			continue;
+		}
+		if (response->HasRequestError()) {
+			throw duckdb::IOException("blast: request failed: %s (URL: %s)", response->GetRequestError(), url);
+		}
+		throw duckdb::HTTPException(*response, "blast: request failed with HTTP %d (URL: %s)", int(response->status),
+		                            url);
+	}
+	throw duckdb::IOException("blast: request failed after %d retries (URL: %s)", MAX_RETRIES, url);
+}
+
+std::string BlastClient::MakePostRequest(const std::string &url, const std::string &body,
+                                         const std::string &content_type) {
+	duckdb::HTTPHeaders headers(db_);
+	headers.Insert("Content-Type", content_type);
+	auto &http_util = duckdb::HTTPUtil::Get(db_);
+	auto params = http_util.InitializeParameters(db_, url);
+	const auto *buf_ptr = reinterpret_cast<duckdb::const_data_ptr_t>(body.data());
+
+	int retry_delay_ms = INITIAL_RETRY_DELAY_MS;
+	for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+		RespectRateLimit();
+		// Rebuild each iteration — PostRequestInfo carries response state in
+		// buffer_out (DuckDB issue #19062).
+		duckdb::PostRequestInfo post_request(url, headers, *params, buf_ptr, body.size());
+		post_request.try_request = true;
+		auto response = http_util.Request(post_request);
+		if (response->Success()) {
+			return post_request.buffer_out;
+		}
+		if (attempt < MAX_RETRIES && !response->HasRequestError() && IsRetryableStatus(int(response->status))) {
+			std::this_thread::sleep_for(std::chrono::milliseconds(retry_delay_ms));
+			retry_delay_ms *= 2;
+			continue;
+		}
+		if (response->HasRequestError()) {
+			throw duckdb::IOException("blast: POST failed: %s (URL: %s)", response->GetRequestError(), url);
+		}
+		throw duckdb::HTTPException(*response, "blast: POST failed with HTTP %d (URL: %s)", int(response->status),
+		                            url);
+	}
+	throw duckdb::IOException("blast: POST failed after %d retries (URL: %s)", MAX_RETRIES, url);
+}
+
+BlastSubmitResult BlastClient::Submit(const std::string &program, const std::string &database,
+                                      const std::string &fasta_query, double evalue, int max_targets, bool megablast) {
+	std::string body = BlastParser::BuildSubmitBody(program, database, fasta_query, evalue, max_targets, megablast);
+	if (!api_key_.empty()) {
+		body += "&api_key=" + BlastParser::UrlEncode(api_key_);
+	}
+	std::string response = MakePostRequest(BLAST_BASE, body, "application/x-www-form-urlencoded");
+	auto result = BlastParser::ParseSubmitResponse(response);
+	if (!result.error.empty()) {
+		throw duckdb::IOException("blast: NCBI returned error: %s", result.error);
+	}
+	if (result.rid.empty()) {
+		auto snippet = response.substr(0, std::min<size_t>(response.size(), 400));
+		throw duckdb::IOException("blast: failed to obtain RID from NCBI (response: %s)", snippet);
+	}
+	return result;
+}
+
+void BlastClient::WaitForCompletion(const std::string &rid, int rtoe_hint) {
+	if (rid.empty()) {
+		throw duckdb::IOException("blast: cannot poll with empty RID");
+	}
+
+	std::string encoded_rid = BlastParser::UrlEncode(rid);
+
+	const int max_initial_wait = MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS;
+	if (rtoe_hint > max_initial_wait) {
+		rtoe_hint = max_initial_wait;
+	}
+	if (rtoe_hint > 0) {
+		duckdb::Printer::Print("blast: waiting " + std::to_string(rtoe_hint) + "s (NCBI estimate) for RID " + rid);
+		std::this_thread::sleep_for(std::chrono::seconds(rtoe_hint));
+	}
+
+	int unknown_count = 0;
+	for (int attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt++) {
+		std::ostringstream url;
+		url << BLAST_BASE << "?CMD=Get&FORMAT_OBJECT=SearchInfo&RID=" << encoded_rid;
+		std::string response = MakeGetRequest(url.str());
+		auto status = BlastParser::ParseStatusResponse(response);
+
+		if (status == BlastStatus::READY) {
+			return;
+		}
+		if (status == BlastStatus::UNKNOWN) {
+			unknown_count++;
+			if (unknown_count > MAX_UNKNOWN_STATUS_RETRIES) {
+				auto snippet = response.substr(0, std::min<size_t>(response.size(), 400));
+				throw duckdb::IOException(
+				    "blast: job %s returned UNKNOWN status %d times — may have expired or failed (response: %s)", rid,
+				    unknown_count, snippet);
+			}
+			duckdb::Printer::Print("blast: RID " + rid + " returned UNKNOWN status (attempt " +
+			                       std::to_string(unknown_count) + "/" + std::to_string(MAX_UNKNOWN_STATUS_RETRIES) +
+			                       "), retrying...");
+		} else {
+			unknown_count = 0;
+		}
+
+		int elapsed = rtoe_hint + (attempt + 1) * POLL_INTERVAL_SECONDS;
+		if (status == BlastStatus::WAITING) {
+			duckdb::Printer::Print("blast: RID " + rid + " still running (~" + std::to_string(elapsed) + "s elapsed)");
+		}
+		std::this_thread::sleep_for(std::chrono::seconds(POLL_INTERVAL_SECONDS));
+	}
+
+	throw duckdb::IOException("blast: timed out after %d poll attempts (~%d minutes) for RID %s. "
+	                          "Check status at: %s?CMD=Get&RID=%s",
+	                          MAX_POLL_ATTEMPTS, (MAX_POLL_ATTEMPTS * POLL_INTERVAL_SECONDS) / 60, rid, BLAST_BASE, rid);
+}
+
+std::string BlastClient::RetrieveResults(const std::string &rid, int max_targets) {
+	std::string encoded_rid = BlastParser::UrlEncode(rid);
+	std::ostringstream url;
+	url << BLAST_BASE << "?CMD=Get&FORMAT_TYPE=Text&ALIGNMENT_VIEW=Tabular&HITLIST_SIZE=" << max_targets
+	    << "&RID=" << encoded_rid;
+	return MakeGetRequest(url.str());
+}
+
+} // namespace miint

--- a/src/blast_parser.cpp
+++ b/src/blast_parser.cpp
@@ -1,0 +1,206 @@
+#include "blast_parser.hpp"
+#include <sstream>
+#include <stdexcept>
+
+namespace miint {
+
+BlastSubmitResult BlastParser::ParseSubmitResponse(const std::string &html) {
+	BlastSubmitResult result;
+
+	auto extract_qblast_value = [&](const std::string &key) -> std::string {
+		auto pos = html.find(key);
+		if (pos == std::string::npos) {
+			return "";
+		}
+		pos += key.size();
+		while (pos < html.size() && (html[pos] == ' ' || html[pos] == '=')) {
+			pos++;
+		}
+		auto end = pos;
+		while (end < html.size() && html[end] != '\n' && html[end] != '\r' && html[end] != ' ') {
+			end++;
+		}
+		return html.substr(pos, end - pos);
+	};
+
+	result.rid = extract_qblast_value("RID ");
+	std::string rtoe_str = extract_qblast_value("RTOE ");
+	if (!rtoe_str.empty()) {
+		try {
+			result.rtoe = std::stoi(rtoe_str);
+		} catch (...) {
+			result.rtoe = 0;
+		}
+	}
+
+	auto error_marker = html.find("class=\"error\">");
+	if (error_marker != std::string::npos) {
+		auto tag_close = html.find('>', error_marker);
+		if (tag_close != std::string::npos) {
+			auto content_start = tag_close + 1;
+			auto content_end = html.find('<', content_start);
+			if (content_end != std::string::npos) {
+				result.error = html.substr(content_start, content_end - content_start);
+			}
+		}
+	}
+
+	return result;
+}
+
+BlastStatus BlastParser::ParseStatusResponse(const std::string &text) {
+	if (text.find("Status=WAITING") != std::string::npos) {
+		return BlastStatus::WAITING;
+	}
+	if (text.find("Status=READY") != std::string::npos) {
+		return BlastStatus::READY;
+	}
+	return BlastStatus::UNKNOWN;
+}
+
+std::vector<BlastHit> BlastParser::ParseTabularResults(const std::string &tabular) {
+	std::vector<BlastHit> hits;
+	if (tabular.empty()) {
+		return hits;
+	}
+
+	std::istringstream stream(tabular);
+	std::string line;
+	while (std::getline(stream, line)) {
+		if (!line.empty() && line.back() == '\r') {
+			line.pop_back();
+		}
+		if (line.empty() || line[0] == '#') {
+			continue;
+		}
+
+		std::vector<std::string> fields;
+		std::istringstream line_stream(line);
+		std::string field;
+		while (std::getline(line_stream, field, '\t')) {
+			fields.push_back(field);
+		}
+
+		if (fields.size() < 12) {
+			continue;
+		}
+
+		try {
+			BlastHit hit;
+			hit.query_id = fields[0];
+			hit.subject_id = fields[1];
+			hit.pct_identity = std::stod(fields[2]);
+			hit.alignment_length = std::stoi(fields[3]);
+			hit.mismatches = std::stoi(fields[4]);
+			hit.gap_opens = std::stoi(fields[5]);
+			hit.query_start = std::stoll(fields[6]);
+			hit.query_end = std::stoll(fields[7]);
+			hit.subject_start = std::stoll(fields[8]);
+			hit.subject_end = std::stoll(fields[9]);
+			hit.evalue = std::stod(fields[10]);
+			hit.bit_score = std::stod(fields[11]);
+			hits.push_back(std::move(hit));
+		} catch (...) {
+			continue;
+		}
+	}
+
+	return hits;
+}
+
+bool BlastParser::ValidateProgram(const std::string &program) {
+	return program == "blastn" || program == "blastp" || program == "blastx" ||
+	       program == "tblastn" || program == "tblastx";
+}
+
+std::string BlastParser::BuildFastaPayload(const std::vector<std::string> &ids,
+                                           const std::vector<std::string> &sequences) {
+	if (ids.size() != sequences.size()) {
+		throw std::invalid_argument("ids and sequences must have the same size");
+	}
+	std::string result;
+	size_t total = 0;
+	for (size_t i = 0; i < ids.size(); i++) {
+		total += 1 + ids[i].size() + 1 + sequences[i].size() + 1;
+	}
+	result.reserve(total);
+	for (size_t i = 0; i < ids.size(); i++) {
+		result += '>';
+		result += ids[i];
+		result += '\n';
+		result += sequences[i];
+		result += '\n';
+	}
+	return result;
+}
+
+std::string BlastParser::UrlEncode(const std::string &value) {
+	std::string encoded;
+	encoded.reserve(value.size() + value.size() / 4);
+	for (unsigned char c : value) {
+		if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-' || c == '_' ||
+		    c == '.' || c == '~') {
+			encoded += static_cast<char>(c);
+		} else {
+			char hex[4];
+			snprintf(hex, sizeof(hex), "%%%02X", c);
+			encoded += hex;
+		}
+	}
+	return encoded;
+}
+
+std::string BlastParser::BuildSubmitBody(const std::string &program, const std::string &database,
+                                         const std::string &fasta_query, double evalue, int max_targets,
+                                         bool megablast) {
+	std::ostringstream body;
+	body << "CMD=Put";
+	body << "&PROGRAM=" << UrlEncode(program);
+	body << "&DATABASE=" << UrlEncode(database);
+
+	std::ostringstream evalue_ss;
+	evalue_ss << evalue;
+	body << "&EXPECT=" << evalue_ss.str();
+
+	body << "&HITLIST_SIZE=" << max_targets;
+	if (megablast) {
+		body << "&MEGABLAST=on";
+	}
+	body << "&QUERY=" << UrlEncode(fasta_query);
+	return body.str();
+}
+
+std::vector<BlastParser::SequenceBatch> BlastParser::SplitIntoBatches(const std::vector<std::string> &ids,
+                                                                     const std::vector<std::string> &sequences,
+                                                                     size_t max_bytes) {
+	std::vector<SequenceBatch> batches;
+	if (ids.empty()) {
+		return batches;
+	}
+
+	SequenceBatch current;
+	size_t current_size = 0;
+
+	for (size_t i = 0; i < ids.size(); i++) {
+		// FASTA record: ">id\nsequence\n"
+		size_t record_size = 1 + ids[i].size() + 1 + sequences[i].size() + 1;
+
+		if (!current.ids.empty() && current_size + record_size > max_bytes) {
+			batches.push_back(std::move(current));
+			current = SequenceBatch {};
+			current_size = 0;
+		}
+
+		current.ids.push_back(ids[i]);
+		current.sequences.push_back(sequences[i]);
+		current_size += record_size;
+	}
+
+	if (!current.ids.empty()) {
+		batches.push_back(std::move(current));
+	}
+
+	return batches;
+}
+
+} // namespace miint

--- a/src/blast_parser.cpp
+++ b/src/blast_parser.cpp
@@ -109,8 +109,8 @@ std::vector<BlastHit> BlastParser::ParseTabularResults(const std::string &tabula
 }
 
 bool BlastParser::ValidateProgram(const std::string &program) {
-	return program == "blastn" || program == "blastp" || program == "blastx" ||
-	       program == "tblastn" || program == "tblastx";
+	return program == "blastn" || program == "blastp" || program == "blastx" || program == "tblastn" ||
+	       program == "tblastx";
 }
 
 std::string BlastParser::BuildFastaPayload(const std::vector<std::string> &ids,
@@ -171,8 +171,8 @@ std::string BlastParser::BuildSubmitBody(const std::string &program, const std::
 }
 
 std::vector<BlastParser::SequenceBatch> BlastParser::SplitIntoBatches(const std::vector<std::string> &ids,
-                                                                     const std::vector<std::string> &sequences,
-                                                                     size_t max_bytes) {
+                                                                      const std::vector<std::string> &sequences,
+                                                                      size_t max_bytes) {
 	std::vector<SequenceBatch> batches;
 	if (ids.empty()) {
 		return batches;

--- a/src/blast_search.cpp
+++ b/src/blast_search.cpp
@@ -1,0 +1,199 @@
+#include "blast_search.hpp"
+#include "miint_log.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/value.hpp"
+#include "duckdb/common/vector_size.hpp"
+#include "duckdb/main/database.hpp"
+
+namespace duckdb {
+
+static std::vector<std::string> GetBlastOutputNames() {
+	return {"query_id",   "subject_id",       "pct_identity", "alignment_length", "mismatches", "gap_opens",
+	        "query_start", "query_end",        "subject_start", "subject_end",     "evalue",     "bit_score"};
+}
+
+static std::vector<LogicalType> GetBlastOutputTypes() {
+	return {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE,  LogicalType::INTEGER,
+	        LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT,  LogicalType::BIGINT,
+	        LogicalType::BIGINT,  LogicalType::BIGINT,  LogicalType::DOUBLE,  LogicalType::DOUBLE};
+}
+
+unique_ptr<FunctionData> BlastSearchTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                        vector<LogicalType> &return_types, vector<std::string> &names) {
+	auto data = make_uniq<Data>();
+
+	if (input.inputs[0].IsNull()) {
+		throw BinderException("blast: table name cannot be NULL");
+	}
+	data->query_table = input.inputs[0].ToString();
+	if (data->query_table.empty()) {
+		throw BinderException("blast: table name cannot be empty");
+	}
+
+	auto get_string = [&](const std::string &name, std::string &out) {
+		auto it = input.named_parameters.find(name);
+		if (it != input.named_parameters.end() && !it->second.IsNull()) {
+			out = it->second.ToString();
+		}
+	};
+	auto get_double = [&](const std::string &name, double &out) {
+		auto it = input.named_parameters.find(name);
+		if (it != input.named_parameters.end() && !it->second.IsNull()) {
+			out = it->second.GetValue<double>();
+		}
+	};
+	auto get_int = [&](const std::string &name, int &out) {
+		auto it = input.named_parameters.find(name);
+		if (it != input.named_parameters.end() && !it->second.IsNull()) {
+			out = it->second.GetValue<int>();
+		}
+	};
+	auto get_bool = [&](const std::string &name, bool &out) {
+		auto it = input.named_parameters.find(name);
+		if (it != input.named_parameters.end() && !it->second.IsNull()) {
+			out = it->second.GetValue<bool>();
+		}
+	};
+
+	get_string("program", data->program);
+	get_string("database", data->database);
+	get_double("evalue", data->evalue);
+	get_int("max_targets", data->max_targets);
+	get_bool("megablast", data->megablast);
+	get_string("api_key", data->api_key);
+
+	if (!miint::BlastParser::ValidateProgram(data->program)) {
+		throw BinderException("blast: Invalid BLAST program '%s'. Must be one of: blastn, blastp, blastx, tblastn, tblastx",
+		                      data->program);
+	}
+	if (data->evalue <= 0) {
+		throw BinderException("blast: evalue must be positive (got %g)", data->evalue);
+	}
+	if (data->max_targets <= 0) {
+		throw BinderException("blast: max_targets must be positive (got %d)", data->max_targets);
+	}
+	if (data->megablast && data->program != "blastn") {
+		throw BinderException("blast: megablast is only valid with program='blastn' (got program='%s')", data->program);
+	}
+
+	ValidateSequenceTableSchema(context, data->query_table);
+
+	data->names = GetBlastOutputNames();
+	data->types = GetBlastOutputTypes();
+	for (auto &n : data->names) {
+		names.emplace_back(n);
+	}
+	for (auto &t : data->types) {
+		return_types.emplace_back(t);
+	}
+
+	return data;
+}
+
+unique_ptr<GlobalTableFunctionState> BlastSearchTableFunction::InitGlobal(ClientContext &context,
+                                                                          TableFunctionInitInput &input) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto &db = DatabaseInstance::GetDatabase(context);
+	auto gstate = make_uniq<GlobalState>();
+
+	gstate->client = make_uniq<miint::BlastClient>(db, data.api_key);
+	gstate->program = data.program;
+	gstate->database = data.database;
+	gstate->evalue = data.evalue;
+	gstate->max_targets = data.max_targets;
+	gstate->megablast = data.megablast;
+
+	auto loaded = LoadSingleEndSequences(context, data.query_table, "blast", /*strict=*/true);
+	gstate->batches = miint::BlastParser::SplitIntoBatches(loaded.labels, loaded.sequences, DEFAULT_MAX_BATCH_BYTES);
+
+	if (gstate->batches.size() > 1) {
+		miint::EmitWarning(context, "blast: splitting %d sequences into %d batches (~%zu bytes per batch limit)",
+		                   static_cast<int>(loaded.labels.size()), static_cast<int>(gstate->batches.size()),
+		                   DEFAULT_MAX_BATCH_BYTES);
+	}
+
+	return gstate;
+}
+
+unique_ptr<LocalTableFunctionState> BlastSearchTableFunction::InitLocal(ExecutionContext &context,
+                                                                        TableFunctionInitInput &input,
+                                                                        GlobalTableFunctionState *global_state) {
+	return make_uniq<LocalState>();
+}
+
+bool BlastSearchTableFunction::GlobalState::FetchNextBatch(ClientContext &context) {
+	while (batch_cursor < batches.size()) {
+		auto &batch = batches[batch_cursor];
+		batch_cursor++;
+
+		auto fasta = miint::BlastParser::BuildFastaPayload(batch.ids, batch.sequences);
+		auto submit_result = client->Submit(program, database, fasta, evalue, max_targets, megablast);
+		client->WaitForCompletion(submit_result.rid, submit_result.rtoe);
+		auto raw_results = client->RetrieveResults(submit_result.rid, max_targets);
+		auto hits = miint::BlastParser::ParseTabularResults(raw_results);
+
+		if (!hits.empty()) {
+			result_buffer = std::move(hits);
+			return true;
+		}
+	}
+	return false;
+}
+
+static void OutputBlastHits(DataChunk &output, const std::vector<miint::BlastHit> &hits, idx_t offset, idx_t count) {
+	for (idx_t i = 0; i < count; i++) {
+		const auto &hit = hits[offset + i];
+		FlatVector::GetData<string_t>(output.data[0])[i] = StringVector::AddString(output.data[0], hit.query_id);
+		FlatVector::GetData<string_t>(output.data[1])[i] = StringVector::AddString(output.data[1], hit.subject_id);
+		FlatVector::GetData<double>(output.data[2])[i] = hit.pct_identity;
+		FlatVector::GetData<int32_t>(output.data[3])[i] = hit.alignment_length;
+		FlatVector::GetData<int32_t>(output.data[4])[i] = hit.mismatches;
+		FlatVector::GetData<int32_t>(output.data[5])[i] = hit.gap_opens;
+		FlatVector::GetData<int64_t>(output.data[6])[i] = hit.query_start;
+		FlatVector::GetData<int64_t>(output.data[7])[i] = hit.query_end;
+		FlatVector::GetData<int64_t>(output.data[8])[i] = hit.subject_start;
+		FlatVector::GetData<int64_t>(output.data[9])[i] = hit.subject_end;
+		FlatVector::GetData<double>(output.data[10])[i] = hit.evalue;
+		FlatVector::GetData<double>(output.data[11])[i] = hit.bit_score;
+	}
+	output.SetCardinality(count);
+}
+
+void BlastSearchTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<GlobalState>();
+	// Lock held during FetchNextBatch (which blocks on HTTP). Safe because
+	// MaxThreads()=1 guarantees a single caller. Same pattern as read_ncbi.cpp.
+	lock_guard<mutex> guard(gstate.lock);
+
+	while (gstate.result_offset >= gstate.result_buffer.size()) {
+		gstate.result_buffer.clear();
+		gstate.result_offset = 0;
+		if (!gstate.FetchNextBatch(context)) {
+			output.SetCardinality(0);
+			return;
+		}
+	}
+
+	idx_t remaining = gstate.result_buffer.size() - gstate.result_offset;
+	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+	OutputBlastHits(output, gstate.result_buffer, gstate.result_offset, count);
+	gstate.result_offset += count;
+}
+
+TableFunction BlastSearchTableFunction::GetFunction() {
+	auto tf = TableFunction("blast", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal, InitLocal);
+	tf.named_parameters["program"] = LogicalType::VARCHAR;
+	tf.named_parameters["database"] = LogicalType::VARCHAR;
+	tf.named_parameters["evalue"] = LogicalType::DOUBLE;
+	tf.named_parameters["max_targets"] = LogicalType::INTEGER;
+	tf.named_parameters["megablast"] = LogicalType::BOOLEAN;
+	tf.named_parameters["api_key"] = LogicalType::VARCHAR;
+	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
+	return tf;
+}
+
+void BlastSearchTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/blast_search.cpp
+++ b/src/blast_search.cpp
@@ -8,14 +8,14 @@
 namespace duckdb {
 
 static std::vector<std::string> GetBlastOutputNames() {
-	return {"query_id",   "subject_id",       "pct_identity", "alignment_length", "mismatches", "gap_opens",
-	        "query_start", "query_end",        "subject_start", "subject_end",     "evalue",     "bit_score"};
+	return {"query_id",    "subject_id", "pct_identity",  "alignment_length", "mismatches", "gap_opens",
+	        "query_start", "query_end",  "subject_start", "subject_end",      "evalue",     "bit_score"};
 }
 
 static std::vector<LogicalType> GetBlastOutputTypes() {
-	return {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE,  LogicalType::INTEGER,
-	        LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT,  LogicalType::BIGINT,
-	        LogicalType::BIGINT,  LogicalType::BIGINT,  LogicalType::DOUBLE,  LogicalType::DOUBLE};
+	return {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::INTEGER,
+	        LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT, LogicalType::BIGINT,
+	        LogicalType::BIGINT,  LogicalType::BIGINT,  LogicalType::DOUBLE, LogicalType::DOUBLE};
 }
 
 unique_ptr<FunctionData> BlastSearchTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
@@ -63,8 +63,9 @@ unique_ptr<FunctionData> BlastSearchTableFunction::Bind(ClientContext &context, 
 	get_string("api_key", data->api_key);
 
 	if (!miint::BlastParser::ValidateProgram(data->program)) {
-		throw BinderException("blast: Invalid BLAST program '%s'. Must be one of: blastn, blastp, blastx, tblastn, tblastx",
-		                      data->program);
+		throw BinderException(
+		    "blast: Invalid BLAST program '%s'. Must be one of: blastn, blastp, blastx, tblastn, tblastx",
+		    data->program);
 	}
 	if (data->evalue <= 0) {
 		throw BinderException("blast: evalue must be positive (got %g)", data->evalue);

--- a/src/include/blast_client.hpp
+++ b/src/include/blast_client.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "blast_parser.hpp"
+#include "duckdb/common/http_util.hpp"
+#include "duckdb/main/database.hpp"
+#include <chrono>
+#include <mutex>
+#include <string>
+
+namespace miint {
+
+// HTTP client for the NCBI BLAST web API.
+//
+// The BLAST API is two-phase:
+//   1. Submit (POST CMD=Put) → returns RID + estimated wait time
+//   2. Poll (GET CMD=Get&FORMAT_OBJECT=SearchInfo) → Status=WAITING/READY/UNKNOWN
+//   3. Retrieve (GET CMD=Get&FORMAT_TYPE=Text&ALIGNMENT_VIEW=Tabular) → outfmt 6 results
+//
+// Rate limiting: NCBI requests ≤3 req/s. The poll loop uses 15s intervals
+// which naturally satisfies this. Individual requests also respect the
+// per-request rate limit.
+//
+// Independent from NCBIClient — uses DuckDB's HTTPUtil directly.
+class BlastClient {
+public:
+	static constexpr const char *BLAST_BASE = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi";
+	static constexpr int POLL_INTERVAL_SECONDS = 15;
+	static constexpr int MAX_POLL_ATTEMPTS = 240; // 60 min timeout
+	static constexpr double RATE_LIMIT_NO_KEY = 3.0;
+	static constexpr double RATE_LIMIT_WITH_KEY = 10.0;
+	static constexpr int MAX_RETRIES = 6;
+	static constexpr int INITIAL_RETRY_DELAY_MS = 1000;
+	static constexpr int MAX_UNKNOWN_STATUS_RETRIES = 3;
+
+	BlastClient(duckdb::DatabaseInstance &db, const std::string &api_key = "");
+	BlastClient(const BlastClient &) = delete;
+	BlastClient &operator=(const BlastClient &) = delete;
+
+	BlastSubmitResult Submit(const std::string &program, const std::string &database, const std::string &fasta_query,
+	                         double evalue, int max_targets, bool megablast);
+
+	void WaitForCompletion(const std::string &rid, int rtoe_hint);
+
+	std::string RetrieveResults(const std::string &rid, int max_targets);
+
+private:
+	duckdb::DatabaseInstance &db_;
+	std::string api_key_;
+	std::chrono::steady_clock::time_point last_request_time_;
+	mutable std::mutex rate_limit_mutex_;
+
+	std::string MakeGetRequest(const std::string &url);
+	std::string MakePostRequest(const std::string &url, const std::string &body, const std::string &content_type);
+	void RespectRateLimit();
+	double GetRateLimit() const;
+	static bool IsRetryableStatus(int status);
+};
+
+} // namespace miint

--- a/src/include/blast_parser.hpp
+++ b/src/include/blast_parser.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace miint {
+
+struct BlastSubmitResult {
+	std::string rid;
+	int rtoe = 0;
+	std::string error;
+};
+
+enum class BlastStatus { WAITING, READY, UNKNOWN };
+
+struct BlastHit {
+	std::string query_id;
+	std::string subject_id;
+	double pct_identity;
+	int32_t alignment_length;
+	int32_t mismatches;
+	int32_t gap_opens;
+	int64_t query_start;
+	int64_t query_end;
+	int64_t subject_start;
+	int64_t subject_end;
+	double evalue;
+	double bit_score;
+};
+
+class BlastParser {
+public:
+	static BlastSubmitResult ParseSubmitResponse(const std::string &html);
+	static BlastStatus ParseStatusResponse(const std::string &text);
+	static std::vector<BlastHit> ParseTabularResults(const std::string &tabular);
+	static bool ValidateProgram(const std::string &program);
+	static std::string BuildFastaPayload(const std::vector<std::string> &ids, const std::vector<std::string> &sequences);
+	static std::string UrlEncode(const std::string &value);
+	static std::string BuildSubmitBody(const std::string &program, const std::string &database,
+	                                   const std::string &fasta_query, double evalue, int max_targets, bool megablast);
+
+	struct SequenceBatch {
+		std::vector<std::string> ids;
+		std::vector<std::string> sequences;
+	};
+	static std::vector<SequenceBatch> SplitIntoBatches(const std::vector<std::string> &ids,
+	                                                   const std::vector<std::string> &sequences, size_t max_bytes);
+};
+
+} // namespace miint

--- a/src/include/blast_parser.hpp
+++ b/src/include/blast_parser.hpp
@@ -35,7 +35,8 @@ public:
 	static BlastStatus ParseStatusResponse(const std::string &text);
 	static std::vector<BlastHit> ParseTabularResults(const std::string &tabular);
 	static bool ValidateProgram(const std::string &program);
-	static std::string BuildFastaPayload(const std::vector<std::string> &ids, const std::vector<std::string> &sequences);
+	static std::string BuildFastaPayload(const std::vector<std::string> &ids,
+	                                     const std::vector<std::string> &sequences);
 	static std::string UrlEncode(const std::string &value);
 	static std::string BuildSubmitBody(const std::string &program, const std::string &database,
 	                                   const std::string &fasta_query, double evalue, int max_targets, bool megablast);

--- a/src/include/blast_search.hpp
+++ b/src/include/blast_search.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "blast_client.hpp"
+#include "blast_parser.hpp"
+#include "sequence_table_reader.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <mutex>
+
+namespace duckdb {
+
+class BlastSearchTableFunction {
+public:
+	static constexpr size_t DEFAULT_MAX_BATCH_BYTES = 4 * 1024 * 1024; // 4 MB
+
+	struct Data : public TableFunctionData {
+		std::string query_table;
+		std::string program = "blastn";
+		std::string database = "nt";
+		double evalue = 10.0;
+		int max_targets = 500;
+		bool megablast = true;
+		std::string api_key;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		std::unique_ptr<miint::BlastClient> client;
+		std::vector<miint::BlastHit> result_buffer;
+		idx_t result_offset = 0;
+
+		std::vector<miint::BlastParser::SequenceBatch> batches;
+		idx_t batch_cursor = 0;
+		mutex lock;
+
+		// Bind-time params copied for use in FetchNextBatch
+		std::string program;
+		std::string database;
+		double evalue;
+		int max_targets;
+		bool megablast;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+
+		bool FetchNextBatch(ClientContext &context);
+	};
+
+	struct LocalState : public LocalTableFunctionState {};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -26,6 +26,7 @@
 #include <read_ncbi_fasta.hpp>
 #include <read_ncbi.hpp>
 #include <read_ncbi_annotation.hpp>
+#include <blast_search.hpp>
 #include <read_ena.hpp>
 #include <read_ena_attributes.hpp>
 #include <read_ena_searchable_fields.hpp>
@@ -251,6 +252,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ReadNCBIFastaTableFunction::Register(loader);
 	ReadNCBITableFunction::Register(loader);
 	ReadNCBIAnnotationTableFunction::Register(loader);
+	BlastSearchTableFunction::Register(loader);
 	ReadENATableFunction::Register(loader);
 	ReadENAAttributesTableFunction::Register(loader);
 	ReadENASearchableFieldsTableFunction::Register(loader);

--- a/test/cpp/test_blast_parser.cpp
+++ b/test/cpp/test_blast_parser.cpp
@@ -1,0 +1,529 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include "blast_parser.hpp"
+
+using namespace miint;
+using Catch::Approx;
+
+// --- ParseSubmitResponse ---------------------------------------------------
+
+TEST_CASE("BlastParser submit response parsing", "[blast]") {
+	SECTION("Extract RID and RTOE from typical NCBI HTML") {
+		// NCBI BLAST returns HTML with QBlastInfo embedded in comments.
+		// Silent parse failure means the job ID is lost and we can never poll.
+		std::string html = R"(
+<!DOCTYPE html>
+<html><head><title>BLAST Search</title></head>
+<body>
+<!--QBlastInfoBegin
+    RID = ABC123XY
+    RTOE = 42
+QBlastInfoEnd-->
+<p>Request submitted.</p>
+</body></html>
+)";
+		auto result = BlastParser::ParseSubmitResponse(html);
+		CHECK(result.rid == "ABC123XY");
+		CHECK(result.rtoe == 42);
+		CHECK(result.error.empty());
+	}
+
+	SECTION("Missing RID returns empty rid") {
+		// If NCBI changes its format or returns garbage, we need to detect
+		// the missing RID rather than silently proceeding with an empty one.
+		std::string html = R"(
+<!--QBlastInfoBegin
+    RTOE = 10
+QBlastInfoEnd-->
+)";
+		auto result = BlastParser::ParseSubmitResponse(html);
+		CHECK(result.rid.empty());
+		CHECK(result.rtoe == 10);
+	}
+
+	SECTION("Missing RTOE defaults to 0") {
+		std::string html = R"(
+<!--QBlastInfoBegin
+    RID = XYZ789
+QBlastInfoEnd-->
+)";
+		auto result = BlastParser::ParseSubmitResponse(html);
+		CHECK(result.rid == "XYZ789");
+		CHECK(result.rtoe == 0);
+	}
+
+	SECTION("Error in response is captured with exact boundary") {
+		// NCBI returns errors inside a specific HTML pattern. If we miss
+		// the error, the user gets a cryptic "missing RID" instead of the
+		// actual problem (e.g., invalid database, bad query format).
+		std::string html = R"(
+<p class="error">Error: Failed to read the Blast query: Nucleotide FASTA provided for protein sequence</p>
+<!--QBlastInfoBegin
+    RID =
+    RTOE = 0
+QBlastInfoEnd-->
+)";
+		auto result = BlastParser::ParseSubmitResponse(html);
+		CHECK(result.error == "Error: Failed to read the Blast query: Nucleotide FASTA provided for protein sequence");
+	}
+
+	SECTION("Error tag with extra attributes before class") {
+		// The error tag may have other attributes; extraction must find
+		// the closing > of the tag, not an intermediate one.
+		std::string html = R"(
+<div id="content"><p id="err1" class="error">Invalid database name</p></div>
+<!--QBlastInfoBegin
+    RID =
+    RTOE = 0
+QBlastInfoEnd-->
+)";
+		auto result = BlastParser::ParseSubmitResponse(html);
+		CHECK(result.error == "Invalid database name");
+	}
+}
+
+// --- ParseStatusResponse ---------------------------------------------------
+
+TEST_CASE("BlastParser status response parsing", "[blast]") {
+	SECTION("WAITING status") {
+		std::string text = R"(
+QBlastInfoBegin
+	Status=WAITING
+QBlastInfoEnd
+)";
+		CHECK(BlastParser::ParseStatusResponse(text) == BlastStatus::WAITING);
+	}
+
+	SECTION("READY status") {
+		std::string text = R"(
+QBlastInfoBegin
+	Status=READY
+QBlastInfoEnd
+)";
+		CHECK(BlastParser::ParseStatusResponse(text) == BlastStatus::READY);
+	}
+
+	SECTION("UNKNOWN status") {
+		std::string text = R"(
+QBlastInfoBegin
+	Status=UNKNOWN
+QBlastInfoEnd
+)";
+		CHECK(BlastParser::ParseStatusResponse(text) == BlastStatus::UNKNOWN);
+	}
+
+	SECTION("Garbage input returns UNKNOWN") {
+		// Defensive: if NCBI changes format or returns an error page,
+		// we must not interpret it as READY (premature retrieval) or
+		// hang in WAITING forever.
+		CHECK(BlastParser::ParseStatusResponse("") == BlastStatus::UNKNOWN);
+		CHECK(BlastParser::ParseStatusResponse("some random text") == BlastStatus::UNKNOWN);
+	}
+
+	SECTION("Case-sensitive matching") {
+		// NCBI API always emits uppercase status values. Lowercase must
+		// not match — treating "waiting" as WAITING could mask a format change.
+		CHECK(BlastParser::ParseStatusResponse("Status=waiting") == BlastStatus::UNKNOWN);
+		CHECK(BlastParser::ParseStatusResponse("Status=Ready") == BlastStatus::UNKNOWN);
+	}
+
+	SECTION("Status key present with empty value") {
+		CHECK(BlastParser::ParseStatusResponse("Status=") == BlastStatus::UNKNOWN);
+	}
+}
+
+// --- ParseTabularResults ---------------------------------------------------
+
+TEST_CASE("BlastParser tabular results parsing", "[blast]") {
+	SECTION("Standard multi-hit output") {
+		// outfmt 6: qseqid sseqid pident length mismatch gapopen
+		//           qstart qend sstart send evalue bitscore
+		// Each field must map to the correct struct member — column
+		// misalignment silently corrupts downstream analysis.
+		std::string tabular =
+		    "query1\tNC_001416.1\t99.5\t200\t1\t0\t1\t200\t1000\t1199\t1.5e-10\t350.2\n"
+		    "query1\tNC_001422.1\t85.3\t150\t22\t1\t10\t159\t500\t649\t0.001\t120.0\n"
+		    "query2\tNC_001416.1\t97.0\t100\t3\t0\t1\t100\t2000\t2099\t5e-50\t500.0\n";
+
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 3);
+
+		CHECK(hits[0].query_id == "query1");
+		CHECK(hits[0].subject_id == "NC_001416.1");
+		CHECK(hits[0].pct_identity == Approx(99.5));
+		CHECK(hits[0].alignment_length == 200);
+		CHECK(hits[0].mismatches == 1);
+		CHECK(hits[0].gap_opens == 0);
+		CHECK(hits[0].query_start == 1);
+		CHECK(hits[0].query_end == 200);
+		CHECK(hits[0].subject_start == 1000);
+		CHECK(hits[0].subject_end == 1199);
+		CHECK(hits[0].evalue == Approx(1.5e-10));
+		CHECK(hits[0].bit_score == Approx(350.2));
+
+		CHECK(hits[1].query_id == "query1");
+		CHECK(hits[1].subject_id == "NC_001422.1");
+		CHECK(hits[1].pct_identity == Approx(85.3));
+
+		CHECK(hits[2].query_id == "query2");
+		CHECK(hits[2].evalue == Approx(5e-50));
+	}
+
+	SECTION("Empty input returns empty vector") {
+		auto hits = BlastParser::ParseTabularResults("");
+		CHECK(hits.empty());
+	}
+
+	SECTION("Comment lines are skipped") {
+		// BLAST tabular output may include comment headers starting with #.
+		// These must not be parsed as data rows.
+		std::string tabular =
+		    "# BLASTN 2.14.0+\n"
+		    "# Query: query1\n"
+		    "# Database: nt\n"
+		    "# 1 hits found\n"
+		    "query1\tNC_001416.1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 1);
+		CHECK(hits[0].query_id == "query1");
+	}
+
+	SECTION("Trailing newline does not produce extra record") {
+		std::string tabular =
+		    "query1\tNC_001416.1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		CHECK(hits.size() == 1);
+	}
+
+	SECTION("Multiple hits for same query") {
+		std::string tabular =
+		    "seq1\thitA\t95.0\t50\t2\t1\t1\t50\t1\t50\t1e-5\t100.0\n"
+		    "seq1\thitB\t90.0\t50\t5\t0\t1\t50\t100\t149\t1e-3\t80.0\n"
+		    "seq1\thitC\t80.0\t40\t8\t0\t5\t44\t200\t239\t0.5\t50.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 3);
+		CHECK(hits[0].subject_id == "hitA");
+		CHECK(hits[1].subject_id == "hitB");
+		CHECK(hits[2].subject_id == "hitC");
+	}
+
+	SECTION("Scientific notation evalue with positive exponent") {
+		std::string tabular =
+		    "q1\ts1\t50.0\t30\t15\t0\t1\t30\t1\t30\t2.5e+02\t20.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 1);
+		CHECK(hits[0].evalue == Approx(250.0));
+	}
+
+	SECTION("Evalue of zero") {
+		// Extremely significant hits emit evalue=0 (not 1e-300).
+		// Must parse as 0.0, not error.
+		std::string tabular =
+		    "q1\ts1\t100.0\t500\t0\t0\t1\t500\t1\t500\t0\t1000.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 1);
+		CHECK(hits[0].evalue == 0.0);
+	}
+
+	SECTION("Windows line endings (CRLF)") {
+		// NCBI web API can return \r\n; trailing \r must not corrupt
+		// the last field (bitscore) and cause a parse failure.
+		std::string tabular =
+		    "q1\ts1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\r\n"
+		    "q2\ts2\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\t150.0\r\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 2);
+		CHECK(hits[0].bit_score == Approx(200.0));
+		CHECK(hits[1].bit_score == Approx(150.0));
+	}
+
+	SECTION("Extra fields beyond 12 are accepted") {
+		// NCBI BLAST API returns extra columns for some programs (e.g.,
+		// blastp adds "% positives" as field 13). We use the first 12
+		// and ignore the rest — dropping these rows would silently lose
+		// all blastp results.
+		std::string tabular =
+		    "q1\ts1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\t95.0\n"
+		    "q2\ts2\t90.0\t60\t6\t0\t1\t60\t1\t60\t1e-10\t100.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 2);
+		CHECK(hits[0].query_id == "q1");
+		CHECK(hits[0].bit_score == Approx(200.0));
+		CHECK(hits[1].query_id == "q2");
+	}
+
+	SECTION("Lines with fewer than 12 fields are skipped") {
+		std::string tabular =
+		    "q1\ts1\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\n"
+		    "q2\ts2\t90.0\t60\t6\t0\t1\t60\t1\t60\t1e-10\t100.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 1);
+		CHECK(hits[0].query_id == "q2");
+	}
+
+	SECTION("Malformed numeric field does not crash") {
+		// A corrupted line must be skipped, not crash the caller
+		// with an unhandled std::invalid_argument from stod/stoi.
+		std::string tabular =
+		    "q1\ts1\tNOTANUMBER\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n"
+		    "q2\ts2\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\t150.0\n";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 1);
+		CHECK(hits[0].query_id == "q2");
+	}
+}
+
+// --- ValidateProgram -------------------------------------------------------
+
+TEST_CASE("BlastParser program validation", "[blast]") {
+	SECTION("Valid programs are accepted") {
+		CHECK(BlastParser::ValidateProgram("blastn") == true);
+		CHECK(BlastParser::ValidateProgram("blastp") == true);
+		CHECK(BlastParser::ValidateProgram("blastx") == true);
+		CHECK(BlastParser::ValidateProgram("tblastn") == true);
+		CHECK(BlastParser::ValidateProgram("tblastx") == true);
+	}
+
+	SECTION("Invalid programs are rejected") {
+		// "megablast" is a mode flag, not a program name.
+		// Case-sensitive: NCBI API is case-sensitive for program names.
+		CHECK(BlastParser::ValidateProgram("megablast") == false);
+		CHECK(BlastParser::ValidateProgram("BLASTN") == false);
+		CHECK(BlastParser::ValidateProgram("") == false);
+		CHECK(BlastParser::ValidateProgram("blast") == false);
+		CHECK(BlastParser::ValidateProgram("psiblast") == false);
+	}
+}
+
+// --- BuildFastaPayload -----------------------------------------------------
+
+TEST_CASE("BlastParser FASTA payload construction", "[blast]") {
+	SECTION("Single sequence") {
+		auto fasta = BlastParser::BuildFastaPayload({"seq1"}, {"ACGTACGT"});
+		CHECK(fasta == ">seq1\nACGTACGT\n");
+	}
+
+	SECTION("Multiple sequences") {
+		auto fasta = BlastParser::BuildFastaPayload(
+		    {"seq1", "seq2", "seq3"},
+		    {"ACGT", "TGCA", "AAAA"});
+		CHECK(fasta == ">seq1\nACGT\n>seq2\nTGCA\n>seq3\nAAAA\n");
+	}
+
+	SECTION("Empty input") {
+		auto fasta = BlastParser::BuildFastaPayload({}, {});
+		CHECK(fasta.empty());
+	}
+
+	SECTION("Mismatched ids and sequences throws") {
+		// Caller bug — ids/sequences must be parallel arrays. Out-of-bounds
+		// access is UB; we throw instead.
+		CHECK_THROWS(BlastParser::BuildFastaPayload({"a", "b"}, {"ACGT"}));
+		CHECK_THROWS(BlastParser::BuildFastaPayload({"a"}, {"ACGT", "TGCA"}));
+	}
+}
+
+// --- BuildSubmitBody -------------------------------------------------------
+
+TEST_CASE("BlastParser submit body construction", "[blast]") {
+	SECTION("Standard blastn with megablast") {
+		// The POST body is application/x-www-form-urlencoded. Each parameter
+		// must be present and correctly formatted — a missing CMD=Put means
+		// NCBI interprets the request as a status check, not a submission.
+		auto body = BlastParser::BuildSubmitBody(
+		    "blastn", "nt", ">q1\nACGT\n", 10.0, 500, true);
+		CHECK(body.find("CMD=Put") != std::string::npos);
+		CHECK(body.find("PROGRAM=blastn") != std::string::npos);
+		CHECK(body.find("DATABASE=nt") != std::string::npos);
+		CHECK(body.find("EXPECT=10") != std::string::npos);
+		CHECK(body.find("HITLIST_SIZE=500") != std::string::npos);
+		CHECK(body.find("MEGABLAST=on") != std::string::npos);
+		CHECK(body.find("QUERY=") != std::string::npos);
+		CHECK(body.find("%3Eq1") != std::string::npos);
+	}
+
+	SECTION("blastp without megablast") {
+		// MEGABLAST param must be absent for non-blastn programs —
+		// NCBI ignores it but including it is misleading and may
+		// cause validation errors in the future.
+		auto body = BlastParser::BuildSubmitBody(
+		    "blastp", "nr", ">q1\nMKWV\n", 0.001, 10, false);
+		CHECK(body.find("PROGRAM=blastp") != std::string::npos);
+		CHECK(body.find("DATABASE=nr") != std::string::npos);
+		CHECK(body.find("EXPECT=0.001") != std::string::npos);
+		CHECK(body.find("HITLIST_SIZE=10") != std::string::npos);
+		CHECK(body.find("MEGABLAST") == std::string::npos);
+	}
+
+	SECTION("Small evalue formatting") {
+		// Scientific notation in the EXPECT param must be parseable by NCBI.
+		auto body = BlastParser::BuildSubmitBody(
+		    "blastn", "nt", ">q1\nACGT\n", 1e-50, 100, false);
+		CHECK(body.find("EXPECT=") != std::string::npos);
+		// Must not be "EXPECT=0" (which std::to_string would produce for tiny doubles)
+		CHECK(body.find("EXPECT=0&") == std::string::npos);
+	}
+
+	SECTION("Newlines in FASTA query are preserved") {
+		// The FASTA payload contains newlines. In application/x-www-form-urlencoded,
+		// newlines should be URL-encoded as %0A (or left raw and handled by the
+		// server). We encode them so the body is valid.
+		auto body = BlastParser::BuildSubmitBody(
+		    "blastn", "nt", ">q1\nACGT\n", 10.0, 500, false);
+		// The QUERY value must contain the FASTA content
+		auto query_pos = body.find("QUERY=");
+		REQUIRE(query_pos != std::string::npos);
+		auto query_value = body.substr(query_pos + 6);
+		auto amp_pos = query_value.find('&');
+		if (amp_pos != std::string::npos) {
+			query_value = query_value.substr(0, amp_pos);
+		}
+		// Newlines should be URL-encoded
+		CHECK(query_value.find("%0A") != std::string::npos);
+		CHECK(query_value.find("%3Eq1") != std::string::npos);
+	}
+}
+
+// --- SplitIntoBatches ------------------------------------------------------
+
+TEST_CASE("BlastParser batch splitting", "[blast]") {
+	SECTION("All sequences fit in one batch") {
+		// Small sequences well under the limit should produce exactly one batch.
+		auto batches = BlastParser::SplitIntoBatches(
+		    {"s1", "s2", "s3"},
+		    {"ACGT", "TGCA", "AAAA"},
+		    1000000);
+		REQUIRE(batches.size() == 1);
+		CHECK(batches[0].ids.size() == 3);
+		CHECK(batches[0].sequences.size() == 3);
+		CHECK(batches[0].ids[0] == "s1");
+		CHECK(batches[0].sequences[2] == "AAAA");
+	}
+
+	SECTION("Sequences split across two batches") {
+		// Each FASTA record is ">id\nSEQ\n" = id.size() + seq.size() + 3 bytes.
+		// With max_bytes=30, two 10-byte sequences fit but three don't.
+		// ">s1\nACGTACGTAC\n" = 16 bytes, ">s2\nTGCATGCATG\n" = 16 bytes
+		// 16+16 = 32 > 30, so they split into separate batches.
+		auto batches = BlastParser::SplitIntoBatches(
+		    {"s1", "s2"},
+		    {"ACGTACGTAC", "TGCATGCATG"},
+		    20);
+		REQUIRE(batches.size() == 2);
+		CHECK(batches[0].ids.size() == 1);
+		CHECK(batches[0].ids[0] == "s1");
+		CHECK(batches[1].ids.size() == 1);
+		CHECK(batches[1].ids[0] == "s2");
+	}
+
+	SECTION("Single oversized sequence goes in its own batch") {
+		// A sequence larger than max_bytes must not be dropped — it gets
+		// its own batch even though it exceeds the limit. Dropping data
+		// silently is unacceptable.
+		auto batches = BlastParser::SplitIntoBatches(
+		    {"big", "small"},
+		    {std::string(5000, 'A'), "ACGT"},
+		    1000);
+		REQUIRE(batches.size() == 2);
+		CHECK(batches[0].ids[0] == "big");
+		CHECK(batches[0].ids.size() == 1);
+		CHECK(batches[1].ids[0] == "small");
+	}
+
+	SECTION("Empty input returns empty batch list") {
+		auto batches = BlastParser::SplitIntoBatches({}, {}, 1000);
+		CHECK(batches.empty());
+	}
+
+	SECTION("Multiple small sequences pack into one batch") {
+		// Verify greedy packing: 100 tiny sequences should fit in one batch
+		// when the limit is generous.
+		std::vector<std::string> ids, seqs;
+		for (int i = 0; i < 100; i++) {
+			ids.push_back("s" + std::to_string(i));
+			seqs.push_back("ACGT");
+		}
+		auto batches = BlastParser::SplitIntoBatches(ids, seqs, 100000);
+		CHECK(batches.size() == 1);
+		CHECK(batches[0].ids.size() == 100);
+	}
+}
+
+// --- Edge cases: realistic NCBI response parsing ----------------------------
+
+TEST_CASE("BlastParser edge cases", "[blast]") {
+	SECTION("Submit response with multi-attribute error tag") {
+		// NCBI error pages can have complex HTML. The parser must extract
+		// content from the class="error" element regardless of surrounding
+		// attributes or tag nesting.
+		std::string html = R"(
+<html><body>
+<div class="content">
+<ul><li><p class="error">Error: Query is Empty</p></li></ul>
+</div>
+<!--QBlastInfoBegin
+    RID =
+    RTOE = 0
+QBlastInfoEnd-->
+</body></html>
+)";
+		auto result = BlastParser::ParseSubmitResponse(html);
+		CHECK(result.error == "Error: Query is Empty");
+		CHECK(result.rid.empty());
+	}
+
+	SECTION("Tabular output with only comment headers (no hits)") {
+		// A valid BLAST run that finds zero hits emits only comment lines.
+		// Must return empty vector, not error.
+		std::string tabular = R"(<p><!--
+QBlastInfoBegin
+	Status=READY
+QBlastInfoEnd
+--><p>
+<PRE>
+# blastn
+# Iteration: 0
+# Query: random_junk
+# RID: ABCDEF123
+# Database: core_nt
+# 0 hits found
+</PRE>
+)";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		CHECK(hits.empty());
+	}
+
+	SECTION("Tabular output wrapped in HTML PRE tags") {
+		// Real NCBI BLAST responses wrap tabular data in <p>, HTML comments,
+		// and <PRE> tags. The parser must handle this without choking.
+		std::string tabular = R"(<p><!--
+QBlastInfoBegin
+	Status=READY
+QBlastInfoEnd
+--><p>
+<PRE>
+# blastn
+# Query: q1
+# Fields: query acc.ver, subject acc.ver, % identity, alignment length, mismatches, gap opens, q. start, q. end, s. start, s. end, evalue, bit score
+# 1 hits found
+q1	NC_001416.1	100.000	100	0	0	1	100	1000	1099	1e-40	185
+</PRE>
+)";
+		auto hits = BlastParser::ParseTabularResults(tabular);
+		REQUIRE(hits.size() == 1);
+		CHECK(hits[0].query_id == "q1");
+		CHECK(hits[0].pct_identity == Approx(100.0));
+	}
+
+	SECTION("UrlEncode RFC 3986 compliance") {
+		// Only unreserved characters pass through. Everything else is
+		// percent-encoded. This matters for FASTA headers with pipe
+		// delimiters and query parameters with special characters.
+		CHECK(BlastParser::UrlEncode("abc123") == "abc123");
+		CHECK(BlastParser::UrlEncode("a b") == "a%20b");
+		CHECK(BlastParser::UrlEncode(">seq|1") == "%3Eseq%7C1");
+		CHECK(BlastParser::UrlEncode("\n") == "%0A");
+		CHECK(BlastParser::UrlEncode("a=b&c") == "a%3Db%26c");
+		CHECK(BlastParser::UrlEncode("") == "");
+	}
+}

--- a/test/cpp/test_blast_parser.cpp
+++ b/test/cpp/test_blast_parser.cpp
@@ -140,10 +140,9 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 		//           qstart qend sstart send evalue bitscore
 		// Each field must map to the correct struct member — column
 		// misalignment silently corrupts downstream analysis.
-		std::string tabular =
-		    "query1\tNC_001416.1\t99.5\t200\t1\t0\t1\t200\t1000\t1199\t1.5e-10\t350.2\n"
-		    "query1\tNC_001422.1\t85.3\t150\t22\t1\t10\t159\t500\t649\t0.001\t120.0\n"
-		    "query2\tNC_001416.1\t97.0\t100\t3\t0\t1\t100\t2000\t2099\t5e-50\t500.0\n";
+		std::string tabular = "query1\tNC_001416.1\t99.5\t200\t1\t0\t1\t200\t1000\t1199\t1.5e-10\t350.2\n"
+		                      "query1\tNC_001422.1\t85.3\t150\t22\t1\t10\t159\t500\t649\t0.001\t120.0\n"
+		                      "query2\tNC_001416.1\t97.0\t100\t3\t0\t1\t100\t2000\t2099\t5e-50\t500.0\n";
 
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 3);
@@ -177,29 +176,26 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 	SECTION("Comment lines are skipped") {
 		// BLAST tabular output may include comment headers starting with #.
 		// These must not be parsed as data rows.
-		std::string tabular =
-		    "# BLASTN 2.14.0+\n"
-		    "# Query: query1\n"
-		    "# Database: nt\n"
-		    "# 1 hits found\n"
-		    "query1\tNC_001416.1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n";
+		std::string tabular = "# BLASTN 2.14.0+\n"
+		                      "# Query: query1\n"
+		                      "# Database: nt\n"
+		                      "# 1 hits found\n"
+		                      "query1\tNC_001416.1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 1);
 		CHECK(hits[0].query_id == "query1");
 	}
 
 	SECTION("Trailing newline does not produce extra record") {
-		std::string tabular =
-		    "query1\tNC_001416.1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n";
+		std::string tabular = "query1\tNC_001416.1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		CHECK(hits.size() == 1);
 	}
 
 	SECTION("Multiple hits for same query") {
-		std::string tabular =
-		    "seq1\thitA\t95.0\t50\t2\t1\t1\t50\t1\t50\t1e-5\t100.0\n"
-		    "seq1\thitB\t90.0\t50\t5\t0\t1\t50\t100\t149\t1e-3\t80.0\n"
-		    "seq1\thitC\t80.0\t40\t8\t0\t5\t44\t200\t239\t0.5\t50.0\n";
+		std::string tabular = "seq1\thitA\t95.0\t50\t2\t1\t1\t50\t1\t50\t1e-5\t100.0\n"
+		                      "seq1\thitB\t90.0\t50\t5\t0\t1\t50\t100\t149\t1e-3\t80.0\n"
+		                      "seq1\thitC\t80.0\t40\t8\t0\t5\t44\t200\t239\t0.5\t50.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 3);
 		CHECK(hits[0].subject_id == "hitA");
@@ -208,8 +204,7 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 	}
 
 	SECTION("Scientific notation evalue with positive exponent") {
-		std::string tabular =
-		    "q1\ts1\t50.0\t30\t15\t0\t1\t30\t1\t30\t2.5e+02\t20.0\n";
+		std::string tabular = "q1\ts1\t50.0\t30\t15\t0\t1\t30\t1\t30\t2.5e+02\t20.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 1);
 		CHECK(hits[0].evalue == Approx(250.0));
@@ -218,8 +213,7 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 	SECTION("Evalue of zero") {
 		// Extremely significant hits emit evalue=0 (not 1e-300).
 		// Must parse as 0.0, not error.
-		std::string tabular =
-		    "q1\ts1\t100.0\t500\t0\t0\t1\t500\t1\t500\t0\t1000.0\n";
+		std::string tabular = "q1\ts1\t100.0\t500\t0\t0\t1\t500\t1\t500\t0\t1000.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 1);
 		CHECK(hits[0].evalue == 0.0);
@@ -228,9 +222,8 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 	SECTION("Windows line endings (CRLF)") {
 		// NCBI web API can return \r\n; trailing \r must not corrupt
 		// the last field (bitscore) and cause a parse failure.
-		std::string tabular =
-		    "q1\ts1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\r\n"
-		    "q2\ts2\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\t150.0\r\n";
+		std::string tabular = "q1\ts1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\r\n"
+		                      "q2\ts2\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\t150.0\r\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 2);
 		CHECK(hits[0].bit_score == Approx(200.0));
@@ -242,9 +235,8 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 		// blastp adds "% positives" as field 13). We use the first 12
 		// and ignore the rest — dropping these rows would silently lose
 		// all blastp results.
-		std::string tabular =
-		    "q1\ts1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\t95.0\n"
-		    "q2\ts2\t90.0\t60\t6\t0\t1\t60\t1\t60\t1e-10\t100.0\n";
+		std::string tabular = "q1\ts1\t99.0\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\t95.0\n"
+		                      "q2\ts2\t90.0\t60\t6\t0\t1\t60\t1\t60\t1e-10\t100.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 2);
 		CHECK(hits[0].query_id == "q1");
@@ -253,9 +245,8 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 	}
 
 	SECTION("Lines with fewer than 12 fields are skipped") {
-		std::string tabular =
-		    "q1\ts1\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\n"
-		    "q2\ts2\t90.0\t60\t6\t0\t1\t60\t1\t60\t1e-10\t100.0\n";
+		std::string tabular = "q1\ts1\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\n"
+		                      "q2\ts2\t90.0\t60\t6\t0\t1\t60\t1\t60\t1e-10\t100.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 1);
 		CHECK(hits[0].query_id == "q2");
@@ -264,9 +255,8 @@ TEST_CASE("BlastParser tabular results parsing", "[blast]") {
 	SECTION("Malformed numeric field does not crash") {
 		// A corrupted line must be skipped, not crash the caller
 		// with an unhandled std::invalid_argument from stod/stoi.
-		std::string tabular =
-		    "q1\ts1\tNOTANUMBER\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n"
-		    "q2\ts2\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\t150.0\n";
+		std::string tabular = "q1\ts1\tNOTANUMBER\t100\t1\t0\t1\t100\t1\t100\t1e-40\t200.0\n"
+		                      "q2\ts2\t95.0\t80\t4\t0\t1\t80\t1\t80\t1e-20\t150.0\n";
 		auto hits = BlastParser::ParseTabularResults(tabular);
 		REQUIRE(hits.size() == 1);
 		CHECK(hits[0].query_id == "q2");
@@ -304,9 +294,7 @@ TEST_CASE("BlastParser FASTA payload construction", "[blast]") {
 	}
 
 	SECTION("Multiple sequences") {
-		auto fasta = BlastParser::BuildFastaPayload(
-		    {"seq1", "seq2", "seq3"},
-		    {"ACGT", "TGCA", "AAAA"});
+		auto fasta = BlastParser::BuildFastaPayload({"seq1", "seq2", "seq3"}, {"ACGT", "TGCA", "AAAA"});
 		CHECK(fasta == ">seq1\nACGT\n>seq2\nTGCA\n>seq3\nAAAA\n");
 	}
 
@@ -330,8 +318,7 @@ TEST_CASE("BlastParser submit body construction", "[blast]") {
 		// The POST body is application/x-www-form-urlencoded. Each parameter
 		// must be present and correctly formatted — a missing CMD=Put means
 		// NCBI interprets the request as a status check, not a submission.
-		auto body = BlastParser::BuildSubmitBody(
-		    "blastn", "nt", ">q1\nACGT\n", 10.0, 500, true);
+		auto body = BlastParser::BuildSubmitBody("blastn", "nt", ">q1\nACGT\n", 10.0, 500, true);
 		CHECK(body.find("CMD=Put") != std::string::npos);
 		CHECK(body.find("PROGRAM=blastn") != std::string::npos);
 		CHECK(body.find("DATABASE=nt") != std::string::npos);
@@ -346,8 +333,7 @@ TEST_CASE("BlastParser submit body construction", "[blast]") {
 		// MEGABLAST param must be absent for non-blastn programs —
 		// NCBI ignores it but including it is misleading and may
 		// cause validation errors in the future.
-		auto body = BlastParser::BuildSubmitBody(
-		    "blastp", "nr", ">q1\nMKWV\n", 0.001, 10, false);
+		auto body = BlastParser::BuildSubmitBody("blastp", "nr", ">q1\nMKWV\n", 0.001, 10, false);
 		CHECK(body.find("PROGRAM=blastp") != std::string::npos);
 		CHECK(body.find("DATABASE=nr") != std::string::npos);
 		CHECK(body.find("EXPECT=0.001") != std::string::npos);
@@ -357,8 +343,7 @@ TEST_CASE("BlastParser submit body construction", "[blast]") {
 
 	SECTION("Small evalue formatting") {
 		// Scientific notation in the EXPECT param must be parseable by NCBI.
-		auto body = BlastParser::BuildSubmitBody(
-		    "blastn", "nt", ">q1\nACGT\n", 1e-50, 100, false);
+		auto body = BlastParser::BuildSubmitBody("blastn", "nt", ">q1\nACGT\n", 1e-50, 100, false);
 		CHECK(body.find("EXPECT=") != std::string::npos);
 		// Must not be "EXPECT=0" (which std::to_string would produce for tiny doubles)
 		CHECK(body.find("EXPECT=0&") == std::string::npos);
@@ -368,8 +353,7 @@ TEST_CASE("BlastParser submit body construction", "[blast]") {
 		// The FASTA payload contains newlines. In application/x-www-form-urlencoded,
 		// newlines should be URL-encoded as %0A (or left raw and handled by the
 		// server). We encode them so the body is valid.
-		auto body = BlastParser::BuildSubmitBody(
-		    "blastn", "nt", ">q1\nACGT\n", 10.0, 500, false);
+		auto body = BlastParser::BuildSubmitBody("blastn", "nt", ">q1\nACGT\n", 10.0, 500, false);
 		// The QUERY value must contain the FASTA content
 		auto query_pos = body.find("QUERY=");
 		REQUIRE(query_pos != std::string::npos);
@@ -389,10 +373,7 @@ TEST_CASE("BlastParser submit body construction", "[blast]") {
 TEST_CASE("BlastParser batch splitting", "[blast]") {
 	SECTION("All sequences fit in one batch") {
 		// Small sequences well under the limit should produce exactly one batch.
-		auto batches = BlastParser::SplitIntoBatches(
-		    {"s1", "s2", "s3"},
-		    {"ACGT", "TGCA", "AAAA"},
-		    1000000);
+		auto batches = BlastParser::SplitIntoBatches({"s1", "s2", "s3"}, {"ACGT", "TGCA", "AAAA"}, 1000000);
 		REQUIRE(batches.size() == 1);
 		CHECK(batches[0].ids.size() == 3);
 		CHECK(batches[0].sequences.size() == 3);
@@ -405,10 +386,7 @@ TEST_CASE("BlastParser batch splitting", "[blast]") {
 		// With max_bytes=30, two 10-byte sequences fit but three don't.
 		// ">s1\nACGTACGTAC\n" = 16 bytes, ">s2\nTGCATGCATG\n" = 16 bytes
 		// 16+16 = 32 > 30, so they split into separate batches.
-		auto batches = BlastParser::SplitIntoBatches(
-		    {"s1", "s2"},
-		    {"ACGTACGTAC", "TGCATGCATG"},
-		    20);
+		auto batches = BlastParser::SplitIntoBatches({"s1", "s2"}, {"ACGTACGTAC", "TGCATGCATG"}, 20);
 		REQUIRE(batches.size() == 2);
 		CHECK(batches[0].ids.size() == 1);
 		CHECK(batches[0].ids[0] == "s1");
@@ -420,10 +398,7 @@ TEST_CASE("BlastParser batch splitting", "[blast]") {
 		// A sequence larger than max_bytes must not be dropped — it gets
 		// its own batch even though it exceeds the limit. Dropping data
 		// silently is unacceptable.
-		auto batches = BlastParser::SplitIntoBatches(
-		    {"big", "small"},
-		    {std::string(5000, 'A'), "ACGT"},
-		    1000);
+		auto batches = BlastParser::SplitIntoBatches({"big", "small"}, {std::string(5000, 'A'), "ACGT"}, 1000);
 		REQUIRE(batches.size() == 2);
 		CHECK(batches[0].ids[0] == "big");
 		CHECK(batches[0].ids.size() == 1);

--- a/test/sql/blast.test
+++ b/test/sql/blast.test
@@ -1,0 +1,143 @@
+# name: test/sql/blast.test
+# description: Test blast table function
+# group: [sql]
+
+require miint
+
+# --- Bind-time validation (no network needed) ---
+
+# TEMP tables work for bind-time validation (DESCRIBE, error checks) because
+# Bind uses the caller's context. They do NOT work for actual blast() queries
+# because InitGlobal's LoadSingleEndSequences uses a separate connection that
+# cannot see session TEMP objects. Live tests in blast_live.test use persistent tables.
+statement ok
+CREATE TEMP TABLE test_seqs (read_id VARCHAR, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO test_seqs VALUES ('seq1', 'ACGTACGTACGTACGTACGT');
+
+# Test error: NULL table name
+statement error
+SELECT * FROM blast(NULL);
+----
+table name cannot be NULL
+
+# Test error: empty table name
+statement error
+SELECT * FROM blast('');
+----
+table name cannot be empty
+
+# Test error: invalid program name
+statement error
+SELECT * FROM blast('test_seqs', program := 'megablast');
+----
+Invalid BLAST program
+
+# Test error: negative evalue
+statement error
+SELECT * FROM blast('test_seqs', evalue := -1.0);
+----
+evalue must be positive
+
+# Test error: zero evalue
+statement error
+SELECT * FROM blast('test_seqs', evalue := 0.0);
+----
+evalue must be positive
+
+# Test error: megablast with non-blastn program
+statement error
+SELECT * FROM blast('test_seqs', program := 'blastp', megablast := true);
+----
+megablast is only valid with program='blastn'
+
+# Test error: max_targets <= 0
+statement error
+SELECT * FROM blast('test_seqs', max_targets := 0);
+----
+max_targets must be positive
+
+# Test error: non-existent table
+statement error
+SELECT * FROM blast('no_such_table_xyz');
+----
+no_such_table_xyz
+
+# Test error: table missing sequence1 column
+statement ok
+CREATE TEMP TABLE bad_schema (read_id VARCHAR, some_col INTEGER);
+
+statement error
+SELECT * FROM blast('bad_schema');
+----
+sequence1
+
+# Test output schema (12 columns matching outfmt 6)
+query IIIIII
+DESCRIBE SELECT * FROM blast('test_seqs');
+----
+query_id	VARCHAR	YES	NULL	NULL	NULL
+subject_id	VARCHAR	YES	NULL	NULL	NULL
+pct_identity	DOUBLE	YES	NULL	NULL	NULL
+alignment_length	INTEGER	YES	NULL	NULL	NULL
+mismatches	INTEGER	YES	NULL	NULL	NULL
+gap_opens	INTEGER	YES	NULL	NULL	NULL
+query_start	BIGINT	YES	NULL	NULL	NULL
+query_end	BIGINT	YES	NULL	NULL	NULL
+subject_start	BIGINT	YES	NULL	NULL	NULL
+subject_end	BIGINT	YES	NULL	NULL	NULL
+evalue	DOUBLE	YES	NULL	NULL	NULL
+bit_score	DOUBLE	YES	NULL	NULL	NULL
+
+# --- Edge case: default parameters ---
+
+# Default program is blastn, database is nt — should bind without errors
+query IIIIII
+DESCRIBE SELECT * FROM blast('test_seqs');
+----
+query_id	VARCHAR	YES	NULL	NULL	NULL
+subject_id	VARCHAR	YES	NULL	NULL	NULL
+pct_identity	DOUBLE	YES	NULL	NULL	NULL
+alignment_length	INTEGER	YES	NULL	NULL	NULL
+mismatches	INTEGER	YES	NULL	NULL	NULL
+gap_opens	INTEGER	YES	NULL	NULL	NULL
+query_start	BIGINT	YES	NULL	NULL	NULL
+query_end	BIGINT	YES	NULL	NULL	NULL
+subject_start	BIGINT	YES	NULL	NULL	NULL
+subject_end	BIGINT	YES	NULL	NULL	NULL
+evalue	DOUBLE	YES	NULL	NULL	NULL
+bit_score	DOUBLE	YES	NULL	NULL	NULL
+
+# All valid programs bind successfully (megablast=false for non-blastn)
+query IIIIII
+DESCRIBE SELECT * FROM blast('test_seqs', program := 'blastp', megablast := false);
+----
+query_id	VARCHAR	YES	NULL	NULL	NULL
+subject_id	VARCHAR	YES	NULL	NULL	NULL
+pct_identity	DOUBLE	YES	NULL	NULL	NULL
+alignment_length	INTEGER	YES	NULL	NULL	NULL
+mismatches	INTEGER	YES	NULL	NULL	NULL
+gap_opens	INTEGER	YES	NULL	NULL	NULL
+query_start	BIGINT	YES	NULL	NULL	NULL
+query_end	BIGINT	YES	NULL	NULL	NULL
+subject_start	BIGINT	YES	NULL	NULL	NULL
+subject_end	BIGINT	YES	NULL	NULL	NULL
+evalue	DOUBLE	YES	NULL	NULL	NULL
+bit_score	DOUBLE	YES	NULL	NULL	NULL
+
+query IIIIII
+DESCRIBE SELECT * FROM blast('test_seqs', program := 'tblastx', megablast := false);
+----
+query_id	VARCHAR	YES	NULL	NULL	NULL
+subject_id	VARCHAR	YES	NULL	NULL	NULL
+pct_identity	DOUBLE	YES	NULL	NULL	NULL
+alignment_length	INTEGER	YES	NULL	NULL	NULL
+mismatches	INTEGER	YES	NULL	NULL	NULL
+gap_opens	INTEGER	YES	NULL	NULL	NULL
+query_start	BIGINT	YES	NULL	NULL	NULL
+query_end	BIGINT	YES	NULL	NULL	NULL
+subject_start	BIGINT	YES	NULL	NULL	NULL
+subject_end	BIGINT	YES	NULL	NULL	NULL
+evalue	DOUBLE	YES	NULL	NULL	NULL
+bit_score	DOUBLE	YES	NULL	NULL	NULL

--- a/test/sql/blast_live.test
+++ b/test/sql/blast_live.test
@@ -1,0 +1,112 @@
+# name: test/sql/blast_live.test
+# description: Live integration tests for blast table function (requires network)
+# group: [sql]
+
+# These tests make real HTTP requests to NCBI BLAST. Each test submission
+# takes 30-120 seconds. Tables are persistent (not TEMP) because
+# LoadSingleEndSequences uses a separate connection that cannot see TEMP objects.
+
+require httpfs
+
+require miint
+
+require-env BLAST_LIVE_AVAILABLE
+
+# --- Setup: create query tables once, reuse across tests ---
+
+# Lambda phage 100bp fragment — should match near-perfectly in nt
+statement ok
+CREATE TABLE blast_nuc_queries AS SELECT * FROM (VALUES
+    ('lambda_100bp', 'GGGCGGCGACCTCGCGGGTTTTCGCTATTTATGAAAATTTTCCGGTTTAAGGCGTTTCCGTTCTTCTTCGTCATAACTTAATGTTTTTATTTAAAATACCT')
+) AS t(read_id, sequence1);
+
+# Fetch blastn results once, reuse for multiple assertions
+statement ok
+CREATE TABLE blast_nuc_results AS
+SELECT * FROM blast('blast_nuc_queries', program := 'blastn', database := 'nt', max_targets := 5, megablast := true);
+
+# --- blastn tests ---
+
+# At least one hit returned
+query I
+SELECT COUNT(*) > 0 FROM blast_nuc_results;
+----
+true
+
+# Query ID matches input read_id
+query I
+SELECT COUNT(DISTINCT query_id) FROM blast_nuc_results;
+----
+1
+
+query I
+SELECT query_id FROM blast_nuc_results LIMIT 1;
+----
+lambda_100bp
+
+# High identity expected for a perfect Lambda phage match
+query I
+SELECT MAX(pct_identity) >= 99.0 FROM blast_nuc_results;
+----
+true
+
+# Low evalue expected for significant match
+query I
+SELECT MIN(evalue) < 1e-10 FROM blast_nuc_results;
+----
+true
+
+# All columns non-NULL
+query I
+SELECT COUNT(*) FROM blast_nuc_results
+WHERE query_id IS NULL OR subject_id IS NULL OR pct_identity IS NULL
+   OR alignment_length IS NULL OR mismatches IS NULL OR gap_opens IS NULL
+   OR query_start IS NULL OR query_end IS NULL
+   OR subject_start IS NULL OR subject_end IS NULL
+   OR evalue IS NULL OR bit_score IS NULL;
+----
+0
+
+# max_targets bounded the result set (used max_targets := 5)
+query I
+SELECT COUNT(DISTINCT subject_id) <= 5 FROM blast_nuc_results;
+----
+true
+
+# --- blastp test ---
+
+# Human insulin B chain — highly conserved, reliably returns hits
+statement ok
+CREATE TABLE blast_prot_queries AS SELECT * FROM (VALUES
+    ('insulin_b', 'FVNQHLCGSHLVEALYLVCGERGFFYTPKT')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE blast_prot_results AS
+SELECT * FROM blast('blast_prot_queries', program := 'blastp', database := 'nr', max_targets := 3, megablast := false);
+
+# At least one protein hit returned
+query I
+SELECT COUNT(*) > 0 FROM blast_prot_results;
+----
+true
+
+# Query ID matches
+query I
+SELECT query_id FROM blast_prot_results LIMIT 1;
+----
+insulin_b
+
+# --- Cleanup ---
+
+statement ok
+DROP TABLE IF EXISTS blast_nuc_queries;
+
+statement ok
+DROP TABLE IF EXISTS blast_nuc_results;
+
+statement ok
+DROP TABLE IF EXISTS blast_prot_queries;
+
+statement ok
+DROP TABLE IF EXISTS blast_prot_results;


### PR DESCRIPTION
## Summary

- Adds a `blast()` table function that sends sequences to NCBI's remote BLAST API and returns tabular hit results (outfmt 6 equivalent)
- Supports all BLAST programs (`blastn`, `blastp`, `blastx`, `tblastn`, `tblastx`) and any NCBI database (`nt`, `nr`, `refseq_rna`, etc.)
- Architecture: `BlastParser` (pure C++, no DuckDB deps) + `BlastClient` (HTTP with rate limiting/retry) + `BlastSearchTableFunction` (Bind/InitGlobal/Execute)

### Function signature
```sql
SELECT * FROM blast('my_sequences',
    program := 'blastn',
    database := 'nt',
    evalue := 1e-10,
    max_targets := 10,
    megablast := true,
    api_key := 'optional_key'
);
```

### Key design decisions
- **Blocking poll**: function blocks during NCBI poll phase (15s intervals, 60min max) with progress to stderr
- **Batch splitting**: queries > 4MB FASTA are automatically split into multiple BLAST submissions
- **Field tolerance**: parser accepts >= 12 tab-separated fields (NCBI returns 13 for blastp — extra `% positives` column)
- **Retrieve URL**: uses `FORMAT_TYPE=Text&ALIGNMENT_VIEW=Tabular` (not `FORMAT_TYPE=Tabular` which returns empty)
- **UNKNOWN status tolerance**: retries up to 3 times before aborting (NCBI BLAST server is notoriously flaky)
- **Rate limiting**: 3 req/s without API key, 10 req/s with key (matches NCBI guidelines)

### Files (13 changed, +1645 lines)
| New files | Purpose |
|---|---|
| `src/include/blast_parser.hpp` / `src/blast_parser.cpp` | Pure parser: response parsing, URL encoding, FASTA building, batch splitting |
| `src/include/blast_client.hpp` / `src/blast_client.cpp` | HTTP client: submit/poll/retrieve with retry/backoff |
| `src/include/blast_search.hpp` / `src/blast_search.cpp` | DuckDB table function wiring |
| `test/cpp/test_blast_parser.cpp` | 120 Catch2 assertions across 8 test cases |
| `test/sql/blast.test` | 300 SQL assertions (bind validation, schema) |
| `test/sql/blast_live.test` | Live NCBI tests (guarded by `BLAST_LIVE_AVAILABLE`) |

## Test plan

- [x] C++ parser unit tests: 120 assertions across 8 test cases (`./build/release/extension/miint/tests "[blast]"`)
- [x] SQL bind/schema tests: 300 assertions (`./build/release/test/unittest "test/sql/blast.test"`)
- [x] Full C++ suite: 1051 cases (1050 passed, 1 skipped), 12216 assertions — zero regressions
- [x] Live blastn test: Lambda phage 100bp → hits with 100% identity, evalue 8.36e-43
- [x] Live blastp test: Human insulin B chain → 3 hits with 100% identity
- [ ] Live tests gated behind `BLAST_LIVE_AVAILABLE` env var (set by `run_tests.sh` reachability probe)
- [ ] CI format check (`make format-check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)