### PR TITLE
fix(ci,cron): finish DuckDB v1.5.3 bump in CI and publisher

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       ci_tools_version: v1.5-variegata
       extension_name: miint
       extra_toolchains: 'rust;omp'
@@ -195,7 +195,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: miint-v1.5.2-extension-${{ matrix.wasm_arch }}
+          name: miint-v1.5.3-extension-${{ matrix.wasm_arch }}
 
       - name: Find WASM file
         id: find-wasm
@@ -295,7 +295,7 @@ jobs:
     name: Code Quality Check
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_code_quality.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       ci_tools_version: v1.5-variegata
       extension_name: miint
       format_checks: 'format;tidy'

--- a/scripts/cron-publish-extension.sh
+++ b/scripts/cron-publish-extension.sh
@@ -59,7 +59,7 @@ fi
 # DUCKDB_VERSION must match both the duckdb submodule pin and the
 # duckdb_version input in .github/workflows/MainDistributionPipeline.yml.
 # When the extension targets a new DuckDB version, bump all three together.
-: "${DUCKDB_VERSION:=v1.5.2}"
+: "${DUCKDB_VERSION:=v1.5.3}"
 
 : "${DEST_USER:?DEST_USER is required}"
 : "${DEST_HOST:?DEST_HOST is required}"
@@ -495,7 +495,7 @@ log "Done."
 #   REPO=the-miint/duckdb-miint
 #   BRANCH=v1.5-variegata
 #   WORKFLOW=MainDistributionPipeline.yml
-#   DUCKDB_VERSION=v1.5.2
+#   DUCKDB_VERSION=v1.5.3
 #   DEST_USER=deploy
 #   DEST_HOST=repo.example.com
 #   DEST_BASE=/var/www/miint-ext


### PR DESCRIPTION
## Problem

The duckdb submodule was bumped to `v1.5.3` in `e5f9541`, but two of the three places the cron publisher's own comment says must "bump all three together" were left at `v1.5.2`:

- `.github/workflows/MainDistributionPipeline.yml` (`duckdb_version` for build + code-quality, and the WASM `download-artifact` name)
- `scripts/cron-publish-extension.sh` (default `DUCKDB_VERSION` + example env file)

CI was therefore still building `miint-v1.5.2-extension-*` artifacts, and the publisher was deploying them under the `v1.5.2` symlink.

## Fix

Bump both remaining locations to `v1.5.3` so submodule / CI / publisher agree.

CI now builds `miint-v1.5.3-extension-*`, which is exactly the prefix the publisher matches against (`miint-${DUCKDB_VERSION}-extension-`). Bumping the workflow alongside the script is required: a script-only change would have made the publisher reject every CI run and deploy nothing.

## Notes / follow-ups (not in this PR)

- **Cron-host env file:** if the deployed env file (e.g. `/etc/miint-publish.env`) hardcodes `DUCKDB_VERSION=v1.5.2`, it overrides the new default — must be updated to `v1.5.3` on the host.
- **CI assumption:** assumes `extension-ci-tools@v1.5-variegata` can build against `v1.5.3` (consistent with the submodule already pinned there). If CI fails on the `duckdb_version` input, that indicates an upstream support gap rather than a problem with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)