### PR TITLE
feat(align_bowtie2): expose mismatch_penalty_min for --mp MAX,MIN

### DIFF
--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -2109,7 +2109,8 @@ The full bowtie2-align typed parameter set is also exposed (one-to-one with the 
 | `seed` | INTEGER | Random seed for reproducibility |
 | `trim5`, `trim3` | INTEGER | Trim N bases from each end of the read |
 | `match_bonus` | INTEGER | `--ma` |
-| `mismatch_penalty` | INTEGER | `--mp` |
+| `mismatch_penalty` | INTEGER | `--mp` MAX (arg1). Pairs with `mismatch_penalty_min` |
+| `mismatch_penalty_min` | INTEGER | `--mp` MIN (arg2). Set both equal for a symmetric penalty (e.g. `1,1`). Unset side defaults to bowtie2's compiled-in value (MAX=6, MIN=2); `MIN > MAX` is rejected |
 | `n_penalty` | INTEGER | `--np` (ambiguous base penalty) |
 | `read_gap_open`, `read_gap_extend` | INTEGER | `--rdg arg1,arg2` |
 | `ref_gap_open`, `ref_gap_extend` | INTEGER | `--rfg arg1,arg2` |
@@ -2256,7 +2257,7 @@ The sharded path emits only mapped reads (the daemon is invoked with `--no-unal`
 - `quiet` (BOOLEAN, default: true): Suppress Bowtie2 stderr output
 - `threads` (INTEGER): Ignored in sharded mode. Use DuckDB's `SET threads=N` to control cross-shard parallelism and `max_threads_per_shard` for per-shard bowtie2 threading. A warning is printed at bind if `threads != 1` is passed directly to this function.
 
-The full bowtie2-align typed parameter set listed under [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) above is also available here (same names, same bind-time validation): `seed`, `trim5`, `trim3`, `match_bonus`, `mismatch_penalty`, `n_penalty`, `read_gap_open`, `read_gap_extend`, `ref_gap_open`, `ref_gap_extend`, `score_min`, `min_insert`, `max_insert`, `mate_orientation`, `no_mixed`, `no_discordant`, `dovetail`, `no_contain`, `no_overlap`, `nofw`, `norc`, `seed_mismatches`, `seed_length`, `max_dp_failures`, `max_seed_rounds`, `report_all`, `xeq`, `rg_id`, `ignore_quals`, `reorder`.
+The full bowtie2-align typed parameter set listed under [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) above is also available here (same names, same bind-time validation): `seed`, `trim5`, `trim3`, `match_bonus`, `mismatch_penalty`, `mismatch_penalty_min`, `n_penalty`, `read_gap_open`, `read_gap_extend`, `ref_gap_open`, `ref_gap_extend`, `score_min`, `min_insert`, `max_insert`, `mate_orientation`, `no_mixed`, `no_discordant`, `dovetail`, `no_contain`, `no_overlap`, `nofw`, `norc`, `seed_mismatches`, `seed_length`, `max_dp_failures`, `max_seed_rounds`, `report_all`, `xeq`, `rg_id`, `ignore_quals`, `reorder`.
 
 The `no_unal` knob is intentionally not exposed: the sharded path always emits only mapped reads (matches the pre-migration `FilterMappedOnly` contract). Use `align_bowtie2` directly if you need to inspect unaligned records.
 

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -97,6 +97,7 @@ const std::unordered_set<std::string> kCommonAlignParams = {
     "trim3",
     "match_bonus",
     "mismatch_penalty",
+    "mismatch_penalty_min",
     "n_penalty",
     "read_gap_open",
     "read_gap_extend",
@@ -188,6 +189,9 @@ void AppendBowtie2AlignParams(ConfigJsonBuilder &cfg, const named_parameter_map_
 	if (auto *v = get("mismatch_penalty")) {
 		cfg.append_int("mismatch_penalty", ValueAsInt(caller, "mismatch_penalty", *v));
 	}
+	if (auto *v = get("mismatch_penalty_min")) {
+		cfg.append_int("mismatch_penalty_min", ValueAsInt(caller, "mismatch_penalty_min", *v));
+	}
 	if (auto *v = get("n_penalty")) {
 		cfg.append_int("n_penalty", ValueAsInt(caller, "n_penalty", *v));
 	}
@@ -271,6 +275,7 @@ void RegisterBowtie2AlignNamedParameterTypes(TableFunction &tf) {
 	tf.named_parameters["trim3"] = LogicalType::INTEGER;
 	tf.named_parameters["match_bonus"] = LogicalType::INTEGER;
 	tf.named_parameters["mismatch_penalty"] = LogicalType::INTEGER;
+	tf.named_parameters["mismatch_penalty_min"] = LogicalType::INTEGER;
 	tf.named_parameters["n_penalty"] = LogicalType::INTEGER;
 	tf.named_parameters["read_gap_open"] = LogicalType::INTEGER;
 	tf.named_parameters["read_gap_extend"] = LogicalType::INTEGER;

--- a/test/sql/align_bowtie2.test
+++ b/test/sql/align_bowtie2.test
@@ -413,6 +413,44 @@ SELECT * FROM align_bowtie2_sharded('typed_queries',
 ----
 seed_length must be 1-32
 
+# ----------------------------------------------------------------------------
+# Two-value --mp MAX,MIN: mismatch_penalty (MAX) + mismatch_penalty_min (MIN)
+# ----------------------------------------------------------------------------
+# bowtie2's `--mp` is a MAX,MIN pair (default 6,2). miint exposes MAX as
+# `mismatch_penalty` and MIN as `mismatch_penalty_min`; both are typed named
+# parameters forwarded into the daemon config JSON. The woltka-style symmetric
+# `1,1` is the motivating case — before mismatch_penalty_min existed, any value
+# < 2 was inexpressible because MIN defaulted to 2.
+
+# The symmetric pair is accepted and forwarded. A perfect-match query still
+# aligns, so we get exactly one hit — proving the daemon parsed config_json
+# with the new field rather than erroring on an unknown key.
+query I
+SELECT COUNT(*) FROM align_bowtie2('typed_queries', 'typed_subjects',
+    mismatch_penalty := 1, mismatch_penalty_min := 1);
+----
+1
+
+# The foot-gun: `mismatch_penalty := 1` alone leaves MIN at its default of 2,
+# so MIN (2) > MAX (1) and bowtie2's MAX,MIN contract is violated. gpl-boundary
+# pre-checks this and returns a clean, knob-named error (no worker crash). The
+# fix is to set mismatch_penalty_min := 1 too, as the test above does.
+statement error
+SELECT * FROM align_bowtie2('typed_queries', 'typed_subjects',
+    mismatch_penalty := 1);
+----
+exceeds MAX
+
+# Same surface for the sharded variant — the MAX,MIN pair is accepted and
+# forwarded, and the perfect-match query still aligns.
+query I
+SELECT COUNT(*) FROM align_bowtie2_sharded('typed_queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'typed_assoc',
+    mismatch_penalty := 1, mismatch_penalty_min := 1);
+----
+1
+
 statement ok
 DROP TABLE typed_queries;
 


### PR DESCRIPTION
## Summary

bowtie2's `--mp` is a `MAX,MIN` pair (default `6,2`). miint exposed only the MAX half (`mismatch_penalty`), so any value `< 2` was inexpressible (MIN defaults to 2) and woltka-style `--mp 1,1` could not be set. This adds a second typed named parameter, **`mismatch_penalty_min`**, for the MIN half.

The change mirrors the existing `mismatch_penalty` handling in the shared `src/align_bowtie2_daemon_common.cpp`, so it covers both `align_bowtie2` and `align_bowtie2_sharded` in one place:
- allowlist entry in `kCommonAlignParams`
- config-JSON forwarder
- DuckDB named-parameter registration (`LogicalType::INTEGER`)

Plus docs (`docs/table-functions.md`: clarified the `mismatch_penalty` row, added the new row, added to the sharded prose list).

## Semantics (match native bowtie2)
- `mismatch_penalty` = MAX, `mismatch_penalty_min` = MIN. An unset side defaults to bowtie2's compiled-in value (MAX=6, MIN=2).
- `MIN > MAX` is rejected. `mismatch_penalty := 1` **alone** is an error (MIN defaults to 2 > 1) — same as native `bowtie2 --mp 1`. Set both: `mismatch_penalty := 1, mismatch_penalty_min := 1`.

## Dependency
Requires **gpl-boundary >= 0.3.0** (GPL-boundary PR #4 / release `v0.3.0`), which adds the `mismatch_penalty_min` config knob and returns a clean, knob-named error when `MIN > MAX` instead of aborting the worker. New miint + old binary silently drops the MIN. CI installs `releases/latest`, which is now v0.3.0.

## Tests
Added to `test/sql/align_bowtie2.test` (typed-params section):
- symmetric `1,1` accepted and forwarded — `align_bowtie2` **and** `align_bowtie2_sharded` (a perfect-match query still aligns → exactly one hit, proving the daemon parsed `config_json` with the new field).
- the `mismatch_penalty := 1` alone foot-gun yields the clean `exceeds MAX` error rather than a crash.

Verified locally: `align_bowtie2.test` 106/106, `align_bowtie2_sharded.test` 78/78 against gpl-boundary v0.3.0; `clang-format` 11.0.1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)