### PR TITLE
diag(gpl_boundary): surface daemon death cause on Submit EPIPE/EOF

### DIFF
--- a/src/gpl_boundary/process.cpp
+++ b/src/gpl_boundary/process.cpp
@@ -40,6 +40,20 @@ void make_pipe(int fds[2]) {
 		throw std::runtime_error("gpl_boundary: pipe() failed: " + std::string(::strerror(errno)));
 	}
 }
+
+// Decode a raw waitpid status into a human-readable, signal-named string.
+// Kept next to make_pipe so the process-control vocabulary lives in one place.
+std::string DescribeWaitStatus(int status) {
+	if (WIFSIGNALED(status)) {
+		const int sig = WTERMSIG(status);
+		const char *name = ::strsignal(sig);
+		return "killed by signal " + std::to_string(sig) + " (" + (name ? name : "unknown") + ")";
+	}
+	if (WIFEXITED(status)) {
+		return "exited with code " + std::to_string(WEXITSTATUS(status));
+	}
+	return "terminated with raw wait status " + std::to_string(status);
+}
 } // namespace
 
 std::string FindExecutableInPath(const std::string &name) {
@@ -368,6 +382,41 @@ int ChildProcess::Wait() {
 	wait_status_ = status;
 	waited_ = true;
 	return status;
+}
+
+std::string ChildProcess::ReapAndDescribe(int grace_ms) {
+	if (waited_) {
+		return DescribeWaitStatus(wait_status_);
+	}
+	if (pid_ <= 0) {
+		return "no child process";
+	}
+	// Poll WNOHANG up to grace_ms. On the daemon-death paths the child is a
+	// zombie already (the pipe EOF/EPIPE that brought us here implies it exited),
+	// so the first poll usually succeeds; the grace window only covers the rare
+	// race where the kernel hasn't transitioned it yet.
+	for (int elapsed = 0;; elapsed += 10) {
+		int status = 0;
+		const pid_t r = ::waitpid(pid_, &status, WNOHANG);
+		if (r == pid_) {
+			wait_status_ = status;
+			waited_ = true;
+			return DescribeWaitStatus(status);
+		}
+		if (r == -1) {
+			// ECHILD: someone else already reaped it (e.g. a process-wide
+			// SIGCHLD handler) — itself a useful tell. Mark waited_ so the
+			// destructor and Wait() don't block on a pid that's gone.
+			const std::string err = ::strerror(errno);
+			waited_ = true;
+			return "already reaped or unwaitable (" + err + ")";
+		}
+		// r == 0: still running.
+		if (elapsed >= grace_ms) {
+			return "still running after " + std::to_string(grace_ms) + "ms (no exit yet)";
+		}
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	}
 }
 
 // =============================================================================

--- a/src/gpl_boundary/session.cpp
+++ b/src/gpl_boundary/session.cpp
@@ -94,6 +94,23 @@ std::string DrainStderrNonblocking(int fd) {
 	return out;
 }
 
+// Compose a "why did the daemon vanish" suffix for Submit's failure paths.
+// Reaps the child to decode its termination — a SIGTERM (e.g. PR_SET_PDEATHSIG
+// firing when the DuckDB worker thread that forked the daemon unwinds) reads
+// very differently from a SIGKILL (OOM killer) or a SIGSEGV (crash) — and
+// splices the daemon's stderr tail. Without this the EPIPE path throws a bare
+// "Broken pipe" and the EOF path a bare "closed stdout", neither of which tells
+// the operator what actually happened. Reap first so the stderr pipe has hit
+// EOF and DrainStderrNonblocking captures everything the daemon last wrote.
+std::string DaemonDeathSuffix(ChildProcess &child) {
+	std::string suffix = " [daemon " + child.ReapAndDescribe() + "]";
+	const std::string stderr_tail = DrainStderrNonblocking(child.stderr_fd());
+	if (!stderr_tail.empty()) {
+		suffix += "\n--- daemon stderr ---\n" + stderr_tail;
+	}
+	return suffix;
+}
+
 // RAII guard that blocks SIGPIPE on the calling thread only. `Session::Shutdown`
 // uses this to write to a possibly-broken pipe without disturbing other threads
 // (DuckDB's scheduler, other sessions) that might rely on the process-wide
@@ -368,14 +385,24 @@ SubmitResult Session::Submit(const std::string &tool, const std::string &config_
 	//    never saw this batch_id and we shouldn't burn it for the next call.
 	const int64_t batch_id = next_batch_id_;
 	const std::string batch_line = build_batch_line(tool, config_json, in_shm.name(), in_shm.size_bytes(), batch_id);
-	WriteLine(child_.stdin_fd(), batch_line);
+	try {
+		WriteLine(child_.stdin_fd(), batch_line);
+	} catch (const std::runtime_error &e) {
+		// EPIPE here means the daemon's stdin read-end is gone — it died before
+		// we finished handing off this batch. Enrich the bare "Broken pipe" with
+		// how it died + its stderr so the cause is actionable.
+		throw std::runtime_error(std::string(e.what()) + DaemonDeathSuffix(child_));
+	}
 	++next_batch_id_;
 
 	// 3. Read response.
 	std::string reply;
 	if (!reader_->ReadLine(reply)) {
+		// The daemon consumed our batch line but closed stdout without replying:
+		// it died between read and write. Same enrichment as the EPIPE path.
 		throw std::runtime_error("gpl_boundary: daemon closed stdout while waiting "
-		                         "for batch response");
+		                         "for batch response" +
+		                         DaemonDeathSuffix(child_));
 	}
 
 	// 4. Parse response.

--- a/src/include/gpl_boundary/process.hpp
+++ b/src/include/gpl_boundary/process.hpp
@@ -96,6 +96,19 @@ public:
 	/// the cached status.
 	int Wait();
 
+	/// Reap the child with a bounded grace period and return a human-readable,
+	/// signal-decoded description of how it terminated:
+	///   - "killed by signal 15 (Terminated)"  — e.g. PR_SET_PDEATHSIG SIGTERM
+	///     firing, or the OOM killer's SIGKILL (9), or a crash (SIGSEGV/SIGABRT)
+	///   - "exited with code 7"
+	///   - "still running after 200ms (no exit yet)" — closed a pipe yet alive
+	///   - "already reaped or unwaitable (...)" — ECHILD: something else waited
+	/// Non-throwing. Idempotent with Wait(): when the child is reaped here the
+	/// status is cached, so the destructor and Wait() won't block again. Used on
+	/// the daemon-death diagnostic paths in Session::Submit so a bare EPIPE
+	/// ("Broken pipe") or stdout-EOF gains the actual cause.
+	std::string ReapAndDescribe(int grace_ms = 200);
+
 private:
 	pid_t pid_ = -1;
 	int stdin_fd_ = -1;

--- a/test/cpp/test_gpl_boundary_process.cpp
+++ b/test/cpp/test_gpl_boundary_process.cpp
@@ -325,6 +325,54 @@ TEST_CASE("ChildProcess fails clearly when the binary does not exist", "[gpl-bou
 }
 
 // =============================================================================
+// Cycle 1.2b — ReapAndDescribe: signal-decoded termination diagnostics
+// =============================================================================
+//
+// Session::Submit's EPIPE/EOF paths use ReapAndDescribe to turn a bare "Broken
+// pipe" into "the daemon was killed by signal 15". These pin the decoding so a
+// SIGTERM (the suspected PR_SET_PDEATHSIG cause) reports distinctly from a
+// SIGKILL (OOM) or a normal exit — that distinction is the whole point.
+
+TEST_CASE("ReapAndDescribe decodes a SIGTERM kill", "[gpl-boundary][process]") {
+	const std::string bash_path = FindExecutableInPath("bash");
+	REQUIRE_FALSE(bash_path.empty());
+	std::vector<std::string> argv = {bash_path, "-c", "sleep 60"};
+	ChildProcess child(argv);
+	REQUIRE(child.pid() > 0);
+	// Let the child reach `sleep` so the signal lands on a running process, not
+	// a racing execve (which could surface as a different status).
+	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	REQUIRE(::kill(child.pid(), SIGTERM) == 0);
+	const std::string desc = child.ReapAndDescribe();
+	INFO("ReapAndDescribe: " << desc);
+	REQUIRE_THAT(desc, Catch::Matchers::ContainsSubstring("signal 15"));
+}
+
+TEST_CASE("ReapAndDescribe decodes a normal exit code", "[gpl-boundary][process]") {
+	const std::string bash_path = FindExecutableInPath("bash");
+	REQUIRE_FALSE(bash_path.empty());
+	std::vector<std::string> argv = {bash_path, "-c", "exit 7"};
+	ChildProcess child(argv);
+	const std::string desc = child.ReapAndDescribe(); // grace window covers the quick exit
+	INFO("ReapAndDescribe: " << desc);
+	REQUIRE_THAT(desc, Catch::Matchers::ContainsSubstring("exited with code 7"));
+}
+
+TEST_CASE("ReapAndDescribe is idempotent and leaves Wait consistent", "[gpl-boundary][process]") {
+	const std::string bash_path = FindExecutableInPath("bash");
+	REQUIRE_FALSE(bash_path.empty());
+	std::vector<std::string> argv = {bash_path, "-c", "exit 3"};
+	ChildProcess child(argv);
+	const std::string first = child.ReapAndDescribe();
+	REQUIRE_THAT(first, Catch::Matchers::ContainsSubstring("exited with code 3"));
+	// Second call returns the cached description; Wait() must not block or differ.
+	REQUIRE(child.ReapAndDescribe() == first);
+	const int status = child.Wait();
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 3);
+}
+
+// =============================================================================
 // Cycle 1.2 — gpl-boundary --version (skip if absent)
 // =============================================================================
 

--- a/test/cpp/test_gpl_boundary_session.cpp
+++ b/test/cpp/test_gpl_boundary_session.cpp
@@ -329,6 +329,25 @@ exit 0)";
 	REQUIRE_THROWS_WITH(session.Submit("fasttree", "{}", "x", 1), Catch::Matchers::ContainsSubstring("tool blew up"));
 }
 
+TEST_CASE("Session::Submit reports the daemon's death signal when it is killed mid-batch", "[gpl-boundary][session]") {
+	// Field repro: the daemon handshakes, consumes our batch line, then dies by
+	// signal (mimicking PR_SET_PDEATHSIG's SIGTERM firing when the DuckDB worker
+	// thread that forked it unwinds) WITHOUT replying. The pre-fix error was a
+	// bare "daemon closed stdout while waiting for batch response", which says
+	// nothing about *why* the daemon vanished. Submit must now splice in the
+	// signal so the cause is visible in the surfaced SQL error.
+	const std::string script =
+	    R"(read -r init_line
+echo '{"success":true,"protocol_version":3,"tools":[{"name":"bowtie2-align","schema_version":2}]}'
+read -r batch_line
+kill -TERM $$
+sleep 5)";
+	auto child = spawn_shim(script);
+	Session session(std::move(child));
+	REQUIRE_NOTHROW(session.Initialize());
+	REQUIRE_THROWS_WITH(session.Submit("bowtie2-align", "{}", "x", 1), ContainsSubstring("signal 15"));
+}
+
 TEST_CASE("Session::Submit rejects calls before Initialize", "[gpl-boundary][session]") {
 	const std::string script = R"(sleep 5
 exit 0)"; // shim that never responds


### PR DESCRIPTION
## What

When the gpl-boundary daemon dies mid-session, `Session::Submit` previously threw a bare:

```
gpl_boundary: WriteLine write() failed: Broken pipe
```

…which says nothing about *how* the daemon died. The `success:false` response path already drains daemon stderr, but the two paths that fire when the daemon is actually *gone* — EPIPE on `WriteLine`, EOF on `ReadLine` — threw raw and discarded the diagnostic.

This PR adds that diagnostic:

- **`ChildProcess::ReapAndDescribe(grace_ms=200)`** — a bounded-wait reap that signal-decodes the child's termination (`killed by signal 15 (Terminated)`, `exited with code N`, `still running after Nms`, `already reaped …`) and caches the status, so `Wait()` and the destructor don't double-block.
- **`Session::Submit`** now appends the decoded cause **plus the daemon's stderr tail** on both death paths.

A bare `Broken pipe` becomes, e.g.:

```
gpl_boundary: WriteLine write() failed: Broken pipe [daemon killed by signal 15 (Terminated)]
--- daemon stderr ---
<...>
```

This distinguishes the common daemon-death modes at a glance: SIGTERM (e.g. `PR_SET_PDEATHSIG` firing) vs SIGKILL (OOM) vs a crash (SIGSEGV/SIGABRT) vs a clean nonzero exit.

## Why

Diagnosing a field report of `align_bowtie2_sharded` failing with `Broken pipe` over a view, the bare message gave nothing to go on. This makes any future daemon death — in **either** the bowtie2 or fasttree path — self-describing.

## Scope / safety

Diagnostic only. The change is **additive on the error paths**: the `try/catch` around `WriteLine` is transparent when it doesn't throw, and `ReapAndDescribe`/stderr-drain run only on EPIPE/EOF. **No behavior change on the success path.** Original message text (`Broken pipe`, `closed stdout …`) is preserved, so anything matching those substrings still matches.

## Tests

- `ReapAndDescribe`: SIGTERM decode, exit-code decode, idempotency-with-`Wait`.
- Session-level: a fake daemon that handshakes, consumes the batch line, then dies by SIGTERM mid-batch — asserts `Submit`'s error now contains the signal.
- Full `[gpl-boundary]` suite green (55 cases / 4389 assertions); clang-format 11.0.1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)