### PR TITLE
feat(copy_fastx): make FASTQ/FASTA paired-end output ergonomic

### DIFF
--- a/docs/copy-formats.md
+++ b/docs/copy-formats.md
@@ -29,22 +29,41 @@ Write query results to FASTQ format files. Requires `read_id`, `sequence1`, and 
 - `QUAL_OFFSET` (default: 33): Quality score encoding offset (33 or 64)
 - `INCLUDE_COMMENT` (default: false): Include comment field in output
 - `ID_AS_SEQUENCE_INDEX` (default: false): Use `sequence_index` as identifier instead of `read_id`
-- `INTERLEAVE` (default: false): Write paired reads interleaved in single file
+- `INTERLEAVE` (default: false): When the data is paired-end, write R1/R2 interleaved into a single file. Optional — see "Single-end vs paired-end output" below. Cannot be combined with the `{ORIENTATION}` placeholder.
 - `COMPRESSION` (default: auto): Enable gzip compression (auto-detected from `.gz` extension)
+
+**Single-end vs paired-end output:**
+
+You do not need to project away `sequence2`/`qual2` or pre-declare whether the data is paired. `read_fastx` always emits `sequence2`/`qual2` (NULL for single-end), and the writer decides per record from whether those values are NULL:
+
+- **`{ORIENTATION}` in the path** selects **split** output: R1 → the `R1` file, R2 → the `R2` file. If the data turns out to be entirely single-end, only the R1 file is written (no empty R2 file is created).
+- **No `{ORIENTATION}`** selects a **single file**. Single-end data is written as-is. Paired-end data is interleaved only if `INTERLEAVE=true`.
+- A record is **paired** when both `sequence2` and `qual2` are non-NULL, and **single-end** when both are NULL. A single COPY must be all one or all the other.
+
+The writer fails loud (rather than guessing or silently dropping data) when:
+- paired data is sent to a single-file path without `INTERLEAVE=true` (add `{ORIENTATION}` to split, or `INTERLEAVE=true` to interleave),
+- `{ORIENTATION}` is combined with `INTERLEAVE=true` (contradictory),
+- `sequence2` and `qual2` disagree on NULL-ness within a record, or
+- the input mixes single-end and paired-end records.
 
 **Examples:**
 ```sql
--- Basic single-end FASTQ output
+-- Basic single-end FASTQ output. SELECT * carries NULL sequence2/qual2 columns;
+-- they are recognized as single-end and a single file is written.
 COPY (SELECT * FROM read_fastx('input.fastq'))
 TO 'output.fastq' (FORMAT FASTQ);
 
--- Paired-end interleaved output
+-- Paired-end interleaved output (single file)
 COPY (SELECT * FROM read_fastx('R1.fastq', 'R2.fastq'))
 TO 'output.fastq' (FORMAT FASTQ, INTERLEAVE true);
 
--- Paired-end split files (use {ORIENTATION} placeholder)
+-- Paired-end split files (the {ORIENTATION} placeholder selects split output)
 COPY (SELECT * FROM read_fastx('R1.fastq', 'R2.fastq'))
 TO 'output_{ORIENTATION}.fastq' (FORMAT FASTQ);
+
+-- Single-end data with {ORIENTATION} simply writes the R1 file (output_R1.fastq.gz)
+COPY (SELECT * FROM read_fastx('input.fastq'))
+TO 'output_{ORIENTATION}.fastq.gz' (FORMAT FASTQ, COMPRESSION gzip);
 
 -- Compressed output with custom quality offset
 COPY (SELECT * FROM read_fastx('input.fastq'))
@@ -71,16 +90,24 @@ Write query results to FASTA format files. Requires `read_id` and `sequence1` co
 **Parameters:**
 - `INCLUDE_COMMENT` (default: false): Include comment field in output
 - `ID_AS_SEQUENCE_INDEX` (default: false): Use `sequence_index` as identifier instead of `read_id`
-- `INTERLEAVE` (default: false): Write paired reads interleaved in single file
+- `INTERLEAVE` (default: false): When the data is paired-end, write R1/R2 interleaved into a single file. Optional — see "Single-end vs paired-end output" below. Cannot be combined with the `{ORIENTATION}` placeholder.
 - `COMPRESSION` (default: auto): Enable gzip compression (auto-detected from `.gz` extension)
+
+**Single-end vs paired-end output:**
+
+FASTA paired-end output works the same way as FASTQ (a record is paired when `sequence2` is non-NULL), without the quality columns:
+
+- **`{ORIENTATION}` in the path** writes split R1/R2 files; an entirely single-end dataset writes only the R1 file.
+- **No `{ORIENTATION}`** writes a single file; paired data is interleaved only if `INTERLEAVE=true`.
+- The writer fails loud when paired data is sent to a single-file path without `INTERLEAVE=true`, when `{ORIENTATION}` is combined with `INTERLEAVE=true`, or when the input mixes single-end and paired-end records.
 
 **Examples:**
 ```sql
--- Basic FASTA output
+-- Basic FASTA output (single-end; NULL sequence2 columns are recognized as single-end)
 COPY (SELECT * FROM read_fastx('input.fasta'))
 TO 'output.fasta' (FORMAT FASTA);
 
--- Paired-end split files
+-- Paired-end split files (the {ORIENTATION} placeholder selects split output)
 COPY (SELECT * FROM read_fastx('R1.fasta', 'R2.fasta'))
 TO 'output_{ORIENTATION}.fasta' (FORMAT FASTA);
 

--- a/src/copy_fasta.cpp
+++ b/src/copy_fasta.cpp
@@ -23,7 +23,8 @@ struct FastaCopyBindData : public SequenceCopyBindData {
 		result->compression = compression;
 		result->flush_size = flush_size;
 		result->file_path = file_path;
-		result->is_paired = is_paired;
+		result->has_r2_columns = has_r2_columns;
+		result->split_output = split_output;
 		result->names = names;
 		result->indices = indices;
 		// No FASTA-specific fields to copy
@@ -34,8 +35,8 @@ struct FastaCopyBindData : public SequenceCopyBindData {
 		auto &other = other_p.Cast<FastaCopyBindData>();
 		return interleave == other.interleave && id_as_sequence_index == other.id_as_sequence_index &&
 		       include_comment == other.include_comment && compression == other.compression &&
-		       file_path == other.file_path && is_paired == other.is_paired && flush_size == other.flush_size &&
-		       names == other.names;
+		       file_path == other.file_path && has_r2_columns == other.has_r2_columns &&
+		       split_output == other.split_output && flush_size == other.flush_size && names == other.names;
 	}
 };
 
@@ -59,18 +60,18 @@ static unique_ptr<FunctionData> FastaCopyBind(ClientContext &context, CopyFuncti
 	// Validate required columns
 	ValidateRequiredColumns(has_read_id, has_sequence1, "FASTA");
 
-	result->is_paired = has_sequence2;
+	// Column presence only; whether each record is actually paired is decided per-row at write
+	// time from sequence2 NULL-ness (read_fastx always emits sequence2, NULL for single-end).
+	result->has_r2_columns = has_sequence2;
 
 	// Parse common parameters
 	CommonCopyParameters common_params;
-	bool has_interleave_param = false;
 
 	for (auto &option : input.info.options) {
-		if (StringUtil::CIEquals(option.first, "interleave")) {
-			has_interleave_param = true;
-		} else if (!StringUtil::CIEquals(option.first, "id_as_sequence_index") &&
-		           !StringUtil::CIEquals(option.first, "include_comment") &&
-		           !StringUtil::CIEquals(option.first, "compression")) {
+		if (!StringUtil::CIEquals(option.first, "interleave") &&
+		    !StringUtil::CIEquals(option.first, "id_as_sequence_index") &&
+		    !StringUtil::CIEquals(option.first, "include_comment") &&
+		    !StringUtil::CIEquals(option.first, "compression")) {
 			throw BinderException("Unknown option for COPY FORMAT FASTA: %s", option.first);
 		}
 	}
@@ -83,8 +84,8 @@ static unique_ptr<FunctionData> FastaCopyBind(ClientContext &context, CopyFuncti
 	result->compression = common_params.compression;
 	result->flush_size = common_params.flush_size;
 
-	// Validate paired-end parameters
-	ValidatePairedEndParameters(result->is_paired, has_interleave_param, result->interleave, result->file_path);
+	// {ORIENTATION} in the path => split R1/R2 files; otherwise a single (optionally interleaved) file.
+	ResolveOutputMode(result->file_path, result->interleave, result->split_output);
 
 	// Validate sequence_index parameter
 	ValidateSequenceIndexParameter(result->id_as_sequence_index, has_sequence_index);
@@ -161,17 +162,16 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 	input.data[indices.sequence1_idx].ToUnifiedFormat(input.size(), seq1_data);
 	auto seq1_strings = UnifiedVectorFormat::GetData<string_t>(seq1_data);
 
-	bool is_paired = fdata.is_paired;
-	if (is_paired) {
+	// The schema may carry a sequence2 column even for single-end data (read_fastx always emits it
+	// as NULL). Whether a given row is paired is decided per-row below from sequence2 NULL-ness.
+	bool has_r2 = fdata.has_r2_columns;
+	if (has_r2) {
 		input.data[indices.sequence2_idx].ToUnifiedFormat(input.size(), seq2_data);
 	}
 
 	// Get references to local buffers
 	auto &stream_r1 = *lstate.writer_state_r1->stream;
-	MemoryStream *stream_r2 = nullptr;
-	if (is_paired && !fdata.interleave) {
-		stream_r2 = lstate.writer_state_r2->stream.get();
-	}
+	MemoryStream *stream_r2 = fdata.split_output ? lstate.writer_state_r2->stream.get() : nullptr;
 
 	// Build all records into local buffer(s) - NO LOCK.
 	// Hot-path rule: never call string_t::GetString() on the sequence -- it makes a heap
@@ -224,23 +224,36 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		WriteFastaRecordToBuffer(stream_r1, id_ptr, id_size, seq1_ptr, seq1_size, comment_ptr, comment_size);
 		lstate.writer_state_r1->written_anything = true;
 
-		// Handle R2 for paired-end
-		if (is_paired) {
-			auto seq2_strings = UnifiedVectorFormat::GetData<string_t>(seq2_data);
+		// Handle R2. A record is paired iff sequence2 is non-NULL; a NULL sequence2 means a
+		// single-end record.
+		if (has_r2) {
 			auto seq2_row = seq2_data.sel->get_index(row);
-			if (!seq2_data.validity.RowIsValid(seq2_row)) {
-				throw InvalidInputException("NULL value in sequence2 column (row %llu)", row);
-			}
-			const char *seq2_ptr = seq2_strings[seq2_row].GetData();
-			idx_t seq2_size = seq2_strings[seq2_row].GetSize();
+			if (seq2_data.validity.RowIsValid(seq2_row)) {
+				lstate.saw_paired = true;
 
-			if (fdata.interleave) {
-				// Write R2 to same buffer
-				WriteFastaRecordToBuffer(stream_r1, id_ptr, id_size, seq2_ptr, seq2_size, comment_ptr, comment_size);
+				auto seq2_strings = UnifiedVectorFormat::GetData<string_t>(seq2_data);
+				const char *seq2_ptr = seq2_strings[seq2_row].GetData();
+				idx_t seq2_size = seq2_strings[seq2_row].GetSize();
+
+				if (fdata.split_output) {
+					// Write R2 to the separate R2 buffer (file created lazily on first flush).
+					WriteFastaRecordToBuffer(*stream_r2, id_ptr, id_size, seq2_ptr, seq2_size, comment_ptr,
+					                         comment_size);
+					lstate.writer_state_r2->written_anything = true;
+				} else if (fdata.interleave) {
+					// Write R2 interleaved into the same buffer as R1.
+					WriteFastaRecordToBuffer(stream_r1, id_ptr, id_size, seq2_ptr, seq2_size, comment_ptr,
+					                         comment_size);
+				} else {
+					// Single-file output but this record is paired and there is nowhere to put R2.
+					throw InvalidInputException(
+					    "Row %llu has paired-end data (sequence2 is set) but the output is a single file. Use the "
+					    "{ORIENTATION} placeholder in the output path to write split R1/R2 files, or set "
+					    "INTERLEAVE=true to interleave R1/R2 into one file.",
+					    row);
+				}
 			} else {
-				// Write R2 to separate buffer
-				WriteFastaRecordToBuffer(*stream_r2, id_ptr, id_size, seq2_ptr, seq2_size, comment_ptr, comment_size);
-				lstate.writer_state_r2->written_anything = true;
+				lstate.saw_single = true;
 			}
 		}
 
@@ -252,7 +265,7 @@ static void FastaCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 			FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
 		}
 		if (stream_r2 && lstate.writer_state_r2->stream->GetPosition() >= lstate.writer_state_r2->flush_size) {
-			FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+			FlushR2Buffer(*lstate.writer_state_r2, gstate);
 		}
 	}
 }

--- a/src/copy_fastq.cpp
+++ b/src/copy_fastq.cpp
@@ -25,7 +25,8 @@ struct FastqCopyBindData : public SequenceCopyBindData {
 		result->compression = compression;
 		result->flush_size = flush_size;
 		result->file_path = file_path;
-		result->is_paired = is_paired;
+		result->has_r2_columns = has_r2_columns;
+		result->split_output = split_output;
 		result->names = names;
 		result->indices = indices;
 		// Copy FASTQ-specific field
@@ -37,7 +38,8 @@ struct FastqCopyBindData : public SequenceCopyBindData {
 		auto &other = other_p.Cast<FastqCopyBindData>();
 		return interleave == other.interleave && id_as_sequence_index == other.id_as_sequence_index &&
 		       include_comment == other.include_comment && qual_offset == other.qual_offset &&
-		       compression == other.compression && file_path == other.file_path && is_paired == other.is_paired &&
+		       compression == other.compression && file_path == other.file_path &&
+		       has_r2_columns == other.has_r2_columns && split_output == other.split_output &&
 		       flush_size == other.flush_size && names == other.names;
 	}
 };
@@ -67,20 +69,20 @@ static unique_ptr<FunctionData> FastqCopyBind(ClientContext &context, CopyFuncti
 		throw BinderException("COPY FORMAT FASTQ requires 'qual1' column");
 	}
 
-	result->is_paired = has_sequence2 && has_qual2;
+	// Column presence only; whether each record is actually paired is decided per-row at write
+	// time from R2 NULL-ness (read_fastx always emits sequence2/qual2, NULL for single-end).
+	result->has_r2_columns = has_sequence2 && has_qual2;
 
 	// Parse common parameters
 	CommonCopyParameters common_params;
 
 	Value qual_offset_param;
-	bool has_interleave_param = false;
 
 	for (auto &option : input.info.options) {
-		if (StringUtil::CIEquals(option.first, "interleave")) {
-			has_interleave_param = true;
-		} else if (StringUtil::CIEquals(option.first, "qual_offset")) {
+		if (StringUtil::CIEquals(option.first, "qual_offset")) {
 			qual_offset_param = option.second[0];
-		} else if (!StringUtil::CIEquals(option.first, "id_as_sequence_index") &&
+		} else if (!StringUtil::CIEquals(option.first, "interleave") &&
+		           !StringUtil::CIEquals(option.first, "id_as_sequence_index") &&
 		           !StringUtil::CIEquals(option.first, "include_comment") &&
 		           !StringUtil::CIEquals(option.first, "compression")) {
 			throw BinderException("Unknown option for COPY FORMAT FASTQ: %s", option.first);
@@ -95,8 +97,8 @@ static unique_ptr<FunctionData> FastqCopyBind(ClientContext &context, CopyFuncti
 	result->compression = common_params.compression;
 	result->flush_size = common_params.flush_size;
 
-	// Validate paired-end parameters
-	ValidatePairedEndParameters(result->is_paired, has_interleave_param, result->interleave, result->file_path);
+	// {ORIENTATION} in the path => split R1/R2 files; otherwise a single (optionally interleaved) file.
+	ResolveOutputMode(result->file_path, result->interleave, result->split_output);
 
 	// Validate sequence_index parameter
 	ValidateSequenceIndexParameter(result->id_as_sequence_index, has_sequence_index);
@@ -167,18 +169,17 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 
 	input.data[indices.qual1_idx].ToUnifiedFormat(input.size(), qual1_data);
 
-	bool is_paired = fdata.is_paired;
-	if (is_paired) {
+	// The schema may carry R2 columns even for single-end data (read_fastx always emits them as
+	// NULL). Whether a given row is paired is decided per-row below from R2 NULL-ness.
+	bool has_r2 = fdata.has_r2_columns;
+	if (has_r2) {
 		input.data[indices.sequence2_idx].ToUnifiedFormat(input.size(), seq2_data);
 		input.data[indices.qual2_idx].ToUnifiedFormat(input.size(), qual2_data);
 	}
 
 	// Get references to local buffers
 	auto &stream_r1 = *lstate.writer_state_r1->stream;
-	MemoryStream *stream_r2 = nullptr;
-	if (is_paired && !fdata.interleave) {
-		stream_r2 = lstate.writer_state_r2->stream.get();
-	}
+	MemoryStream *stream_r2 = fdata.split_output ? lstate.writer_state_r2->stream.get() : nullptr;
 
 	// Build all records into local buffer(s) - NO LOCK.
 	// Hot-path rule: never call string_t::GetString() on sequence/quality fields -- it
@@ -256,45 +257,61 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 		               qual1_length);
 		lstate.writer_state_r1->written_anything = true;
 
-		// Handle R2 for paired-end
-		if (is_paired) {
-			auto seq2_strings = UnifiedVectorFormat::GetData<string_t>(seq2_data);
+		// Handle R2. A record is paired iff sequence2 AND qual2 are both non-NULL; both NULL means
+		// a single-end record. Exactly one NULL is a malformed FASTQ record.
+		if (has_r2) {
 			auto seq2_row = seq2_data.sel->get_index(row);
-			if (!seq2_data.validity.RowIsValid(seq2_row)) {
-				throw InvalidInputException("NULL value in sequence2 column (row %llu)", row);
-			}
-			const char *seq2_ptr = seq2_strings[seq2_row].GetData();
-			idx_t seq2_size = seq2_strings[seq2_row].GetSize();
-
 			auto qual2_row = qual2_data.sel->get_index(row);
-			if (!qual2_data.validity.RowIsValid(qual2_row)) {
-				throw InvalidInputException("NULL value in qual2 column (row %llu)", row);
-			}
-			auto qual2_list = ListVector::GetEntry(input.data[indices.qual2_idx]);
-			auto qual2_list_data = FlatVector::GetData<uint8_t>(qual2_list);
-			auto qual2_entries = UnifiedVectorFormat::GetData<list_entry_t>(qual2_data);
-			idx_t qual2_length = qual2_entries[qual2_row].length;
-			const uint8_t *qual2_ptr = qual2_list_data + qual2_entries[qual2_row].offset;
+			bool seq2_valid = seq2_data.validity.RowIsValid(seq2_row);
+			bool qual2_valid = qual2_data.validity.RowIsValid(qual2_row);
 
-			// Validate quality score length matches sequence length
-			if (qual2_length != seq2_size) {
+			if (seq2_valid != qual2_valid) {
 				throw InvalidInputException(
-				    "Quality score length (%llu) does not match sequence length (%llu) for row %llu (R2)", qual2_length,
-				    seq2_size, row);
+				    "Row %llu: sequence2 and qual2 must both be set (paired-end) or both be NULL (single-end)", row);
 			}
 
-			if (fdata.interleave) {
-				// Write R2 to same buffer
-				encoder.Encode(sink_r1, id_ptr, id_size, comment_ptr, comment_size, seq2_ptr, seq2_size, qual2_ptr,
-				               qual2_length);
+			if (seq2_valid) {
+				lstate.saw_paired = true;
+
+				auto seq2_strings = UnifiedVectorFormat::GetData<string_t>(seq2_data);
+				const char *seq2_ptr = seq2_strings[seq2_row].GetData();
+				idx_t seq2_size = seq2_strings[seq2_row].GetSize();
+
+				auto qual2_list = ListVector::GetEntry(input.data[indices.qual2_idx]);
+				auto qual2_list_data = FlatVector::GetData<uint8_t>(qual2_list);
+				auto qual2_entries = UnifiedVectorFormat::GetData<list_entry_t>(qual2_data);
+				idx_t qual2_length = qual2_entries[qual2_row].length;
+				const uint8_t *qual2_ptr = qual2_list_data + qual2_entries[qual2_row].offset;
+
+				// Validate quality score length matches sequence length
+				if (qual2_length != seq2_size) {
+					throw InvalidInputException(
+					    "Quality score length (%llu) does not match sequence length (%llu) for row %llu (R2)",
+					    qual2_length, seq2_size, row);
+				}
+
+				if (fdata.split_output) {
+					// Write R2 to the separate R2 buffer (file created lazily on first flush).
+					auto sink_r2 = [stream_r2](const char *data, std::size_t size) {
+						stream_r2->WriteData(const_data_ptr_cast(data), size);
+					};
+					encoder.Encode(sink_r2, id_ptr, id_size, comment_ptr, comment_size, seq2_ptr, seq2_size, qual2_ptr,
+					               qual2_length);
+					lstate.writer_state_r2->written_anything = true;
+				} else if (fdata.interleave) {
+					// Write R2 interleaved into the same buffer as R1.
+					encoder.Encode(sink_r1, id_ptr, id_size, comment_ptr, comment_size, seq2_ptr, seq2_size, qual2_ptr,
+					               qual2_length);
+				} else {
+					// Single-file output but this record is paired and there is nowhere to put R2.
+					throw InvalidInputException(
+					    "Row %llu has paired-end data (sequence2 is set) but the output is a single file. Use the "
+					    "{ORIENTATION} placeholder in the output path to write split R1/R2 files, or set "
+					    "INTERLEAVE=true to interleave R1/R2 into one file.",
+					    row);
+				}
 			} else {
-				// Write R2 to separate buffer
-				auto sink_r2 = [stream_r2](const char *data, std::size_t size) {
-					stream_r2->WriteData(const_data_ptr_cast(data), size);
-				};
-				encoder.Encode(sink_r2, id_ptr, id_size, comment_ptr, comment_size, seq2_ptr, seq2_size, qual2_ptr,
-				               qual2_length);
-				lstate.writer_state_r2->written_anything = true;
+				lstate.saw_single = true;
 			}
 		}
 
@@ -305,7 +322,7 @@ static void FastqCopySink(ExecutionContext &context, FunctionData &bind_data, Gl
 			FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
 		}
 		if (stream_r2 && lstate.writer_state_r2->stream->GetPosition() >= lstate.writer_state_r2->flush_size) {
-			FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+			FlushR2Buffer(*lstate.writer_state_r2, gstate);
 		}
 	}
 }

--- a/src/copy_format_common.cpp
+++ b/src/copy_format_common.cpp
@@ -24,18 +24,12 @@ void FormatWriterState::Reset() {
 //===--------------------------------------------------------------------===//
 // Format Writer Helper Functions
 //===--------------------------------------------------------------------===//
-void FlushFormatBuffer(FormatWriterState &local_state, CopyFileHandle &file, mutex &lock) {
-	if (!local_state.written_anything) {
-		return;
-	}
-
-	lock_guard<mutex> glock(lock);
-
-	// Write accumulated buffer to file in <= 1 GiB slices. DuckDB's MiniZStreamWrapper
-	// (the gzip path) casts the write size to unsigned int internally, so a single write
-	// larger than 4 GiB throws "Information loss on integer cast". Chunking keeps every
-	// underlying compressor call within 32-bit bounds regardless of how much the local
-	// MemoryStream accumulated.
+// Write the accumulated local buffer to the file in <= 1 GiB slices, then reset the buffer.
+// Caller must hold the global lock. DuckDB's MiniZStreamWrapper (the gzip path) casts the write
+// size to unsigned int internally, so a single write larger than 4 GiB throws "Information loss
+// on integer cast". Chunking keeps every underlying compressor call within 32-bit bounds
+// regardless of how much the local MemoryStream accumulated.
+static void WriteBufferToFile(CopyFileHandle &file, FormatWriterState &local_state) {
 	constexpr idx_t MAX_WRITE_CHUNK = 1ULL * 1024 * 1024 * 1024; // 1 GiB
 	const_data_ptr_t data = local_state.stream->GetData();
 	idx_t remaining = local_state.stream->GetPosition();
@@ -49,6 +43,29 @@ void FlushFormatBuffer(FormatWriterState &local_state, CopyFileHandle &file, mut
 
 	// Reset local buffer
 	local_state.Reset();
+}
+
+void FlushFormatBuffer(FormatWriterState &local_state, CopyFileHandle &file, mutex &lock) {
+	if (!local_state.written_anything) {
+		return;
+	}
+
+	lock_guard<mutex> glock(lock);
+	WriteBufferToFile(file, local_state);
+}
+
+void FlushR2Buffer(FormatWriterState &local_state, SequenceCopyGlobalState &gstate) {
+	if (!local_state.written_anything) {
+		return;
+	}
+
+	lock_guard<mutex> glock(gstate.lock);
+	if (!gstate.file_r2) {
+		// First non-NULL R2 record across all threads -> create the R2 file now. This is what
+		// keeps an all-single-end dataset from producing an empty R2 file in split mode.
+		gstate.file_r2 = make_uniq<CopyFileHandle>(*gstate.fs, gstate.r2_path, gstate.compression);
+	}
+	WriteBufferToFile(*gstate.file_r2, local_state);
 }
 
 //===--------------------------------------------------------------------===//
@@ -206,20 +223,17 @@ void ValidateRequiredColumns(bool has_read_id, bool has_sequence1, const string 
 	}
 }
 
-void ValidatePairedEndParameters(bool is_paired, bool has_interleave_param, bool interleave, const string &file_path) {
-	// INTERLEAVE parameter required for paired-end data
-	if (is_paired && !has_interleave_param) {
-		throw BinderException("INTERLEAVE parameter required for paired-end data");
-	}
-
-	// Validate {ORIENTATION} usage
+void ResolveOutputMode(const string &file_path, bool interleave, bool &out_split_output) {
+	// The {ORIENTATION} placeholder is the split-vs-single switch. INTERLEAVE=true means "one file
+	// with R1/R2 alternating", which is the opposite of split output -- so the two are contradictory.
 	bool has_orientation = HasOrientationPlaceholder(file_path);
-	if (is_paired && !interleave && !has_orientation) {
-		throw BinderException("Paired-end data with INTERLEAVE=false requires {ORIENTATION} in file path");
+	if (has_orientation && interleave) {
+		throw BinderException(
+		    "Cannot combine the {ORIENTATION} placeholder with INTERLEAVE=true: use {ORIENTATION} in the path "
+		    "to write split R1/R2 files, or INTERLEAVE=true (without {ORIENTATION}) to interleave R1/R2 into a "
+		    "single file");
 	}
-	if (!is_paired && has_orientation) {
-		throw BinderException("Single-end data cannot use {ORIENTATION} in file path");
-	}
+	out_split_output = has_orientation;
 }
 
 void ValidateSequenceIndexParameter(bool id_as_sequence_index, bool has_sequence_index) {
@@ -237,19 +251,18 @@ unique_ptr<GlobalFunctionData> SequenceCopyInitializeGlobal(ClientContext &conte
 	auto &fs = FileSystem::GetFileSystem(context);
 
 	auto gstate = make_uniq<SequenceCopyGlobalState>();
-	gstate->is_paired = fdata.is_paired;
-	gstate->interleave = fdata.interleave;
+	gstate->fs = &fs;
+	gstate->compression = fdata.compression;
 
-	if (fdata.is_paired && !fdata.interleave) {
-		// Split mode: open two files
-		string path_r1 = SubstituteOrientation(file_path, "R1");
-		string path_r2 = SubstituteOrientation(file_path, "R2");
+	// R1 is always written. SubstituteOrientation is a no-op when {ORIENTATION} is absent, so this
+	// resolves to the raw path for single-file/interleaved output and to the R1 file in split mode.
+	string path_r1 = SubstituteOrientation(file_path, "R1");
+	gstate->file_r1 = make_uniq<CopyFileHandle>(fs, path_r1, fdata.compression);
 
-		gstate->file_r1 = make_uniq<CopyFileHandle>(fs, path_r1, fdata.compression);
-		gstate->file_r2 = make_uniq<CopyFileHandle>(fs, path_r2, fdata.compression);
-	} else {
-		// Interleaved or single-end: open one file
-		gstate->file_r1 = make_uniq<CopyFileHandle>(fs, file_path, fdata.compression);
+	if (fdata.split_output) {
+		// R2 file is created lazily on the first non-NULL R2 record (see FlushR2Buffer), so a
+		// single-end dataset written with {ORIENTATION} never produces an empty R2 file.
+		gstate->r2_path = SubstituteOrientation(file_path, "R2");
 	}
 
 	return gstate;
@@ -261,7 +274,7 @@ unique_ptr<LocalFunctionData> SequenceCopyInitializeLocal(ExecutionContext &cont
 
 	lstate->writer_state_r1 = make_uniq<FormatWriterState>(context.client, fdata.flush_size);
 
-	if (fdata.is_paired && !fdata.interleave) {
+	if (fdata.split_output) {
 		lstate->writer_state_r2 = make_uniq<FormatWriterState>(context.client, fdata.flush_size);
 	}
 
@@ -273,13 +286,26 @@ void SequenceCopyCombine(const SequenceCopyBindData &fdata, SequenceCopyGlobalSt
 	// Flush any remaining data in local buffers
 	FlushFormatBuffer(*lstate.writer_state_r1, *gstate.file_r1, gstate.lock);
 
-	if (fdata.is_paired && !fdata.interleave) {
-		FlushFormatBuffer(*lstate.writer_state_r2, *gstate.file_r2, gstate.lock);
+	if (fdata.split_output) {
+		FlushR2Buffer(*lstate.writer_state_r2, gstate);
 	}
+
+	// Publish this thread's single/paired observations for the cross-thread consistency check.
+	lock_guard<mutex> glock(gstate.lock);
+	gstate.saw_paired |= lstate.saw_paired;
+	gstate.saw_single |= lstate.saw_single;
 }
 
 void SequenceCopyFinalize(SequenceCopyGlobalState &gstate) {
 	lock_guard<mutex> glock(gstate.lock);
+
+	// A single COPY must be either all single-end or all paired-end. Seeing both means the input
+	// mixed paired and unpaired records, which would silently misalign split/interleaved output.
+	if (gstate.saw_paired && gstate.saw_single) {
+		throw InvalidInputException(
+		    "Inconsistent paired-end data: some records have sequence2 set and others do not. A single COPY must "
+		    "be either all single-end or all paired-end.");
+	}
 
 	if (gstate.file_r1) {
 		gstate.file_r1->Close();

--- a/src/include/copy_format_common.hpp
+++ b/src/include/copy_format_common.hpp
@@ -88,7 +88,11 @@ struct CommonCopyParameters {
 // Common Validation Functions
 //===--------------------------------------------------------------------===//
 void ValidateRequiredColumns(bool has_read_id, bool has_sequence1, const string &format_name);
-void ValidatePairedEndParameters(bool is_paired, bool has_interleave_param, bool interleave, const string &file_path);
+// Resolves the output structure from the path + INTERLEAVE option. The presence of the
+// {ORIENTATION} placeholder is the split-vs-single switch: when present, R1/R2 are written to
+// separate files; when absent, output is a single file (interleaved iff INTERLEAVE=true).
+// Sets out_split_output. Throws on the one contradictory combination ({ORIENTATION}+INTERLEAVE=true).
+void ResolveOutputMode(const string &file_path, bool interleave, bool &out_split_output);
 void ValidateSequenceIndexParameter(bool id_as_sequence_index, bool has_sequence_index);
 
 //===--------------------------------------------------------------------===//
@@ -97,13 +101,18 @@ void ValidateSequenceIndexParameter(bool id_as_sequence_index, bool has_sequence
 
 // Base bind data for sequence formats (FASTA/FASTQ)
 struct SequenceCopyBindData : public FunctionData {
-	bool interleave = false;
+	bool interleave = false; // INTERLEAVE=true: write R1/R2 records alternating into one file
 	bool id_as_sequence_index = false;
 	bool include_comment = false;
 	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
 	idx_t flush_size = DEFAULT_COPY_FLUSH_SIZE;
 	string file_path;
-	bool is_paired = false;
+	// Whether the input *schema* carries R2 columns (sequence2 [+ qual2 for FASTQ]). This does
+	// NOT mean the data is paired -- read_fastx always emits these columns (NULL for single-end).
+	// Whether a given record is paired is decided per-row at write time from R2 NULL-ness.
+	bool has_r2_columns = false;
+	// Whether the output path contains the {ORIENTATION} placeholder, i.e. split R1/R2 files.
+	bool split_output = false;
 	vector<string> names;
 	ColumnIndices indices; // Pre-computed column indices
 
@@ -114,15 +123,25 @@ struct SequenceCopyBindData : public FunctionData {
 struct SequenceCopyGlobalState : public GlobalFunctionData {
 	mutex lock;
 	unique_ptr<CopyFileHandle> file_r1;
-	unique_ptr<CopyFileHandle> file_r2;
-	bool is_paired = false;
-	bool interleave = false;
+	unique_ptr<CopyFileHandle> file_r2; // split mode only; created lazily on first R2 write
+	// Deferred R2-file creation parameters (split mode). The R2 file is only created once a
+	// non-NULL R2 record is actually written, so an all-single-end dataset never produces an
+	// empty R2 file even when {ORIENTATION} is used.
+	FileSystem *fs = nullptr;
+	string r2_path;
+	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
+	// Consistency tracking across all threads: a single COPY must be either all single-end or
+	// all paired-end. Both set true -> inconsistent input (checked at finalize).
+	bool saw_paired = false;
+	bool saw_single = false;
 };
 
 // Shared local state for sequence formats (100% identical for FASTA/FASTQ)
 struct SequenceCopyLocalState : public LocalFunctionData {
 	unique_ptr<FormatWriterState> writer_state_r1;
 	unique_ptr<FormatWriterState> writer_state_r2; // For split paired-end
+	bool saw_paired = false;                       // this thread wrote >=1 paired record
+	bool saw_single = false;                       // this thread wrote >=1 single-end record
 };
 
 //===--------------------------------------------------------------------===//
@@ -135,6 +154,9 @@ unique_ptr<GlobalFunctionData> SequenceCopyInitializeGlobal(ClientContext &conte
 
 // Initialize local state for sequence formats
 unique_ptr<LocalFunctionData> SequenceCopyInitializeLocal(ExecutionContext &context, const SequenceCopyBindData &fdata);
+
+// Flush a local R2 buffer in split mode, lazily creating the R2 file on first non-empty flush.
+void FlushR2Buffer(FormatWriterState &local_state, SequenceCopyGlobalState &gstate);
 
 // Combine (flush) local buffers for sequence formats
 void SequenceCopyCombine(const SequenceCopyBindData &fdata, SequenceCopyGlobalState &gstate,

--- a/test/sql/copy_fasta.test
+++ b/test/sql/copy_fasta.test
@@ -93,23 +93,28 @@ COPY (SELECT read_id FROM test_fasta_single) TO '__TEST_DIR__/error2.fa' (FORMAT
 ----
 COPY FORMAT FASTA requires 'sequence1' column
 
-# Test 10: Error - paired data without INTERLEAVE parameter
+# Test 10: Error - genuinely paired data sent to a single-file path
+# (no {ORIENTATION} to split into, INTERLEAVE not requested) -> fail loud with guidance
 statement error
 COPY (SELECT read_id, comment, sequence1, sequence2 FROM test_fasta_paired) TO '__TEST_DIR__/error3.fa' (FORMAT FASTA);
 ----
-INTERLEAVE parameter required for paired-end data
+Use the {ORIENTATION} placeholder
 
-# Test 11: Error - paired data with INTERLEAVE=false but no {ORIENTATION}
+# Test 11: Error - explicit INTERLEAVE=false but no {ORIENTATION} for genuinely paired data.
 statement error
 COPY (SELECT read_id, comment, sequence1, sequence2 FROM test_fasta_paired) TO '__TEST_DIR__/error4.fa' (FORMAT FASTA, INTERLEAVE false);
 ----
-{ORIENTATION} in file path
+Use the {ORIENTATION} placeholder
 
-# Test 12: Error - single-end data with {ORIENTATION}
-statement error
-COPY (SELECT read_id, comment, sequence1 FROM test_fasta_single) TO '__TEST_DIR__/error5.{ORIENTATION}.fa' (FORMAT FASTA);
+# Test 12: Single-end data (no sequence2 column) + {ORIENTATION} now writes the R1 file only.
+statement ok
+COPY (SELECT read_id, comment, sequence1 FROM test_fasta_single ORDER BY sequence_index) TO '__TEST_DIR__/output12.{ORIENTATION}.fa' (FORMAT FASTA);
+
+query II
+SELECT read_id, sequence1 FROM read_fastx('__TEST_DIR__/output12.R1.fa') ORDER BY sequence_index;
 ----
-Single-end data cannot use {ORIENTATION}
+seq1	ATGCATGCATGC
+seq2	GGCCGGCCGGCC
 
 # Test 13: Error - ID_AS_SEQUENCE_INDEX without sequence_index column
 statement error
@@ -141,6 +146,56 @@ SELECT read_id, sequence1, comment FROM read_fastx('__TEST_DIR__/output_nulls.fa
 ----
 seq1	ATGCATGCATGC	NULL
 seq2	GGCCGGCCGGCC	NULL
+
+# Test 16: Problem #1 - selecting sequence2 from a single-end source yields a NULL sequence2
+# column. Writing to a plain path must produce a single-end file, not error.
+statement ok
+COPY (SELECT read_id, comment, sequence1, sequence2 FROM read_fastx('data/fastq/test.fa') ORDER BY sequence_index) TO '__TEST_DIR__/fa_p1.fa' (FORMAT FASTA);
+
+query III
+SELECT read_id, sequence1, comment FROM read_fastx('__TEST_DIR__/fa_p1.fa') ORDER BY sequence_index;
+----
+seq1	ATGCATGCATGC	NULL
+seq2	GGCCGGCCGGCC	NULL
+
+# Test 17: Problem #2 - paired data + {ORIENTATION} with NO INTERLEAVE parameter -> split R1/R2.
+statement ok
+COPY (SELECT read_id, comment, sequence1, sequence2 FROM test_fasta_paired ORDER BY sequence_index) TO '__TEST_DIR__/fa_p2.{ORIENTATION}.fa' (FORMAT FASTA);
+
+query IIII
+SELECT sequence_index, read_id, sequence1, sequence2 FROM read_fastx('__TEST_DIR__/fa_p2.R1.fa', sequence2='__TEST_DIR__/fa_p2.R2.fa') ORDER BY sequence_index;
+----
+1	pair_a1	AAAA	TTTT
+
+# Test 18: Headline - NULL sequence2 column + {ORIENTATION} writes a single R1 file, no R2 file.
+statement ok
+COPY (SELECT read_id, comment, sequence1, sequence2 FROM read_fastx('data/fastq/test.fa') ORDER BY sequence_index) TO '__TEST_DIR__/fa_headline.{ORIENTATION}.fa' (FORMAT FASTA);
+
+query II
+SELECT read_id, sequence1 FROM read_fastx('__TEST_DIR__/fa_headline.R1.fa') ORDER BY sequence_index;
+----
+seq1	ATGCATGCATGC
+seq2	GGCCGGCCGGCC
+
+statement error
+SELECT * FROM read_fastx('__TEST_DIR__/fa_headline.R2.fa');
+----
+
+# Test 19: Contradiction - {ORIENTATION} placeholder combined with INTERLEAVE=true.
+statement error
+COPY (SELECT read_id, comment, sequence1, sequence2 FROM test_fasta_paired) TO '__TEST_DIR__/fa_contradiction.{ORIENTATION}.fa' (FORMAT FASTA, INTERLEAVE true);
+----
+Cannot combine the {ORIENTATION} placeholder with INTERLEAVE=true
+
+# Test 20: Mixed single-end and paired-end records in one COPY -> fail loud (inconsistent).
+statement error
+COPY (
+  SELECT read_id, comment, sequence1, sequence2 FROM test_fasta_paired
+  UNION ALL
+  SELECT read_id, comment, sequence1, sequence2 FROM read_fastx('data/fastq/test.fa')
+) TO '__TEST_DIR__/fa_mixed.{ORIENTATION}.fa' (FORMAT FASTA);
+----
+Inconsistent paired-end data
 
 # Cleanup
 statement ok

--- a/test/sql/copy_fastq.test
+++ b/test/sql/copy_fastq.test
@@ -109,23 +109,29 @@ COPY (SELECT read_id, sequence1 FROM test_single) TO '__TEST_DIR__/error3.fq' (F
 ----
 COPY FORMAT FASTQ requires 'qual1' column
 
-# Test 12: Error - paired data without INTERLEAVE parameter
+# Test 12: Error - genuinely paired data sent to a single-file path
+# (no {ORIENTATION} to split into, INTERLEAVE not requested) -> fail loud with guidance
 statement error
 COPY (SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM test_paired) TO '__TEST_DIR__/error4.fq' (FORMAT FASTQ);
 ----
-INTERLEAVE parameter required for paired-end data
+Use the {ORIENTATION} placeholder
 
-# Test 13: Error - paired data with INTERLEAVE=false but no {ORIENTATION}
+# Test 13: Error - explicit INTERLEAVE=false but no {ORIENTATION} for genuinely paired data.
+# INTERLEAVE=false is the default (single file); split output needs an {ORIENTATION} target.
 statement error
 COPY (SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM test_paired) TO '__TEST_DIR__/error5.fq' (FORMAT FASTQ, INTERLEAVE false);
 ----
-{ORIENTATION} in file path
+Use the {ORIENTATION} placeholder
 
-# Test 14: Error - single-end data with {ORIENTATION}
-statement error
-COPY (SELECT read_id, comment, sequence1, qual1 FROM test_single) TO '__TEST_DIR__/error6.{ORIENTATION}.fq' (FORMAT FASTQ);
+# Test 14: Single-end data (no sequence2/qual2 columns) + {ORIENTATION} now writes the R1 file only.
+statement ok
+COPY (SELECT read_id, comment, sequence1, qual1 FROM test_single ORDER BY sequence_index) TO '__TEST_DIR__/output14.{ORIENTATION}.fq' (FORMAT FASTQ);
+
+query III
+SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/output14.R1.fq') ORDER BY sequence_index;
 ----
-Single-end data cannot use {ORIENTATION}
+read_a1	AAAA	[40, 40, 40, 40]
+read_a2	TTTT	[39, 39, 39, 39]
 
 # Test 15: Error - ID_AS_SEQUENCE_INDEX without sequence_index column
 statement error
@@ -159,6 +165,67 @@ read_a1	AAAA	[40, 40, 40, 40]
 read_a2	TTTT	[39, 39, 39, 39]
 read_b1	GGGG	[38, 38, 38, 38]
 read_b2	CCCC	[37, 37, 37, 37]
+
+# Test 18: Problem #1 - SELECT * from single-end read_fastx carries sequence2/qual2 columns
+# (filled with NULL). Writing to a plain path must produce a single-end file, not error.
+statement ok
+COPY (SELECT * FROM test_single ORDER BY sequence_index) TO '__TEST_DIR__/p1_single.fastq' (FORMAT FASTQ);
+
+query III
+SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/p1_single.fastq') ORDER BY sequence_index;
+----
+read_a1	AAAA	[40, 40, 40, 40]
+read_a2	TTTT	[39, 39, 39, 39]
+
+# Test 19: Problem #2 - paired data + {ORIENTATION} with NO INTERLEAVE parameter -> split R1/R2.
+statement ok
+COPY (SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM test_paired ORDER BY sequence_index) TO '__TEST_DIR__/p2.{ORIENTATION}.fq' (FORMAT FASTQ);
+
+query IIIIII
+SELECT sequence_index, read_id, sequence1, sequence2, qual1, qual2 FROM read_fastx('__TEST_DIR__/p2.R1.fq', sequence2='__TEST_DIR__/p2.R2.fq') ORDER BY sequence_index;
+----
+1	pair_a1	AAAA	TTTT	[40, 40, 40, 40]	[39, 39, 39, 39]
+
+# Test 20: Headline example - SELECT * from single-end (NULL sequence2/qual2) + {ORIENTATION} + gzip.
+# Must write a single R1 file and NOT create an R2 file.
+statement ok
+COPY (SELECT * FROM test_single ORDER BY sequence_index) TO '__TEST_DIR__/headline.{ORIENTATION}.fastq.gz' (FORMAT FASTQ, COMPRESSION gzip);
+
+query III
+SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/headline.R1.fastq.gz') ORDER BY sequence_index;
+----
+read_a1	AAAA	[40, 40, 40, 40]
+read_a2	TTTT	[39, 39, 39, 39]
+
+# The R2 file must not have been created (single-end data).
+statement error
+SELECT * FROM read_fastx('__TEST_DIR__/headline.R2.fastq.gz');
+----
+
+# Test 21: Contradiction - {ORIENTATION} placeholder combined with INTERLEAVE=true.
+statement error
+COPY (SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM test_paired) TO '__TEST_DIR__/contradiction.{ORIENTATION}.fq' (FORMAT FASTQ, INTERLEAVE true);
+----
+Cannot combine the {ORIENTATION} placeholder with INTERLEAVE=true
+
+# Test 22: Mixed single-end and paired-end records in one COPY -> fail loud (inconsistent).
+statement error
+COPY (
+  SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM test_paired
+  UNION ALL
+  SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM test_single
+) TO '__TEST_DIR__/mixed.{ORIENTATION}.fq' (FORMAT FASTQ);
+----
+Inconsistent paired-end data
+
+# Test 23: Malformed FASTQ record - sequence2 set but qual2 NULL.
+statement error
+COPY (
+  SELECT read_id, comment, sequence1, 'TTTT'::VARCHAR AS sequence2, qual1, NULL::UTINYINT[] AS qual2
+  FROM test_single WHERE sequence_index = 1
+) TO '__TEST_DIR__/xor.{ORIENTATION}.fq' (FORMAT FASTQ);
+----
+must both be set
 
 # Cleanup
 statement ok


### PR DESCRIPTION
## Problem

Writing FASTQ/FASTA was awkward. Paired-vs-single was decided purely from **column presence**, but `read_fastx` always emits `sequence2`/`qual2` (NULL for single-end). The fallout, all reported by a user:

1. `SELECT *` from single-end data carries NULL `sequence2`/`qual2`, so it looked "paired" and demanded `INTERLEAVE`.
2. Paired data + `{ORIENTATION}` still errored that `INTERLEAVE` was required, even though the docs call it `false` by default.
3. Single-end data + `{ORIENTATION}` was rejected outright.
4. The natural one-liner — `COPY (SELECT * FROM read_fastx('single_end.fastq.gz')) TO 'out.{ORIENTATION}.fastq.gz' (FORMAT FASTQ, COMPRESSION gzip)` — didn't work.

## New model (shared by both FORMAT FASTQ and FORMAT FASTA)

- **`{ORIENTATION}` in the path is the split-vs-single switch.** Present ⇒ split `R1`/`R2` files; absent ⇒ single file (interleaved iff `INTERLEAVE=true`).
- **Paired-vs-single is decided per record at write time** from R2 NULL-ness, not from column presence. NULL `sequence2`/`qual2` ⇒ the record is single-end.
- **The R2 file is created lazily** on the first non-NULL R2 record, so an all-single-end dataset written with `{ORIENTATION}` produces only the `R1` file (no empty `R2` file).
- **`INTERLEAVE` is now optional**; only `INTERLEAVE=true` forces interleaving.

### Fails loud (instead of guessing or silently corrupting output)
- genuinely paired data sent to a single-file path without `INTERLEAVE=true`,
- `{ORIENTATION}` combined with `INTERLEAVE=true` (contradictory),
- a FASTQ record whose `sequence2`/`qual2` disagree on NULL-ness,
- one COPY that mixes single-end and paired-end records (cross-thread check at finalize).

The fail-loud-vs-silently-interleave choice for the plain-path paired case was made deliberately (it matches the project's "fail loud" rule and never silently mixes R2 into a file the user may have wanted split).

## Verification

- `test/sql/copy_fastq.test` (134 assertions) and `test/sql/copy_fasta.test` (104 assertions) pass, plus the compression/buffering variants and `read_sequences_sam.test`.
- Updated tests for the changed behaviors (formerly tests 12–14 / 10–12) and added coverage for every scenario above.
- End-to-end smoke-tested through the built `duckdb` shell, including the headline one-liner (produces only `out.R1.fastq.gz`).
- `clang-format` (11.0.1) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)