### PR TITLE
perf(copy): multithreaded bgzf gzip for FASTQ/FASTA, threaded BAM writes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1441,6 +1441,7 @@ FetchContent_MakeAvailable(catch2)
 set(TEST_SOURCES
     src/SequenceReader.cpp
     test/cpp/test_SequenceReader.cpp
+    test/cpp/test_DuckDBSeqStream.cpp
     src/QualScore.cpp
     test/cpp/test_QualScore.cpp
     src/qc_algorithms.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,12 +65,14 @@ option(MIINT_ENABLE_SORTMERNA "Build with SortMeRNA rRNA alignment support" ON)
 option(MIINT_ENABLE_GPL_BOUNDARY "Build with gpl-boundary subsystem (process pipes + Arrow IPC over POSIX shm)" ON)
 option(MIINT_ENABLE_UNIFRAC "Build with UniFrac (PCoA / PERMANOVA / Faith PD) support" ON)
 
-# libdeflate: opt-in, Linux-only accelerator for htslib bgzf gzip (FASTQ/FASTA/BAM COPY).
-# Default OFF — new static dependency (see feedback_prefer_embedded_libs); the parallel-bgzf
-# win only matters on multi-core hosts. Hard-gated to Linux: the Windows htslib build is a
-# hand-written config.h/config.mk (no autotools autodetect) and wasm_eh is single-threaded
-# in-browser, so neither benefits. Flip default to ON later to ship it in the Linux distro.
-option(MIINT_ENABLE_LIBDEFLATE "Build htslib bgzf with libdeflate (Linux only)" OFF)
+# libdeflate: Linux-only accelerator for htslib bgzf gzip (FASTQ/FASTA/BAM COPY).
+# Default ON so the shipped Linux binary actually gets the win (~3x over zlib-parallel bgzf,
+# ~37x over the original single-threaded gzip writer; measured 2026-06-03). Hard-gated to
+# Linux below: the Windows htslib build is a hand-written config.h/config.mk (no autotools
+# autodetect) and wasm_eh is single-threaded in-browser, so neither benefits — the gate
+# force-disables them. A missing vcpkg port also soft-disables (find_package below), so
+# default-ON degrades gracefully everywhere it can't apply.
+option(MIINT_ENABLE_LIBDEFLATE "Build htslib bgzf with libdeflate (Linux only)" ON)
 if(MIINT_ENABLE_LIBDEFLATE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
     message(STATUS "MIINT_ENABLE_LIBDEFLATE only supported on Linux; disabling here")
     set(MIINT_ENABLE_LIBDEFLATE OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1494,6 +1494,7 @@ set(TEST_SOURCES
     src/SequenceReader.cpp
     test/cpp/test_SequenceReader.cpp
     test/cpp/test_DuckDBSeqStream.cpp
+    test/cpp/test_CopyFileHandlePipe.cpp
     src/QualScore.cpp
     test/cpp/test_QualScore.cpp
     src/qc_algorithms.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,28 @@ option(MIINT_ENABLE_SORTMERNA "Build with SortMeRNA rRNA alignment support" ON)
 option(MIINT_ENABLE_GPL_BOUNDARY "Build with gpl-boundary subsystem (process pipes + Arrow IPC over POSIX shm)" ON)
 option(MIINT_ENABLE_UNIFRAC "Build with UniFrac (PCoA / PERMANOVA / Faith PD) support" ON)
 
+# libdeflate: opt-in, Linux-only accelerator for htslib bgzf gzip (FASTQ/FASTA/BAM COPY).
+# Default OFF — new static dependency (see feedback_prefer_embedded_libs); the parallel-bgzf
+# win only matters on multi-core hosts. Hard-gated to Linux: the Windows htslib build is a
+# hand-written config.h/config.mk (no autotools autodetect) and wasm_eh is single-threaded
+# in-browser, so neither benefits. Flip default to ON later to ship it in the Linux distro.
+option(MIINT_ENABLE_LIBDEFLATE "Build htslib bgzf with libdeflate (Linux only)" OFF)
+if(MIINT_ENABLE_LIBDEFLATE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(STATUS "MIINT_ENABLE_LIBDEFLATE only supported on Linux; disabling here")
+    set(MIINT_ENABLE_LIBDEFLATE OFF)
+endif()
+if(MIINT_ENABLE_LIBDEFLATE)
+    find_package(libdeflate CONFIG QUIET)
+    if(TARGET libdeflate::libdeflate_static)
+        set(LIBDEFLATE_TARGET libdeflate::libdeflate_static)
+    elseif(TARGET libdeflate::libdeflate_shared)
+        set(LIBDEFLATE_TARGET libdeflate::libdeflate_shared)
+    else()
+        message(WARNING "MIINT_ENABLE_LIBDEFLATE=ON but no libdeflate package found; disabling")
+        set(MIINT_ENABLE_LIBDEFLATE OFF)
+    endif()
+endif()
+
 # libssu_inmem.a / libskbb_inmem.a are compiled with -fopenmp; the final
 # extension must resolve their OpenMP runtime symbols (__kmpc_*, omp_*).
 #
@@ -279,8 +301,8 @@ message(STATUS "Submodule versions: minimap2=${MINIMAP2_GIT_VERSION} WFA2=${WFA2
 
 # Build htslib from release tarball
 # Configure with zstd support if available (htslib autodetects via pkg-config)
-if(HAVE_LIBZSTD)
-    # Set PKG_CONFIG_PATH so htslib configure can find zstd
+if(HAVE_LIBZSTD OR MIINT_ENABLE_LIBDEFLATE)
+    # Set PKG_CONFIG_PATH so htslib configure can find zstd / libdeflate
     set(HTSLIB_PKG_CONFIG_PATH "PKG_CONFIG_PATH=${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET}/lib/pkgconfig")
 else()
     set(HTSLIB_PKG_CONFIG_PATH "")
@@ -365,6 +387,20 @@ else()
     message(WARNING "Could not determine explicit ZLIB library file for HTSlib")
 endif()
 
+# libdeflate (Linux opt-in): point htslib's configure at the vcpkg-installed headers
+# and lib. htslib probes libdeflate via AC_CHECK_HEADER/AC_CHECK_LIB (not pkg-config),
+# so feed -I/-L directly rather than trusting libdeflate.pc. --with-libdeflate makes it
+# mandatory: configure errors loudly if not found (Rule 10) instead of silently using zlib.
+if(MIINT_ENABLE_LIBDEFLATE)
+    set(HTSLIB_VCPKG_ROOT ${CMAKE_CURRENT_BINARY_DIR}/vcpkg_installed/${VCPKG_TARGET_TRIPLET})
+    set(HTSLIB_CFLAGS  "${HTSLIB_CFLAGS} -I${HTSLIB_VCPKG_ROOT}/include")
+    set(HTSLIB_LDFLAGS "${HTSLIB_LDFLAGS} -L${HTSLIB_VCPKG_ROOT}/lib")
+    set(HTSLIB_LIBDEFLATE_FLAG --with-libdeflate)
+    message(STATUS "HTSlib will build WITH libdeflate from ${HTSLIB_VCPKG_ROOT}")
+else()
+    set(HTSLIB_LIBDEFLATE_FLAG --without-libdeflate)
+endif()
+
 if(WIN32)
     # Windows/MinGW: skip autotools configure (requires full MSYS2 shell which is
     # not available in DuckDB's rtools42 CI environment). Instead, generate config.h
@@ -429,7 +465,7 @@ else()
             --disable-libcurl
             --disable-bz2
             --disable-lzma
-            --without-libdeflate
+            ${HTSLIB_LIBDEFLATE_FLAG}
         BUILD_COMMAND ${HTSLIB_BUILD_COMMAND}
         INSTALL_COMMAND ${HTSLIB_INSTALL_COMMAND}
         BUILD_IN_SOURCE 0
@@ -1226,6 +1262,10 @@ endif()
 if(MIINT_ENABLE_HDF5 AND HDF5_FOUND)
     target_compile_definitions(${EXTENSION_NAME} PRIVATE MIINT_HAS_HDF5)
 endif()
+if(MIINT_ENABLE_LIBDEFLATE)
+    # Include dirs propagate from the linked imported target's interface.
+    target_compile_definitions(${EXTENSION_NAME} PRIVATE MIINT_HAS_LIBDEFLATE)
+endif()
 if(MIINT_ENABLE_SORTMERNA)
     target_compile_definitions(${EXTENSION_NAME} PRIVATE MIINT_HAS_SORTMERNA)
 endif()
@@ -1326,6 +1366,10 @@ endif()
 if(HAVE_LIBZSTD)
     target_link_libraries(${EXTENSION_NAME} ${ZSTD_TARGET})
 endif()
+# libdeflate appended AFTER the hts-containing block above, so -ldeflate follows -lhts.
+if(MIINT_ENABLE_LIBDEFLATE)
+    target_link_libraries(${EXTENSION_NAME} ${LIBDEFLATE_TARGET})
+endif()
 
 target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE RYPE_ARROW
     MIINT_STATIC_BUILD
@@ -1348,6 +1392,9 @@ if(MIINT_ENABLE_ABPOA)
 endif()
 if(MIINT_ENABLE_HDF5 AND HDF5_FOUND)
     target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE MIINT_HAS_HDF5)
+endif()
+if(MIINT_ENABLE_LIBDEFLATE)
+    target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE MIINT_HAS_LIBDEFLATE)
 endif()
 if(MIINT_ENABLE_SORTMERNA)
     target_compile_definitions(${LOADABLE_EXTENSION_NAME} PRIVATE MIINT_HAS_SORTMERNA)
@@ -1418,6 +1465,9 @@ elseif(UNIX)
 endif()
 if(HAVE_LIBZSTD)
     target_link_libraries(${LOADABLE_EXTENSION_NAME} ${ZSTD_TARGET})
+endif()
+if(MIINT_ENABLE_LIBDEFLATE)
+    target_link_libraries(${LOADABLE_EXTENSION_NAME} ${LIBDEFLATE_TARGET})
 endif()
 # The loadable extension is dlopen'd at runtime. When the host DuckDB is loaded
 # via Python (RTLD_LOCAL), duckdb_je_* symbols from the host are not visible.
@@ -1665,6 +1715,9 @@ if(MIINT_ENABLE_VSEARCH AND MIINT_ENABLE_CURL AND UNIX AND NOT APPLE)
 endif()
 if(HAVE_LIBZSTD)
     target_link_libraries(tests ${ZSTD_TARGET})
+endif()
+if(MIINT_ENABLE_LIBDEFLATE)
+    target_link_libraries(tests ${LIBDEFLATE_TARGET})
 endif()
 if(MIINT_ENABLE_UNIFRAC)
     target_include_directories(tests PRIVATE

--- a/bench/copy_fastx/.gitignore
+++ b/bench/copy_fastx/.gitignore
@@ -1,0 +1,3 @@
+# Benchmark inputs/outputs are large and machine-specific; keep them local.
+data/
+results/

--- a/bench/copy_fastx/README.md
+++ b/bench/copy_fastx/README.md
@@ -1,0 +1,87 @@
+# COPY ... FORMAT {fastq,fasta} write-path benchmark
+
+Empirical harness to measure the FASTQ/FASTA **write** (`COPY ... TO`) throughput,
+compressed and uncompressed, on real microbiome data — so we can establish a
+baseline now and re-run it to verify the gains from any writer changes later.
+
+These scripts only *collect* data. They do not modify the extension.
+
+## Prerequisites
+
+- The miint extension built: `./build/release/duckdb` (the preloaded shell).
+  If you only have the loadable extension, point a vanilla shell at it with
+  `MIINT_DUCKDB=/path/to/duckdb MIINT_EXT=/path/to/miint.duckdb_extension`.
+- Network access to EBI/ENA (the stage step streams over `httpfs`).
+
+## 1. Fetch / stage data (once)
+
+```bash
+bash bench/copy_fastx/fetch_data.sh
+```
+
+- Uses the extension's own `read_ena_sequences` (over `httpfs`) to stream a real
+  paired Illumina WGS metagenome run straight into `data/staged.parquet` — the
+  same code path the project ships, no hand-rolled downloads.
+- Default run is **ERR10677119** (PRJEB11419, ~7.8M read pairs). Override with
+  `ACCESSION=ERRxxxxxx`, or cap reads with `MAX_SEQUENCES=N` for fast iteration.
+- Idempotent: re-running skips staging if `data/staged.parquet` exists.
+
+Outputs land in `bench/copy_fastx/data/` (git-ignored): `staged.parquet` plus a
+`staged.meta` with the row counts and per-read payload sizes.
+
+## 2. Run the benchmark
+
+```bash
+bash bench/copy_fastx/run_bench.sh
+```
+
+What it does:
+1. **Stages once** (via `fetch_data.sh`): streams the ENA run into
+   `data/staged.parquet` so network + FASTQ decode are excluded from write timing.
+2. For each matrix cell it starts a fresh in-memory DuckDB, loads the parquet
+   into a temp table, sets `PRAGMA threads` and `preserve_insertion_order`,
+   then times **only** the `COPY` via `.timer`.
+3. Appends one row per repeat to `results/bench_<commit>_<ts>.csv`.
+
+### Matrix (all overridable via env)
+
+| dimension   | default            | why it's here |
+|-------------|--------------------|---------------|
+| `FORMATS`   | `fastq fasta`      | both share the writer |
+| `LAYOUTS`   | `single split`     | `single` = single-end one file; `split` = paired `{ORIENTATION}` R1/R2 (the order-sensitive case) |
+| `COMPS`     | `none gzip`        | isolates encoder cost vs gzip cost |
+| `ORDERS`    | `reorder preserve` | `reorder` = `preserve_insertion_order=false`, the knob that *gates a parallel copy sink*; `preserve` is the correctness control |
+| `THREADS`   | `1 <nproc>`        | 1 vs many |
+| `REPEATS`   | `3`                | fastest repeat is reported |
+
+Add `interleave` to `LAYOUTS` for the paired-interleaved path.
+
+### Reading the baseline
+
+On the current code the writer never opts into parallelism, so **`threads=1`
+and `threads=N` should produce nearly identical times** — that flat line *is*
+the finding. The `none` vs `gzip` gap shows how much of the wall time is gzip
+(expected to dominate for `.gz`). After a change, re-run and compare:
+
+```bash
+./build/release/duckdb -box :memory: \
+  "SELECT format, layout, compression, \"order\", threads,
+          min(wall_s) best_s, max(output_MBps) best_MBps
+   FROM read_csv('bench/copy_fastx/results/*.csv')
+   GROUP BY ALL ORDER BY 1,2,3,4,5"
+```
+
+The `commit` column tags every row, so before/after rows are unambiguous even
+in the same CSV glob.
+
+## Notes / caveats
+
+- COPY outputs go to `OUTDIR` (default `$TMPDIR/miint_copybench_out`) with unique
+  names and are **truncated** (not deleted) after their size is recorded, to
+  bound disk use without using `rm`. You can clear that dir yourself.
+- `output_MBps` is bytes that actually hit disk / wall. For `gzip` rows that is
+  *compressed* throughput; compare `none` vs `gzip` at equal `(format,layout)` to
+  see the compression tax.
+- This harness covers the FASTX writer only. SAM/BAM is a separate write path
+  (needs aligned input) and is analyzed in the parent discussion, not measured
+  here.

--- a/bench/copy_fastx/compressor_probe.sh
+++ b/bench/copy_fastx/compressor_probe.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Isolate WHY `COPY ... FORMAT fastq` with gzip is slow, and quantify the ceiling
+# achievable with compressors we already have (htslib bgzf) vs the current path.
+#
+# Produces a real uncompressed FASTQ sample from the staged ENA data, then times
+# every available compressor at level 6 (DuckDB's default), single- vs
+# multi-threaded, plus an isolated zlib mem_level=1-vs-8 test (DuckDB inits gzip
+# with mem_level=1) and DuckDB's own COPY on the same sample.
+#
+# `bgzip` here IS htslib's bgzf CLI (the library we embed). pigz/libdeflate are
+# only ceiling references and are NOT proposed as dependencies.
+#
+# Re-run after changing the writer to confirm the in-process path matches.
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+DUCKDB="${MIINT_DUCKDB:-$REPO_ROOT/build/release/duckdb}"
+PQ="${MIINT_BENCH_DATA_DIR:-$SCRIPT_DIR/data}/staged.parquet"
+S="${OUTDIR:-${TMPDIR:-/tmp}/miint_cmp}"
+N="${SAMPLE_READS:-2000000}"
+mkdir -p "$S"
+[[ -f "$PQ" ]] || { echo "stage data first: bash $SCRIPT_DIR/fetch_data.sh" >&2; exit 1; }
+
+export TIMEFORMAT='%R'
+run() { local name="$1"; shift; local t; t=$( { time "$@" >/dev/null 2>/dev/null; } 2>&1 ); \
+  awk -v n="$name" -v b="$BYTES" -v t="$t" 'BEGIN{printf "%-26s %7.2fs  %8.1f MB/s in\n", n, t, (b/1048576.0)/t}'; }
+
+if [[ ! -f "$S/sample.fq" ]]; then
+  echo "Producing ${N}-read uncompressed FASTQ sample ..."
+  "$DUCKDB" -batch :memory: \
+    "COPY (SELECT read_id, comment, sequence1, qual1 FROM read_parquet('$PQ') LIMIT $N) TO '$S/sample.fq' (FORMAT FASTQ);" >/dev/null
+fi
+BYTES=$(stat -c %s "$S/sample.fq"); echo "sample: $BYTES bytes (~$((BYTES/1048576)) MB)"
+
+NPROC="$(nproc)"
+echo "=== single-threaded (level 6) ==="
+command -v gzip            >/dev/null && run "gzip -6"             bash -c "gzip -6 -c '$S/sample.fq'"
+command -v libdeflate-gzip >/dev/null && run "libdeflate-gzip -6 (ref)" bash -c "libdeflate-gzip -6 -c '$S/sample.fq'"
+command -v bgzip           >/dev/null && run "bgzip -l6 -@1 (htslib)" bash -c "bgzip -l6 -c -@1 '$S/sample.fq'"
+command -v pigz            >/dev/null && run "pigz -6 -p1 (ref)"    bash -c "pigz -6 -p1 -c '$S/sample.fq'"
+echo "=== multi-threaded (level 6, $NPROC threads) ==="
+command -v bgzip           >/dev/null && run "bgzip -l6 -@$NPROC (htslib)" bash -c "bgzip -l6 -c -@$NPROC '$S/sample.fq'"
+command -v pigz            >/dev/null && run "pigz -6 -p$NPROC (ref)"  bash -c "pigz -6 -p$NPROC -c '$S/sample.fq'"
+
+echo "=== DuckDB COPY gzip on the same sample (current path) ==="
+t=$( { time "$DUCKDB" -batch :memory: \
+  "COPY (SELECT read_id, comment, sequence1, qual1 FROM read_parquet('$PQ') LIMIT $N) TO '$S/ddb.fq.gz' (FORMAT FASTQ, COMPRESSION gzip);" >/dev/null 2>&1; } 2>&1 )
+awk -v b="$BYTES" -v t="$t" 'BEGIN{printf "DuckDB COPY gzip           %7.2fs  %8.1f MB/s in\n", t, (b/1048576.0)/t}'
+
+echo "=== compressed size / ratio (level 6) ==="
+for f in "$S"/*.gz; do [[ -f "$f" ]] && printf '  %-14s %s bytes\n' "$(basename "$f")" "$(stat -c %s "$f")"; done
+
+echo "=== isolate zlib mem_level (DuckDB inits gzip with mem_level=1; default is 8) ==="
+head -c $((150*1024*1024)) "$S/sample.fq" > "$S/slice.fq"
+python3 - "$S/slice.fq" <<'PY'
+import sys, zlib, time
+data = open(sys.argv[1], 'rb').read(); mb = len(data)/1048576
+for ml in (1, 8):
+    c = zlib.compressobj(6, zlib.DEFLATED, -15, ml)
+    t0 = time.perf_counter(); out = c.compress(data) + c.flush(); dt = time.perf_counter() - t0
+    print(f"  memLevel={ml}: {dt:6.2f}s  {mb/dt:6.1f} MB/s in   out={len(out)} bytes")
+PY

--- a/bench/copy_fastx/fetch_data.sh
+++ b/bench/copy_fastx/fetch_data.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Stage real microbiome paired-end sequence data from ENA into a Parquet file for
+# the COPY-format write benchmark (run_bench.sh). Uses the extension's own
+# `read_ena_sequences` table function (over httpfs) rather than hand-rolled
+# downloads, so it goes through the same code path the project ships.
+#
+# One-time + idempotent: re-running skips staging if data/staged.parquet exists.
+#
+# Default accession is a paired Illumina WGS metagenome run from study PRJEB11419
+# (~7.8M read pairs, ~640MB compressed). Pick a different one with ACCESSION=...,
+# or cap the read count with MAX_SEQUENCES for faster iteration.
+#
+# Env knobs:
+#   ACCESSION             ENA run accession (default ERR10677119)
+#   MAX_SEQUENCES         cap reads per run, 0 = full run (default 0)
+#   MIINT_DUCKDB          duckdb shell with miint preloaded (default build/release/duckdb)
+#   MIINT_EXT             if set, `LOAD '<path>'` is issued first (vanilla shell)
+#   MIINT_BENCH_DATA_DIR  output dir (default ./data next to this script)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DUCKDB="${MIINT_DUCKDB:-$REPO_ROOT/build/release/duckdb}"
+DATA_DIR="${MIINT_BENCH_DATA_DIR:-$SCRIPT_DIR/data}"
+STAGED="$DATA_DIR/staged.parquet"
+STAGED_META="$DATA_DIR/staged.meta"
+ACCESSION="${ACCESSION:-ERR10677119}"
+MAX_SEQUENCES="${MAX_SEQUENCES:-0}"
+
+mkdir -p "$DATA_DIR"
+
+log() { printf '[fetch] %s\n' "$*" >&2; }
+die() { printf '[fetch] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ -x "$DUCKDB" ]] || die "duckdb shell not found/executable: $DUCKDB (build it, or set MIINT_DUCKDB)"
+
+LOAD_EXT=""
+[[ -n "${MIINT_EXT:-}" ]] && LOAD_EXT="LOAD '${MIINT_EXT}';"
+
+if [[ -f "$STAGED" && -f "$STAGED_META" ]]; then
+	log "Staged parquet already present: $STAGED"
+	sed 's/^/[fetch]   /' "$STAGED_META" >&2
+	exit 0
+fi
+
+# Optional read cap.
+max_clause=""
+[[ "$MAX_SEQUENCES" != "0" ]] && max_clause=", max_sequences => $MAX_SEQUENCES"
+
+log "Staging ENA run $ACCESSION -> $STAGED via read_ena_sequences (one-time) ..."
+log "(streaming over httpfs; this hits EBI/ENA and may take a minute)"
+
+"$DUCKDB" -batch :memory: 2>&1 <<SQL | sed 's/^/[fetch]   /' >&2
+LOAD httpfs;
+$LOAD_EXT
+COPY (
+    SELECT sequence_index, read_id, comment, sequence1, sequence2, qual1, qual2
+    FROM read_ena_sequences('$ACCESSION'$max_clause)
+) TO '$STAGED' (FORMAT PARQUET);
+SQL
+
+[[ -f "$STAGED" ]] || die "staging produced no parquet (see output above)"
+
+log "Computing staged metadata ..."
+"$DUCKDB" -batch -noheader -list :memory: > "$STAGED_META" <<SQL || die "metadata query failed"
+$LOAD_EXT
+SELECT 'accession=$ACCESSION';
+SELECT 'rows=' || count(*) FROM read_parquet('$STAGED');
+SELECT 'paired_rows=' || count(*) FROM read_parquet('$STAGED') WHERE sequence2 IS NOT NULL;
+SELECT 'r1_bytes=' || coalesce(sum(length(sequence1) + length(qual1)), 0) FROM read_parquet('$STAGED');
+SELECT 'r2_bytes=' || coalesce(sum(length(sequence2) + length(qual2)), 0) FROM read_parquet('$STAGED') WHERE sequence2 IS NOT NULL;
+SQL
+
+log "Staged. Metadata:"
+sed 's/^/[fetch]   /' "$STAGED_META" >&2
+log "Parquet: $(ls -lh "$STAGED" | awk '{print $5}')  ($STAGED)"
+log "Run the benchmark with: bash $SCRIPT_DIR/run_bench.sh"

--- a/bench/copy_fastx/run_bench.sh
+++ b/bench/copy_fastx/run_bench.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+#
+# Benchmark the COPY ... FORMAT {fastq,fasta} WRITE path, compressed and
+# uncompressed, on real microbiome data fetched by fetch_data.sh.
+#
+# Design goals:
+#   * Measure ONLY the COPY statement, not FASTQ decode. We stage the data into a
+#     Parquet file once and load it into an in-memory temp table per run, then
+#     time just the COPY via DuckDB's `.timer`.
+#   * Be re-runnable and append-only: every row is tagged with the git commit and
+#     thread count, so a baseline collected today can be compared against a run
+#     after the writer is parallelized. Threads=1 vs threads=N showing NO
+#     difference today is the expected baseline (the writer ignores parallelism);
+#     a future run should show N pulling ahead.
+#   * Touch no files destructively. Outputs go to unique paths under OUTDIR and
+#     are truncated (not removed) after their size is recorded, to bound disk use
+#     without using `rm` (a project hard rule).
+#
+# Usage:
+#   bash run_bench.sh                 # stage (once) + run the default matrix
+#   FORMATS="fastq" COMPS="gzip" THREADS="1 8" REPEATS=1 bash run_bench.sh
+#
+# Env knobs (all optional):
+#   MIINT_DUCKDB     duckdb shell with the miint extension (default build/release/duckdb)
+#   MIINT_EXT        if set, `LOAD '<path>'` is issued (for a vanilla duckdb shell)
+#   MIINT_BENCH_DATA_DIR  data dir written by fetch_data.sh (default ./data)
+#   OUTDIR           where COPY outputs are written (default $TMPDIR/miint_copybench_out)
+#   RESULTS_CSV      results file (default ./results/bench_<commit>_<ts>.csv)
+#   FORMATS          space list subset of {fastq fasta}   (default both)
+#   LAYOUTS          space list subset of {single interleave split} (default "single split")
+#   COMPS            space list subset of {none gzip}      (default both)
+#   ORDERS           space list subset of {reorder preserve} (default both)
+#   THREADS          space list of thread counts           (default "1 <nproc>")
+#   REPEATS          repeats per cell, fastest is reported  (default 3)
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DUCKDB="${MIINT_DUCKDB:-$REPO_ROOT/build/release/duckdb}"
+DATA_DIR="${MIINT_BENCH_DATA_DIR:-$SCRIPT_DIR/data}"
+STAGED="$DATA_DIR/staged.parquet"
+STAGED_META="$DATA_DIR/staged.meta"
+OUTDIR="${OUTDIR:-${TMPDIR:-/tmp}/miint_copybench_out}"
+
+NPROC="$(nproc 2>/dev/null || echo 4)"
+FORMATS="${FORMATS:-fastq fasta}"
+LAYOUTS="${LAYOUTS:-single split}"
+COMPS="${COMPS:-none gzip}"
+ORDERS="${ORDERS:-reorder preserve}"
+THREADS="${THREADS:-1 $NPROC}"
+REPEATS="${REPEATS:-3}"
+
+COMMIT="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || echo nogit)"
+DIRTY=""
+git -C "$REPO_ROOT" diff --quiet 2>/dev/null || DIRTY="+dirty"
+RUN_ID="$(date +%Y%m%d_%H%M%S)"
+RESULTS_CSV="${RESULTS_CSV:-$SCRIPT_DIR/results/bench_${COMMIT}${DIRTY}_${RUN_ID}.csv}"
+
+mkdir -p "$OUTDIR" "$(dirname "$RESULTS_CSV")"
+
+log() { printf '[bench] %s\n' "$*" >&2; }
+die() { printf '[bench] ERROR: %s\n' "$*" >&2; exit 1; }
+
+[[ -x "$DUCKDB" ]] || die "duckdb shell not found/executable: $DUCKDB (build it, or set MIINT_DUCKDB)"
+
+# LOAD line for a vanilla shell; empty for the preloaded project shell.
+LOAD_SQL=""
+[[ -n "${MIINT_EXT:-}" ]] && LOAD_SQL="LOAD '${MIINT_EXT}';"
+
+# Run a SQL script (stdin) through duckdb in-memory; return combined output.
+run_sql() { "$DUCKDB" -batch :memory: 2>&1; }
+
+# ---------------------------------------------------------------------------
+# Stage once: ENA run -> Parquet (delegated to fetch_data.sh, idempotent).
+# ---------------------------------------------------------------------------
+stage() {
+	if [[ -f "$STAGED" && -f "$STAGED_META" ]]; then
+		log "Staged parquet already present: $STAGED"
+		return
+	fi
+	log "No staged parquet yet; running fetch_data.sh (one-time ENA stage) ..."
+	bash "$SCRIPT_DIR/fetch_data.sh" || die "fetch_data.sh failed"
+	[[ -f "$STAGED" && -f "$STAGED_META" ]] || die "staging did not produce $STAGED"
+}
+
+ROWS=0
+read_meta() { ROWS="$(awk -F= '/^rows=/{print $2}' "$STAGED_META")"; }
+
+# ---------------------------------------------------------------------------
+# Build the SELECT, COPY options, file extension and output spec for a cell.
+# ---------------------------------------------------------------------------
+make_select() {  # $1=format $2=layout -> echoes SELECT list + FROM
+	local fmt="$1" layout="$2"
+	case "$layout" in
+		single)
+			if [[ "$fmt" == fastq ]]; then echo "SELECT read_id, comment, sequence1, qual1 FROM src";
+			else echo "SELECT read_id, comment, sequence1 FROM src"; fi ;;
+		interleave|split)
+			if [[ "$fmt" == fastq ]]; then echo "SELECT read_id, comment, sequence1, sequence2, qual1, qual2 FROM src WHERE sequence2 IS NOT NULL";
+			else echo "SELECT read_id, comment, sequence1, sequence2 FROM src WHERE sequence2 IS NOT NULL"; fi ;;
+	esac
+}
+
+ext_for() {  # $1=format $2=comp -> file extension
+	local fmt="$1" comp="$2" base
+	[[ "$fmt" == fastq ]] && base="fq" || base="fa"
+	[[ "$comp" == gzip ]] && echo "$base.gz" || echo "$base"
+}
+
+copy_opts() {  # $1=format $2=layout $3=comp -> COPY options paren content
+	local fmt="$1" layout="$2" comp="$3" opts
+	[[ "$fmt" == fastq ]] && opts="FORMAT FASTQ" || opts="FORMAT FASTA"
+	[[ "$layout" == interleave ]] && opts="$opts, INTERLEAVE true"
+	[[ "$comp" == gzip ]] && opts="$opts, COMPRESSION gzip"
+	echo "$opts"
+}
+
+# Sum the byte size(s) of a run's output, then truncate to reclaim disk (no rm).
+measure_output() {  # $1=layout $2=basepath $3=ext -> echoes total bytes
+	local layout="$1" base="$2" ext="$3" total=0 f
+	local files=()
+	if [[ "$layout" == split ]]; then
+		files=("$base.R1.$ext" "$base.R2.$ext")
+	else
+		files=("$base.$ext")
+	fi
+	for f in "${files[@]}"; do
+		[[ -f "$f" ]] || { echo "MISSING:$f" >&2; echo 0; return; }
+		total=$(( total + $(stat -c '%s' "$f") ))
+		: > "$f"   # truncate, do not delete
+	done
+	echo "$total"
+}
+
+# ---------------------------------------------------------------------------
+# Main matrix
+# ---------------------------------------------------------------------------
+stage
+read_meta
+log "rows=$ROWS  commit=${COMMIT}${DIRTY}  nproc=$NPROC"
+log "matrix: FORMATS=[$FORMATS] LAYOUTS=[$LAYOUTS] COMPS=[$COMPS] ORDERS=[$ORDERS] THREADS=[$THREADS] REPEATS=$REPEATS"
+log "results -> $RESULTS_CSV"
+
+printf 'timestamp,commit,nproc,format,layout,compression,order,threads,repeat,rows,output_bytes,wall_s,output_MBps,records_per_s\n' > "$RESULTS_CSV"
+
+counter=0
+for fmt in $FORMATS; do
+  for layout in $LAYOUTS; do
+    sel="$(make_select "$fmt" "$layout")"
+    for comp in $COMPS; do
+      ext="$(ext_for "$fmt" "$comp")"
+      opts="$(copy_opts "$fmt" "$layout" "$comp")"
+      for order in $ORDERS; do
+        # 'reorder' lets DuckDB drop insertion order (the knob that gates a
+        # parallel copy sink); 'preserve' keeps it (the correctness control).
+        if [[ "$order" == reorder ]]; then pio="false"; else pio="true"; fi
+        for th in $THREADS; do
+          for rep in $(seq 1 "$REPEATS"); do
+            counter=$((counter+1))
+            base="$OUTDIR/r_${fmt}_${layout}_${comp}_${order}_t${th}_${rep}_${counter}"
+            if [[ "$layout" == split ]]; then
+              outpath="$base.{ORIENTATION}.$ext"
+            else
+              outpath="$base.$ext"
+            fi
+
+            sql="$LOAD_SQL
+PRAGMA threads=$th;
+SET preserve_insertion_order=$pio;
+CREATE TEMP TABLE src AS SELECT * FROM read_parquet('$STAGED');
+.timer on
+COPY ($sel) TO '$outpath' ($opts);"
+
+            out="$(printf '%s\n' "$sql" | run_sql)" || {
+              printf '%s\n' "$out" | sed 's/^/[bench]   /' >&2
+              die "COPY failed for $fmt/$layout/$comp/$order/t$th"
+            }
+            wall="$(printf '%s\n' "$out" | awk '/Run Time/{t=$5} END{print t}')"
+            [[ -n "$wall" ]] || { printf '%s\n' "$out" | sed 's/^/[bench]   /' >&2; die "could not parse timer output"; }
+
+            obytes="$(measure_output "$layout" "$base" "$ext")"
+            mbps="$(awk -v b="$obytes" -v t="$wall" 'BEGIN{ if(t>0) printf "%.2f", (b/1048576.0)/t; else print "NA" }')"
+            rps="$(awk -v r="$ROWS" -v t="$wall" 'BEGIN{ if(t>0) printf "%.0f", r/t; else print "NA" }')"
+
+            printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+              "$(date +%FT%T)" "${COMMIT}${DIRTY}" "$NPROC" "$fmt" "$layout" "$comp" "$order" "$th" "$rep" \
+              "$ROWS" "$obytes" "$wall" "$mbps" "$rps" >> "$RESULTS_CSV"
+            log "$fmt/$layout/$comp/$order t=$th rep=$rep : ${wall}s  ${mbps} MB/s  out=${obytes}B"
+          done
+        done
+      done
+    done
+  done
+done
+
+# ---------------------------------------------------------------------------
+# Summary: fastest repeat per (format,layout,compression,order,threads)
+# ---------------------------------------------------------------------------
+log "Summary (fastest of $REPEATS repeats per cell):"
+"$DUCKDB" -batch -box :memory: 2>/dev/null <<SQL || true
+SELECT format, layout, compression, "order", threads,
+       min(wall_s) AS best_s,
+       max(output_MBps) AS best_MBps,
+       max(records_per_s) AS best_rec_s
+FROM read_csv('$RESULTS_CSV')
+GROUP BY ALL
+ORDER BY format, layout, compression, "order", threads;
+SQL
+
+log "Done. CSV: $RESULTS_CSV"
+log "Compare two CSVs later with, e.g.:"
+log "  $DUCKDB -box :memory: \"SELECT * FROM read_csv('$SCRIPT_DIR/results/*.csv')\""

--- a/docs/copy-formats.md
+++ b/docs/copy-formats.md
@@ -30,7 +30,7 @@ Write query results to FASTQ format files. Requires `read_id`, `sequence1`, and 
 - `INCLUDE_COMMENT` (default: false): Include comment field in output
 - `ID_AS_SEQUENCE_INDEX` (default: false): Use `sequence_index` as identifier instead of `read_id`
 - `INTERLEAVE` (default: false): When the data is paired-end, write R1/R2 interleaved into a single file. Optional — see "Single-end vs paired-end output" below. Cannot be combined with the `{ORIENTATION}` placeholder.
-- `COMPRESSION` (default: auto): Enable gzip compression (auto-detected from `.gz` extension)
+- `COMPRESSION` (default: auto): Enable gzip compression (auto-detected from `.gz` extension). Local `.gz` output is written as **BGZF** (block-gzip via htslib): a fully standard gzip file readable by any gzip tool, but compressed in parallel — it follows DuckDB's thread count (`PRAGMA threads`) and runs ~10x faster than single-threaded gzip on multi-core hosts, while staying block-indexable. Output order is preserved. (Remote `scheme://` targets fall back to single-threaded gzip.)
 
 **Single-end vs paired-end output:**
 
@@ -91,7 +91,7 @@ Write query results to FASTA format files. Requires `read_id` and `sequence1` co
 - `INCLUDE_COMMENT` (default: false): Include comment field in output
 - `ID_AS_SEQUENCE_INDEX` (default: false): Use `sequence_index` as identifier instead of `read_id`
 - `INTERLEAVE` (default: false): When the data is paired-end, write R1/R2 interleaved into a single file. Optional — see "Single-end vs paired-end output" below. Cannot be combined with the `{ORIENTATION}` placeholder.
-- `COMPRESSION` (default: auto): Enable gzip compression (auto-detected from `.gz` extension)
+- `COMPRESSION` (default: auto): Enable gzip compression (auto-detected from `.gz` extension). Local `.gz` output is written as **BGZF** (block-gzip via htslib): a fully standard gzip file readable by any gzip tool, but compressed in parallel — it follows DuckDB's thread count (`PRAGMA threads`) and runs ~10x faster than single-threaded gzip on multi-core hosts, while staying block-indexable. Output order is preserved. (Remote `scheme://` targets fall back to single-threaded gzip.)
 
 **Single-end vs paired-end output:**
 
@@ -148,6 +148,7 @@ Write query results to SAM or BAM format files. Requires all mandatory SAM colum
 - `SEQUENCE_DATA` (VARCHAR, optional): Table or view name containing original read sequences from `read_fastx`. When provided, writes actual SEQ and QUAL fields into the output instead of `*`. See [Sequence Data](#sequence-data) below.
 - `COMPRESSION` (default: auto, SAM only): Enable gzip compression (auto-detected from `.gz` extension)
 - `COMPRESSION_LEVEL` (BAM only): BGZF compression level 0-9 (default: 6). Higher = better compression, slower speed.
+- **Multithreaded compression:** BAM and gzip-SAM output compress in parallel, following DuckDB's thread count (`PRAGMA threads`). Record order is preserved and the output is byte-identical to single-threaded writing. (The speedup is smaller than for FASTQ/FASTA because per-record marshalling is serialized; only the BGZF compression is parallelized.)
 
 **SAM Format Examples:**
 ```sql

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -5,7 +5,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 ## Table of Contents
 
 - [`read_alignments`](#read_alignmentsfilename-reference_lengthstable_name-include_filepathfalse-include_seq_qualfalse) - SAM/BAM alignment files
-- [`read_fastx`](#read_fastxfilename-sequence2filename-include_filepathfalse-qual_offset33) - FASTA/FASTQ sequence files
+- [`read_fastx`](#read_fastxfilename-sequence2filename-include_filepathfalse-qual_offset33-max_batch_bytes512mib) - FASTA/FASTQ sequence files
 - [`read_sequences_sff`](#read_sequences_sfffilename-include_filepathfalse-trimtrue) - SFF (454/Roche) sequence files
 - [`read_mzml`](#read_mzmlfilename-include_filepathfalse) - mzML mass spectrometry files
 - [`read_mzxml`](#read_mzxmlfilename-include_filepathfalse) - mzXML mass spectrometry files
@@ -213,7 +213,7 @@ FROM alignment_slice('chr1_alns', 1000, 2000);
 - Multi-region slicing (different regions per reference) is not yet supported; use separate queries per region
 - `alignment_seq_identity` with the `'cigar'` method works on sliced output because it reads identity directly from `=`/`X` CIGAR ops without needing tags. Other methods (`gap_compressed`, `blast`, `gap_excluded`) require NM or MD tags which are NULLed after trimming.
 
-## `read_fastx(filename, [sequence2=filename], [include_filepath=false], [qual_offset=33])`
+## `read_fastx(filename, [sequence2=filename], [include_filepath=false], [qual_offset=33], [max_batch_bytes='512MiB'])`
 Read FASTA/FASTQ sequence files.
 
 **Parameters:**
@@ -224,6 +224,7 @@ Read FASTA/FASTQ sequence files.
   - **Paired-end with globs**: When `filename` is a glob pattern, `sequence2` must also be a glob pattern. Both are expanded and sorted independently, then paired by position. The expanded file counts must match.
 - `include_filepath` (BOOLEAN, optional, default false): Add filepath column to output
 - `qual_offset` (INTEGER, optional, default 33): Quality score offset (33 for Phred+33, 64 for Phred+64)
+- `max_batch_bytes` (VARCHAR, optional, default `'512MiB'`): Soft cap on the uncompressed sequence+quality bytes buffered per output chunk, given as a formatted byte size (e.g. `'256MiB'`, `'2GB'`). The reader stops adding records to a chunk once their combined bytes reach this budget, which bounds memory when individual records are very large (e.g. assembled genomes at multiple MB each). Short-read data is unaffected — a chunk fills to the standard vector size long before the cap. Must be greater than 0.
 
 **Output schema:**
 - `sequence_index` (BIGINT): 1-based sequential index per file (resets to 1 for each file when reading multiple files)

--- a/src/copy_format_common.cpp
+++ b/src/copy_format_common.cpp
@@ -1,6 +1,12 @@
 #include "copy_format_common.hpp"
+#include "remote_file_helper.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/numeric_utils.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
+
+#include <htslib-1.22.1/htslib/bgzf.h>
+#include <cerrno>
 
 namespace duckdb {
 
@@ -25,10 +31,11 @@ void FormatWriterState::Reset() {
 // Format Writer Helper Functions
 //===--------------------------------------------------------------------===//
 // Write the accumulated local buffer to the file in <= 1 GiB slices, then reset the buffer.
-// Caller must hold the global lock. DuckDB's MiniZStreamWrapper (the gzip path) casts the write
-// size to unsigned int internally, so a single write larger than 4 GiB throws "Information loss
-// on integer cast". Chunking keeps every underlying compressor call within 32-bit bounds
-// regardless of how much the local MemoryStream accumulated.
+// Caller must hold the global lock. This guards every CopyFileHandle::Write backend, not just one:
+// the remote-gzip fallback goes through DuckDB's MiniZStreamWrapper, which casts the write size to
+// unsigned int and throws "Information loss on integer cast" on a single >4 GiB write; chunking
+// keeps that (and any 32-bit limit in the bgzf/BufferedFileWriter backends) safe regardless of how
+// much the local MemoryStream accumulated.
 static void WriteBufferToFile(CopyFileHandle &file, FormatWriterState &local_state) {
 	constexpr idx_t MAX_WRITE_CHUNK = 1ULL * 1024 * 1024 * 1024; // 1 GiB
 	const_data_ptr_t data = local_state.stream->GetData();
@@ -63,7 +70,8 @@ void FlushR2Buffer(FormatWriterState &local_state, SequenceCopyGlobalState &gsta
 	if (!gstate.file_r2) {
 		// First non-NULL R2 record across all threads -> create the R2 file now. This is what
 		// keeps an all-single-end dataset from producing an empty R2 file in split mode.
-		gstate.file_r2 = make_uniq<CopyFileHandle>(*gstate.fs, gstate.r2_path, gstate.compression);
+		gstate.file_r2 =
+		    make_uniq<CopyFileHandle>(*gstate.fs, gstate.r2_path, gstate.compression, gstate.compression_threads);
 	}
 	WriteBufferToFile(*gstate.file_r2, local_state);
 }
@@ -71,20 +79,60 @@ void FlushR2Buffer(FormatWriterState &local_state, SequenceCopyGlobalState &gsta
 //===--------------------------------------------------------------------===//
 // CopyFileHandle Implementation
 //===--------------------------------------------------------------------===//
-CopyFileHandle::CopyFileHandle(FileSystem &fs, const string &path, FileCompressionType compression_p)
-    : compression(compression_p) {
+CopyFileHandle::CopyFileHandle(FileSystem &fs, const string &path, FileCompressionType compression_p,
+                               int compression_threads) {
+	// Local gzip output goes through htslib bgzf: it is gzip-compatible (reads back through any gzip
+	// reader, including read_fastx) and bgzf_mt parallelizes deflate while emitting blocks in order,
+	// so a single-threaded in-order feed still produces a deterministically-ordered file. DuckDB's
+	// own gzip writer is single-threaded, which is the bottleneck this avoids. Remote targets keep
+	// the BufferedFileWriter path: htslib's hFILE cannot open DuckDB's virtual filesystem, and we use
+	// the same RemoteFileHelper::IsRemotePath test the reader (read_fastx) uses so writer and reader
+	// agree on what counts as local.
+	if (compression_p == FileCompressionType::GZIP && !miint::RemoteFileHelper::IsRemotePath(path)) {
+		// "wx6" = write, exclusive-create (O_EXCL), gzip level 6. The 'x' makes the create atomic and
+		// fail loudly if the file exists, preserving the FILE_CREATE_NEW contract of the
+		// BufferedFileWriter path without a TOCTOU; '6' matches DuckDB's MZ_DEFAULT_LEVEL.
+		errno = 0;
+		bgzf_file = bgzf_open(path.c_str(), "wx6");
+		if (!bgzf_file) {
+			if (errno == EEXIST) {
+				throw IOException("Failed to open \"%s\" for writing: file already exists", path);
+			}
+			throw IOException("Failed to open \"%s\" for bgzf writing", path);
+		}
+		if (compression_threads > 1) {
+			// 256 sub-blocks per thread batch is htslib's typical default. Best-effort: on failure
+			// bgzf transparently falls back to single-threaded compression.
+			bgzf_mt(bgzf_file, compression_threads, 256);
+		}
+		return;
+	}
+
 	auto flags =
-	    FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileLockType::WRITE_LOCK | compression;
+	    FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE_NEW | FileLockType::WRITE_LOCK | compression_p;
 
 	// BufferedFileWriter handles both file opening and buffering
 	file_writer = make_uniq<BufferedFileWriter>(fs, path, flags);
 }
 
 CopyFileHandle::~CopyFileHandle() {
-	Close();
+	// Never let a flush error escape a destructor; Finalize calls Close() explicitly
+	// for the error-reporting path.
+	try {
+		Close();
+	} catch (...) { // NOLINT: destructor must not throw
+	}
 }
 
 void CopyFileHandle::Write(const_data_ptr_t data, idx_t size) {
+	if (bgzf_file) {
+		auto written = bgzf_write(bgzf_file, data, size);
+		if (written < 0 || static_cast<idx_t>(written) != size) {
+			throw IOException("bgzf_write failed (wrote %lld of %llu bytes)", static_cast<long long>(written),
+			                  static_cast<unsigned long long>(size));
+		}
+		return;
+	}
 	if (file_writer) {
 		file_writer->WriteData(data, size);
 	}
@@ -95,6 +143,14 @@ void CopyFileHandle::WriteString(const string &data) {
 }
 
 void CopyFileHandle::Close() {
+	if (bgzf_file) {
+		auto ret = bgzf_close(bgzf_file); // flushes pending blocks + writes BGZF EOF
+		bgzf_file = nullptr;
+		if (ret < 0) {
+			throw IOException("bgzf_close failed");
+		}
+		return;
+	}
 	if (file_writer) {
 		file_writer->Close();
 		file_writer.reset();
@@ -253,11 +309,16 @@ unique_ptr<GlobalFunctionData> SequenceCopyInitializeGlobal(ClientContext &conte
 	auto gstate = make_uniq<SequenceCopyGlobalState>();
 	gstate->fs = &fs;
 	gstate->compression = fdata.compression;
+	// Follow DuckDB's configured thread count for bgzf compression workers (only matters for the
+	// gzip path; ignored for uncompressed output). Split output opens two bgzf pools (R1 + R2), so
+	// halve the budget to avoid running ~2N deflate workers on an N-core host.
+	int db_threads = NumericCast<int>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	gstate->compression_threads = (fdata.split_output && db_threads > 1) ? db_threads / 2 : db_threads;
 
 	// R1 is always written. SubstituteOrientation is a no-op when {ORIENTATION} is absent, so this
 	// resolves to the raw path for single-file/interleaved output and to the R1 file in split mode.
 	string path_r1 = SubstituteOrientation(file_path, "R1");
-	gstate->file_r1 = make_uniq<CopyFileHandle>(fs, path_r1, fdata.compression);
+	gstate->file_r1 = make_uniq<CopyFileHandle>(fs, path_r1, fdata.compression, gstate->compression_threads);
 
 	if (fdata.split_output) {
 		// R2 file is created lazily on the first non-NULL R2 record (see FlushR2Buffer), so a

--- a/src/copy_format_common.cpp
+++ b/src/copy_format_common.cpp
@@ -1,5 +1,6 @@
 #include "copy_format_common.hpp"
 #include "remote_file_helper.hpp"
+#include "bgzf_write_mode.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/numeric_utils.hpp"
@@ -89,11 +90,11 @@ CopyFileHandle::CopyFileHandle(FileSystem &fs, const string &path, FileCompressi
 	// the same RemoteFileHelper::IsRemotePath test the reader (read_fastx) uses so writer and reader
 	// agree on what counts as local.
 	if (compression_p == FileCompressionType::GZIP && !miint::RemoteFileHelper::IsRemotePath(path)) {
-		// "wx6" = write, exclusive-create (O_EXCL), gzip level 6. The 'x' makes the create atomic and
-		// fail loudly if the file exists, preserving the FILE_CREATE_NEW contract of the
-		// BufferedFileWriter path without a TOCTOU; '6' matches DuckDB's MZ_DEFAULT_LEVEL.
+		// BgzfWriteMode picks "wx6" for regular files (atomic no-clobber/no-TOCTOU, the
+		// FILE_CREATE_NEW contract) and "w6" for stdout / pipes / devices, which always exist and
+		// would otherwise fail O_EXCL with EEXIST. bgzf_open maps "-" (and /dev/stdout) to stdout.
 		errno = 0;
-		bgzf_file = bgzf_open(path.c_str(), "wx6");
+		bgzf_file = bgzf_open(path.c_str(), miint::BgzfWriteMode(path));
 		if (!bgzf_file) {
 			if (errno == EEXIST) {
 				throw IOException("Failed to open \"%s\" for writing: file already exists", path);

--- a/src/copy_sam.cpp
+++ b/src/copy_sam.cpp
@@ -9,8 +9,10 @@
 #include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/vector_operations/generic_executor.hpp"
 #include "duckdb/function/copy_function.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include <htslib-1.22.1/htslib/sam.h>
 #include <htslib-1.22.1/htslib/hts.h>
 #include <unordered_map>
@@ -402,6 +404,18 @@ static unique_ptr<GlobalFunctionData> SAMCopyInitializeGlobal(ClientContext &con
 	gstate->sam_file = SAMFilePtr(sam_open(file_path.c_str(), mode.c_str()));
 	if (!gstate->sam_file) {
 		throw IOException("Failed to open file for writing: " + file_path);
+	}
+
+	// Offload bgzf compression to a worker pool for BAM / gzip-SAM output. htslib
+	// writes the compressed blocks in record order regardless of pool size, so the
+	// output is byte-identical to the single-threaded path -- just faster.
+	// Uncompressed SAM ("w") has nothing to compress, so threads add no value.
+	bool compressed_output = fdata.format == SAMOutputFormat::BAM || fdata.use_gzip;
+	if (compressed_output) {
+		auto n_threads = NumericCast<int>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+		if (n_threads > 1) {
+			hts_set_threads(gstate->sam_file.get(), n_threads);
+		}
 	}
 
 	// Create header from reference_lengths if provided, otherwise create empty header

--- a/src/include/bgzf_write_mode.hpp
+++ b/src/include/bgzf_write_mode.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+// Open-mode selection for the local bgzf gzip writer (COPY ... COMPRESSION gzip).
+//
+// Returns the htslib bgzf_open mode string. Regular-file (or not-yet-existing) targets get "wx6"
+// -- write, exclusive-create (O_EXCL), gzip level 6 -- which preserves the FILE_CREATE_NEW "fail if
+// the file already exists" contract atomically (no TOCTOU). Targets that ALWAYS already exist --
+// stdout/stderr, /dev/fd aliases, and pre-created pipes/devices -- must NOT get O_EXCL, or the open
+// fails with EEXIST and breaks gzip streaming to a pipe or /dev/stdout (a regression vs the
+// uncompressed BufferedFileWriter path, which streams to them fine); those get plain "w6".
+//
+// Kept DuckDB-free (only <string> + <sys/stat.h>) so it is unit-testable in the standalone catch2
+// test binary, which deliberately does not link libduckdb.
+
+#include <string>
+#include <sys/stat.h>
+
+namespace miint {
+
+inline const char *BgzfWriteMode(const std::string &path) {
+	auto starts_with = [&](const char *prefix) {
+		return path.rfind(prefix, 0) == 0;
+	};
+	// Named stdout/stderr/fd aliases: never exclusive. Matched by name, not by stat target --
+	// stdout may be redirected to a regular file, which would also trip O_EXCL.
+	if (path == "-" || path == "/dev/stdout" || path == "/dev/stderr" || starts_with("/dev/fd/") ||
+	    starts_with("/proc/self/fd/")) {
+		return "w6";
+	}
+	// An existing non-regular file (FIFO / character / block / socket) is a deliberate streaming
+	// sink; only a regular file (or a not-yet-existing path) keeps the no-clobber/no-TOCTOU guard.
+	struct stat st;
+	if (stat(path.c_str(), &st) == 0 && !S_ISREG(st.st_mode)) {
+		return "w6";
+	}
+	return "wx6";
+}
+
+} // namespace miint

--- a/src/include/copy_format_common.hpp
+++ b/src/include/copy_format_common.hpp
@@ -6,6 +6,9 @@
 #include "duckdb/common/serializer/memory_stream.hpp"
 #include "duckdb/common/enums/file_compression_type.hpp"
 
+// htslib's BGZF handle; defined in <htslib/bgzf.h>, only included in the .cpp.
+struct BGZF;
+
 namespace duckdb {
 
 //===--------------------------------------------------------------------===//
@@ -18,7 +21,11 @@ constexpr idx_t DEFAULT_COPY_FLUSH_SIZE = 1024 * 1024; // 1MB default buffer siz
 //===--------------------------------------------------------------------===//
 class CopyFileHandle {
 public:
-	CopyFileHandle(FileSystem &fs, const string &path, FileCompressionType compression);
+	// compression_threads > 1 enables htslib bgzf multithreaded compression for
+	// LOCAL gzip output (bgzf is gzip-compatible and bgzf_mt preserves block
+	// order). Uncompressed output and remote (scheme://) gzip targets keep the
+	// BufferedFileWriter path.
+	CopyFileHandle(FileSystem &fs, const string &path, FileCompressionType compression, int compression_threads = 1);
 	~CopyFileHandle();
 
 	void Write(const_data_ptr_t data, idx_t size);
@@ -26,8 +33,10 @@ public:
 	void Close();
 
 private:
+	// Exactly one is active for the handle's lifetime: bgzf_file for local gzip (htslib bgzf),
+	// file_writer for uncompressed output and the remote-gzip fallback.
 	unique_ptr<BufferedFileWriter> file_writer;
-	FileCompressionType compression;
+	struct ::BGZF *bgzf_file = nullptr;
 };
 
 //===--------------------------------------------------------------------===//
@@ -130,6 +139,9 @@ struct SequenceCopyGlobalState : public GlobalFunctionData {
 	FileSystem *fs = nullptr;
 	string r2_path;
 	FileCompressionType compression = FileCompressionType::UNCOMPRESSED;
+	// Worker threads for bgzf gzip compression (follows DuckDB's thread count);
+	// captured at global-init so the lazily-created R2 file uses the same value.
+	int compression_threads = 1;
 	// Consistency tracking across all threads: a single COPY must be either all single-end or
 	// all paired-end. Both set true -> inconsistent input (checked at finalize).
 	bool saw_paired = false;

--- a/src/include/duckdb_seq_stream.hpp
+++ b/src/include/duckdb_seq_stream.hpp
@@ -30,9 +30,13 @@ extern thread_local std::string g_seq_read_error;
 // read error, or — critically — EOF reached before Z_STREAM_END, which means the gzip
 // stream was truncated).
 //
-// `stream_end` tracks whether Z_STREAM_END has been observed across calls. Once set, the
-// function returns 0 cleanly on subsequent invocations rather than treating the trailing
-// "no input, no output" state as truncation. Caller initializes to false.
+// `stream_end` tracks whether the FINAL gzip member has ended. gzip is a concatenation of
+// members (BGZF/block-gzip emits one member per ~64 KiB block, and tools like `cat a.gz b.gz`
+// produce multi-member files), so a single Z_STREAM_END is a member boundary, not necessarily
+// end-of-file: this helper resets and continues into the next member, matching zlib's gzread.
+// Only once no further gzip member follows is `stream_end` set; subsequent calls then return 0
+// cleanly rather than treating the trailing "no input, no output" state as truncation. Caller
+// initializes to false.
 template <typename ReadRawFn>
 int InflateFromSource(z_stream &zs, char *compressed_buf, size_t buf_size, int &compressed_avail,
                       char *&compressed_next, bool &input_eof, bool &stream_end, ReadRawFn read_raw, void *dst,
@@ -72,6 +76,39 @@ int InflateFromSource(z_stream &zs, char *compressed_buf, size_t buf_size, int &
 		compressed_next += consumed;
 
 		if (ret == Z_STREAM_END) {
+			// Member boundary, not necessarily EOF. gzip is concatenated members and BGZF emits
+			// one per block, so continue into the next member instead of stopping at the first
+			// boundary (the bug that silently truncated bgzf .gz to its first ~64 KiB block when
+			// read through this path). A new member starts with the gzip magic 0x1f 0x8b; anything
+			// else (or no more input) is the true end -- and trailing non-gzip padding is tolerated,
+			// not treated as corruption, matching zlib's gzread.
+			// The 2 magic bytes can straddle a read (and a read may return fewer bytes than asked),
+			// so keep compacting the leftover to the front and topping up until we have both bytes
+			// or hit EOF.
+			while (compressed_avail < 2 && !input_eof) {
+				for (int k = 0; k < compressed_avail; k++) {
+					compressed_buf[k] = compressed_next[k];
+				}
+				compressed_next = compressed_buf;
+				auto n = read_raw(compressed_buf + compressed_avail, buf_size - static_cast<size_t>(compressed_avail));
+				if (n < 0) {
+					return -1;
+				}
+				if (n == 0) {
+					input_eof = true;
+				} else {
+					compressed_avail += static_cast<int>(n);
+				}
+			}
+			bool next_is_gzip_member = compressed_avail >= 2 &&
+			                           static_cast<unsigned char>(compressed_next[0]) == 0x1f &&
+			                           static_cast<unsigned char>(compressed_next[1]) == 0x8b;
+			if (next_is_gzip_member) {
+				if (inflateReset(&zs) != Z_OK) {
+					return -1;
+				}
+				continue; // decode the next member into the same output buffer
+			}
 			stream_end = true;
 			break;
 		}

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -93,6 +93,9 @@
 #include <htslib-1.22.1/htslib/hts.h>
 #include <kseq++/config.hpp>
 #include <zlib.h>
+#ifdef MIINT_HAS_LIBDEFLATE
+#include <libdeflate.h>
+#endif
 
 #ifdef MIINT_HAS_HDF5
 #include <copy_biom.hpp>
@@ -173,6 +176,9 @@ static unique_ptr<FunctionData> MiintVersionsBind(ClientContext &context, TableF
 #endif
 #endif
 	data->versions.emplace_back("zlib", zlibVersion());
+#ifdef MIINT_HAS_LIBDEFLATE
+	data->versions.emplace_back("libdeflate", LIBDEFLATE_VERSION_STRING);
+#endif
 #ifdef MIINT_HAS_CURL
 	data->versions.emplace_back("libcurl", miint::GetCurlVersion());
 #endif

--- a/test/cpp/test_CopyFileHandlePipe.cpp
+++ b/test/cpp/test_CopyFileHandlePipe.cpp
@@ -1,0 +1,115 @@
+// Tests for the local gzip writer's open-mode selection (src/include/bgzf_write_mode.hpp), the fix
+// that lets COPY ... (COMPRESSION gzip) stream to stdout / named pipes.
+//
+// Regression: the writer opened bgzf with mode "wx6" (O_EXCL). O_EXCL rejects any target that
+// already exists -- stdout, /dev/stdout, pre-created pipes -- with EEXIST, so
+//   duckdb -c "COPY (...) TO '/dev/stdout' (FORMAT FASTQ, COMPRESSION gzip)" | downstream_tool
+// failed with "file already exists" even though the uncompressed path streams to them fine. The fix
+// keeps O_EXCL only for regular-file targets. This verifies the mode decision and that gzip data
+// actually round-trips through a real FIFO opened with the chosen mode.
+//
+// POSIX-only (mkfifo / O_NONBLOCK): not built on Windows or WASM.
+
+#if !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <bgzf_write_mode.hpp>
+#include <htslib-1.22.1/htslib/bgzf.h>
+#include <zlib.h>
+
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace {
+
+// Inflate the first gzip member (the lone bgzf data block for a small payload) back to plaintext.
+std::string GunzipFirstMember(const std::string &in) {
+	z_stream zs;
+	std::memset(&zs, 0, sizeof(zs));
+	REQUIRE(inflateInit2(&zs, 16 + MAX_WBITS) == Z_OK);
+	zs.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(in.data()));
+	zs.avail_in = static_cast<uInt>(in.size());
+	std::string out;
+	char buf[8192];
+	int ret;
+	do {
+		zs.next_out = reinterpret_cast<Bytef *>(buf);
+		zs.avail_out = sizeof(buf);
+		ret = inflate(&zs, Z_NO_FLUSH);
+		REQUIRE((ret == Z_OK || ret == Z_STREAM_END));
+		out.append(buf, sizeof(buf) - zs.avail_out);
+	} while (ret != Z_STREAM_END);
+	inflateEnd(&zs);
+	return out;
+}
+
+} // namespace
+
+TEST_CASE("BgzfWriteMode keeps O_EXCL only for regular files", "[copy][bgzf][pipe]") {
+	// stdout / stderr / fd aliases stream -> no O_EXCL.
+	REQUIRE(std::string(miint::BgzfWriteMode("-")) == "w6");
+	REQUIRE(std::string(miint::BgzfWriteMode("/dev/stdout")) == "w6");
+	REQUIRE(std::string(miint::BgzfWriteMode("/dev/stderr")) == "w6");
+	REQUIRE(std::string(miint::BgzfWriteMode("/dev/fd/1")) == "w6");
+	// /dev/null is an existing non-regular (char) device -> no O_EXCL.
+	REQUIRE(std::string(miint::BgzfWriteMode("/dev/null")) == "w6");
+	// A not-yet-existing regular path keeps the atomic no-clobber guard.
+	REQUIRE(std::string(miint::BgzfWriteMode("/tmp/miint_nonexistent_xyz.fq.gz")) == "wx6");
+}
+
+TEST_CASE("gzip COPY streams to a named pipe without O_EXCL EEXIST", "[copy][bgzf][pipe]") {
+	char dir_tmpl[] = "/tmp/miint_pipe_XXXXXX";
+	const char *dir = mkdtemp(dir_tmpl);
+	REQUIRE(dir != nullptr);
+	const std::string fifo = std::string(dir) + "/out.fq.gz";
+	REQUIRE(mkfifo(fifo.c_str(), 0600) == 0);
+
+	// The fix: an existing FIFO must select "w6" (no O_EXCL). Pre-fix this was "wx6".
+	REQUIRE(std::string(miint::BgzfWriteMode(fifo)) == "w6");
+
+	const std::string payload = "@r1\nACGTACGTACGTACGT\n+\nIIIIIIIIIIIIIIII\n";
+
+	// Open the read end non-blocking FIRST so the writer's blocking O_WRONLY open succeeds
+	// immediately and a regression (open failing) FAILS the test instead of hanging on a reader with
+	// no writer. The payload is far below the pipe buffer, so the writer never blocks on a full pipe.
+	const int rfd = open(fifo.c_str(), O_RDONLY | O_NONBLOCK);
+	REQUIRE(rfd >= 0);
+
+	// Open + write through the real bgzf path using the production-selected mode. Pre-fix, "wx6" on
+	// the existing FIFO returned a null handle (EEXIST); the REQUIRE below would have failed.
+	BGZF *bg = bgzf_open(fifo.c_str(), miint::BgzfWriteMode(fifo));
+	REQUIRE(bg != nullptr);
+	REQUIRE(bgzf_write(bg, payload.data(), payload.size()) == static_cast<ssize_t>(payload.size()));
+	REQUIRE(bgzf_close(bg) == 0);
+
+	std::string captured;
+	char buf[8192];
+	for (;;) {
+		ssize_t n = read(rfd, buf, sizeof(buf));
+		if (n > 0) {
+			captured.append(buf, static_cast<size_t>(n));
+			continue;
+		}
+		if (n == 0) {
+			break; // EOF: writer closed
+		}
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			break;
+		}
+		break;
+	}
+	close(rfd);
+
+	REQUIRE(!captured.empty());
+	REQUIRE(GunzipFirstMember(captured) == payload);
+
+	unlink(fifo.c_str());
+	rmdir(dir);
+}
+
+#endif // !_WIN32 && !__EMSCRIPTEN__

--- a/test/cpp/test_DuckDBSeqStream.cpp
+++ b/test/cpp/test_DuckDBSeqStream.cpp
@@ -1,0 +1,135 @@
+// Unit tests for InflateFromSource (src/include/duckdb_seq_stream.hpp), the streaming gzip
+// decompressor used by the REMOTE read path (read_fastx over http/s3, read_ena_sequences).
+//
+// Regression focus: gzip is a concatenation of members and BGZF (block-gzip, what the FASTQ/FASTA
+// COPY writer now produces) emits one member per ~64 KiB block. The decoder must continue across
+// member boundaries; an earlier version stopped at the first Z_STREAM_END and silently truncated a
+// remotely-read bgzf file to its first block. The local read path uses zlib gzread (multi-member
+// capable), so only this path was affected and only over the network -- exactly the gap SQL
+// round-trip tests on local files could not see.
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <zlib.h>
+
+#include <duckdb_seq_stream.hpp>
+
+namespace {
+
+// Compress `data` into one standalone gzip member (RFC1952) -- the unit BGZF and `cat a.gz b.gz`
+// concatenate.
+std::string GzipMember(const std::string &data) {
+	z_stream zs;
+	std::memset(&zs, 0, sizeof(zs));
+	REQUIRE(deflateInit2(&zs, 6, Z_DEFLATED, 16 + MAX_WBITS, 8, Z_DEFAULT_STRATEGY) == Z_OK);
+	std::string out;
+	out.resize(deflateBound(&zs, data.size()) + 64);
+	zs.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(data.data()));
+	zs.avail_in = static_cast<uInt>(data.size());
+	zs.next_out = reinterpret_cast<Bytef *>(&out[0]);
+	zs.avail_out = static_cast<uInt>(out.size());
+	REQUIRE(deflate(&zs, Z_FINISH) == Z_STREAM_END);
+	out.resize(out.size() - zs.avail_out);
+	deflateEnd(&zs);
+	return out;
+}
+
+// Drive InflateFromSource over `compressed`, serving it in `chunk`-byte reads so member boundaries
+// straddle the read buffer (stressing the magic-byte lookahead/compaction). Returns the fully
+// decompressed bytes; sets `ok` false on any reported error.
+std::string Decode(const std::string &compressed, size_t chunk, bool &ok) {
+	size_t off = 0;
+	auto read_raw = [&](void *buf, size_t sz) -> int {
+		size_t n = std::min({sz, chunk, compressed.size() - off});
+		std::memcpy(buf, compressed.data() + off, n);
+		off += n;
+		return static_cast<int>(n);
+	};
+
+	z_stream zs;
+	std::memset(&zs, 0, sizeof(zs));
+	if (inflateInit2(&zs, 16 + MAX_WBITS) != Z_OK) {
+		ok = false;
+		return {};
+	}
+	std::vector<char> cbuf(256);
+	int cavail = 0;
+	char *cnext = cbuf.data();
+	bool input_eof = false, stream_end = false;
+	std::string decoded;
+	char dst[1024];
+	ok = true;
+	for (;;) {
+		int n = miint::InflateFromSource(zs, cbuf.data(), cbuf.size(), cavail, cnext, input_eof, stream_end, read_raw,
+		                                 dst, sizeof(dst));
+		if (n < 0) {
+			ok = false;
+			break;
+		}
+		if (n == 0) {
+			break;
+		}
+		decoded.append(dst, static_cast<size_t>(n));
+	}
+	inflateEnd(&zs);
+	return decoded;
+}
+
+// Non-trivially-compressible content (varies per byte) so the gzip members are real, multi-block.
+std::string VariedBlock(char base, size_t len) {
+	std::string s(len, base);
+	for (size_t i = 0; i < len; i++) {
+		s[i] = static_cast<char>(base + static_cast<char>(i % 23));
+	}
+	return s;
+}
+
+} // namespace
+
+TEST_CASE("InflateFromSource decodes a single-member gzip stream", "[seqstream]") {
+	std::string a = VariedBlock('A', 40000);
+	bool ok = false;
+	std::string decoded = Decode(GzipMember(a), 4096, ok);
+	REQUIRE(ok);
+	CHECK(decoded == a);
+}
+
+TEST_CASE("InflateFromSource decodes multi-member (bgzf-style concatenated) gzip", "[seqstream]") {
+	// Two members back-to-back, exactly the shape BGZF produces (one member per block).
+	std::string a = VariedBlock('A', 20000);
+	std::string b = VariedBlock('a', 20000);
+	std::string stream = GzipMember(a) + GzipMember(b);
+
+	// chunk=1 guarantees the 2-byte gzip magic of member 2 arrives across two separate reads,
+	// exercising the boundary compaction; the others cover the common cases.
+	for (size_t chunk : {static_cast<size_t>(1), static_cast<size_t>(7), static_cast<size_t>(4096)}) {
+		bool ok = false;
+		std::string decoded = Decode(stream, chunk, ok);
+		REQUIRE(ok);
+		// Pre-fix this returned just `a` (first Z_STREAM_END treated as end-of-stream).
+		CHECK(decoded == a + b);
+	}
+}
+
+TEST_CASE("InflateFromSource consumes a trailing empty member (BGZF EOF marker)", "[seqstream]") {
+	// BGZF terminates with a 28-byte empty block: a valid gzip member that decompresses to nothing.
+	std::string a = VariedBlock('A', 30000);
+	std::string stream = GzipMember(a) + GzipMember("");
+	bool ok = false;
+	std::string decoded = Decode(stream, 8, ok);
+	REQUIRE(ok);
+	CHECK(decoded == a);
+}
+
+TEST_CASE("InflateFromSource still reports truncation rather than silent short read", "[seqstream]") {
+	std::string a = VariedBlock('A', 30000);
+	std::string member = GzipMember(a);
+	std::string truncated = member.substr(0, member.size() - 6); // drop the gzip trailer
+	bool ok = true;
+	Decode(truncated, 4096, ok);
+	CHECK_FALSE(ok); // EOF before Z_STREAM_END must surface as an error
+}

--- a/test/sql/copy_gzip_bgzf.test
+++ b/test/sql/copy_gzip_bgzf.test
@@ -1,0 +1,143 @@
+# name: test/sql/copy_gzip_bgzf.test
+# description: gzip FASTQ/FASTA COPY round-trips losslessly across many bgzf blocks, preserving order and R1/R2 pairing
+# group: [sql]
+
+require miint
+
+# ~200k records of small reads -> a few MB uncompressed -> dozens of bgzf blocks,
+# so this exercises multi-block compression, block ordering, and the EOF marker
+# (not just a single-block file). read_id is made unique per row so the EXCEPT
+# checks below verify per-record content, not just a collapsed set.
+
+statement ok
+CREATE TABLE big_se AS
+SELECT (row_number() OVER ())::BIGINT AS sequence_index,
+       read_id || '_' || i AS read_id,
+       sequence1, qual1
+FROM read_fastx('data/fastq/small_a.fq') CROSS JOIN generate_series(1, 100000) t(i);
+
+statement ok
+COPY (SELECT read_id, sequence1, qual1 FROM big_se ORDER BY sequence_index)
+TO '__TEST_DIR__/bgzf_se.fq.gz' (FORMAT FASTQ);
+
+# Count preserved (no truncation / no duplication across blocks).
+query I
+SELECT (SELECT count(*) FROM read_fastx('__TEST_DIR__/bgzf_se.fq.gz')) - (SELECT count(*) FROM big_se);
+----
+0
+
+# Content lossless, both directions (corruption in any record -> nonzero).
+query I
+SELECT count(*) FROM (
+  SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/bgzf_se.fq.gz')
+  EXCEPT
+  SELECT read_id, sequence1, qual1 FROM big_se
+);
+----
+0
+
+query I
+SELECT count(*) FROM (
+  SELECT read_id, sequence1, qual1 FROM big_se
+  EXCEPT
+  SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/bgzf_se.fq.gz')
+);
+----
+0
+
+# Order preserved across blocks: file-order (read-back sequence_index) must match
+# the written order (original sequence_index).
+query I
+SELECT count(*) FROM (
+  SELECT row_number() OVER (ORDER BY sequence_index) AS rn, read_id
+  FROM read_fastx('__TEST_DIR__/bgzf_se.fq.gz')
+) rb
+JOIN big_se b ON b.sequence_index = rb.rn
+WHERE b.read_id <> rb.read_id;
+----
+0
+
+# --- Paired-end split ({ORIENTATION}) gzip: pairing must survive the two-file write ---
+statement ok
+CREATE TABLE big_pe AS
+SELECT (row_number() OVER ())::BIGINT AS sequence_index,
+       read_id || '_' || i AS read_id,
+       sequence1, sequence2, qual1, qual2
+FROM read_fastx('data/fastq/small_a_r1.fq', sequence2='data/fastq/small_a_r2.fq')
+CROSS JOIN generate_series(1, 100000) t(i);
+
+statement ok
+COPY (SELECT read_id, sequence1, sequence2, qual1, qual2 FROM big_pe ORDER BY sequence_index)
+TO '__TEST_DIR__/bgzf_pe.{ORIENTATION}.fq.gz' (FORMAT FASTQ);
+
+# Reading R1+R2 as a pair must reproduce each original (read_id, R1, R2) tuple.
+# If R1/R2 desynchronized across blocks/threads, seq2 would attach to the wrong
+# read_id and this would be nonzero.
+query I
+SELECT count(*) FROM (
+  SELECT read_id, sequence1, sequence2, qual1, qual2
+  FROM read_fastx('__TEST_DIR__/bgzf_pe.R1.fq.gz', sequence2='__TEST_DIR__/bgzf_pe.R2.fq.gz')
+  EXCEPT
+  SELECT read_id, sequence1, sequence2, qual1, qual2 FROM big_pe
+);
+----
+0
+
+query I
+SELECT count(*) FROM (
+  SELECT read_id, sequence1, sequence2, qual1, qual2 FROM big_pe
+  EXCEPT
+  SELECT read_id, sequence1, sequence2, qual1, qual2
+  FROM read_fastx('__TEST_DIR__/bgzf_pe.R1.fq.gz', sequence2='__TEST_DIR__/bgzf_pe.R2.fq.gz')
+);
+----
+0
+
+# Each split file must have exactly the full record count (catches truncation/duplication on
+# either file independently of the set-based EXCEPT checks above).
+query I
+SELECT (SELECT count(*) FROM read_fastx('__TEST_DIR__/bgzf_pe.R1.fq.gz')) - (SELECT count(*) FROM big_pe);
+----
+0
+
+query I
+SELECT (SELECT count(*) FROM read_fastx('__TEST_DIR__/bgzf_pe.R2.fq.gz')) - (SELECT count(*) FROM big_pe);
+----
+0
+
+# --- FASTA gzip multi-block round-trip ---
+statement ok
+COPY (SELECT read_id, sequence1 FROM big_se ORDER BY sequence_index)
+TO '__TEST_DIR__/bgzf.fa.gz' (FORMAT FASTA);
+
+query I
+SELECT count(*) FROM (
+  SELECT read_id, sequence1 FROM read_fastx('__TEST_DIR__/bgzf.fa.gz')
+  EXCEPT
+  SELECT read_id, sequence1 FROM big_se
+);
+----
+0
+
+# Re-writing an existing gzip target overwrites it (standard COPY temp-file + rename semantics; the
+# bgzf path opens the temp file with O_EXCL, matching the uncompressed path's FILE_CREATE_NEW). The
+# second write must succeed and fully replace the file -- here a 1-record write over a many-record
+# file, so a read-back of 1 proves replacement (not append) and a valid bgzf file.
+statement ok
+COPY (SELECT read_id, sequence1, qual1 FROM big_se ORDER BY sequence_index)
+TO '__TEST_DIR__/bgzf_exists.fq.gz' (FORMAT FASTQ);
+
+statement ok
+COPY (SELECT read_id, sequence1, qual1 FROM big_se ORDER BY sequence_index LIMIT 1)
+TO '__TEST_DIR__/bgzf_exists.fq.gz' (FORMAT FASTQ);
+
+query I
+SELECT count(*) FROM read_fastx('__TEST_DIR__/bgzf_exists.fq.gz');
+----
+1
+
+statement ok
+DROP TABLE big_se;
+
+statement ok
+DROP TABLE big_pe;

--- a/test/sql/miint_versions.test
+++ b/test/sql/miint_versions.test
@@ -26,7 +26,7 @@ WHERE library IN ('miint', 'htslib', 'minimap2', 'kseq++', 'WFA2-lib', 'zlib', '
 # Every row matches either a core or optional library name
 query I
 SELECT COUNT(*) FROM miint_versions()
-WHERE library NOT IN ('miint', 'htslib', 'minimap2', 'kseq++', 'WFA2-lib', 'HDF5', 'zlib', 'libcurl', 'rype', 'vsearch', 'mafft', 'abpoa', 'unifrac', 'scikit-bio-binaries');
+WHERE library NOT IN ('miint', 'htslib', 'minimap2', 'kseq++', 'WFA2-lib', 'HDF5', 'zlib', 'libdeflate', 'libcurl', 'rype', 'vsearch', 'mafft', 'abpoa', 'unifrac', 'scikit-bio-binaries');
 ----
 0
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,7 @@
   "dependencies": [
     "zlib",
     "zstd",
+    { "name": "libdeflate", "platform": "linux" },
     "expat",
     "openssl",
     "curl",


### PR DESCRIPTION
## Summary

`COPY ... FORMAT fastq/fasta` with gzip was **~195× slower** than uncompressed (~1.9 MB/s out) and entirely single-threaded. Root cause (measured, not assumed): deflate runs at ~9 MB/s on high-entropy FASTQ and DuckDB's gzip writer is single-threaded — `mem_level=1` turned out to be a red herring (~12% effect).

This switches local gzip output to **htslib bgzf** (already embedded) with `bgzf_mt` following DuckDB's thread count. bgzf is gzip-compatible and emits blocks in order, so the single-threaded in-order sink stays correct (split R1/R2 pairing preserved) while compression parallelizes. BAM/gzip-SAM get the same treatment via a one-line `hts_set_threads`.

> **Scope update (later commits in this PR):** this now *also* links **libdeflate** into the embedded htslib (`MIINT_ENABLE_LIBDEFLATE`, default-ON for Linux) to replace zlib as the bgzf block codec — see the libdeflate section below. The bgzf migration itself adds no dependency; **libdeflate is the one new static dependency this PR introduces**, added because it triples the parallel throughput and the bgzf rework is exactly what makes it drop in.

## Results: bgzf migration (real ENA metagenome ERR10677119, 3.9M paired reads, 12 cores)

| path | before | after | speedup |
|---|---|---|---|
| FASTQ gzip, single-end | 148.6 s | **13.4 s** | **11.1×** |
| FASTQ gzip, split paired | 283 s | **23.1 s** | **12.3×** |
| BAM (real PacBio HiFi, `hts_set_threads`) | 6.6 s | **1.2 s** | **5.5×** (byte-identical output) |

Uncompressed output (already ~1.6 GB/s) is unchanged. With zlib, bgzf output runs ~90–105 MB/s in at 12 threads (the zlib-parallel ceiling); the libdeflate swap below lifts that to ~300+ MB/s in.

## libdeflate codec swap (added in follow-up commits)

`MIINT_ENABLE_LIBDEFLATE` (CMake, **default ON, Linux-gated**) builds the embedded htslib `--with-libdeflate`, so bgzf blocks compress with libdeflate instead of zlib. **This is the one new static dependency in the PR** — vcpkg `libdeflate` 1.24, `linux`-platform-qualified. Windows (hand-rolled htslib `config.h`) and WASM (single-threaded in-browser, binary bloat) stay on zlib via the Linux gate; a missing port soft-disables, so default-ON degrades gracefully where it can't apply.

Why it drops in despite libdeflate having **no streaming API**: bgzf already chops output into independent ≤64 KB blocks (`BGZF_BLOCK_SIZE = 0xff00`), and htslib compresses each block with a single one-shot `libdeflate_deflate_compress` call (`bgzf.c`, under `HAVE_LIBDEFLATE`). bgzf provides the streaming/framing; libdeflate is just the per-block codec — the same way samtools uses it. The block independence that lets a one-shot compressor work here is the same property that lets `bgzf_mt` parallelize it.

| gzip path, 12 threads | zlib-parallel (this PR) | + libdeflate | vs zlib | vs original |
|---|---|---|---|---|
| FASTQ single-end | 13.4 s · 90 MB/s in | **4.0 s · 303 MB/s in** | **3.35×** | **37×** |
| FASTQ split paired | 23.1 s · 105 MB/s in | **7.75 s · 313 MB/s in** | **2.98×** | **36×** |
| FASTQ single-end, **1 thread** | 118.8 s | **35.3 s** | **3.36×** | — |

The in-process bgzf path now reaches the `bgzip -@12` libdeflate ceiling (~331 MB/s host CLI). Output still round-trips losslessly (`copy_gzip_bgzf.test`); `miint_versions()` reports `libdeflate 1.24`. Verified a default `make release` (no `EXT_FLAGS`) links it. **Note:** the `linux_arm64` release lane now builds libdeflate too but was not verified locally — worth a glance when CI runs.

## Reader bugfix (this change exposes a latent one)

`InflateFromSource` — the **remote** read path (`read_fastx` over http/s3, `read_ena_sequences`) — stopped at the first gzip member's `Z_STREAM_END`, silently truncating any multi-member / bgzf `.gz` read remotely to its first ~64 KiB block. It now resets and continues across members (matching zlib's `gzread`), tolerating trailing padding. Verified end-to-end: a 500k-record (~570-block) bgzf file served over HTTP reads back complete.

## Writer details

- Atomic `O_EXCL` create via `bgzf_open("wx6")` (no TOCTOU); local-vs-remote decided by `RemoteFileHelper::IsRemotePath`, consistent with the reader. Remote/uncompressed targets keep the `BufferedFileWriter` path.
- Split output halves the per-file bgzf thread budget to avoid 2N workers on an N-core host.

## Tests / docs / tooling

- `test/cpp/test_DuckDBSeqStream.cpp` — multi-member / boundary-straddle (`chunk=1`) / truncation coverage for the reader fix.
- `test/sql/copy_gzip_bgzf.test` — multi-block round-trip, split-file pairing + counts, overwrite semantics.
- Docs: bgzf behavior noted for FASTQ/FASTA/SAM/BAM; documented the previously-undocumented `read_fastx` `max_batch_bytes`.
- `bench/copy_fastx/` — the rerunnable harness used to collect the numbers above.

Full `run_tests.sh` and C++ suite (12,773 assertions) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
