### PR TITLE
docs(tutorials): read ENA data via read_ena_sequences, not hardcoded URLs

### DIFF
--- a/onboarding-tutorials/advanced.md
+++ b/onboarding-tutorials/advanced.md
@@ -18,9 +18,7 @@ duckdb -c "
 INSTALL httpfs; LOAD httpfs;
 INSTALL miint FROM community; LOAD miint;
 SELECT count(*) AS n_reads
-FROM read_fastx(
-    'https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/ERR1074767/10317.000004216.fastq.gz'
-);
+FROM read_ena_sequences('ERR1074767');
 "
 ```
 
@@ -43,21 +41,15 @@ INSTALL httpfs; LOAD httpfs;
 INSTALL miint FROM community; LOAD miint;
 
 COPY (
-    SELECT * FROM read_fastx(
-        'https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/ERR1074767/10317.000004216.fastq.gz'
-    ) WHERE sequence_index % 3 = 0
+    SELECT * FROM read_ena_sequences('ERR1074767') WHERE sequence_index % 3 = 0
 ) TO '${OUTDIR}/sample_a.parquet' (FORMAT parquet);
 
 COPY (
-    SELECT * FROM read_fastx(
-        'https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/ERR1074767/10317.000004216.fastq.gz'
-    ) WHERE sequence_index % 3 = 1
+    SELECT * FROM read_ena_sequences('ERR1074767') WHERE sequence_index % 3 = 1
 ) TO '${OUTDIR}/sample_b.parquet' (FORMAT parquet);
 
 COPY (
-    SELECT * FROM read_fastx(
-        'https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/ERR1074767/10317.000004216.fastq.gz'
-    ) WHERE sequence_index % 3 = 2
+    SELECT * FROM read_ena_sequences('ERR1074767') WHERE sequence_index % 3 = 2
 ) TO '${OUTDIR}/sample_c.parquet' (FORMAT parquet);
 "
 ```
@@ -159,9 +151,7 @@ CREATE TABLE ref_genome AS
 
 CREATE TABLE reads AS
     SELECT *
-    FROM read_fastx(
-        'https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/ERR1074767/10317.000004216.fastq.gz'
-    );
+    FROM read_ena_sequences('ERR1074767');
 
 CREATE TABLE alignments AS
     SELECT *
@@ -269,7 +259,7 @@ FROM alignments a
 LEFT JOIN rrna_16s r
   ON a.position >= r.gene_start
  AND a.stop_position <= r.gene_end
-WHERE a.read_id = '10317.000004216_6975'
+WHERE a.read_id = 'ERR1074767.6976'
 ORDER BY alignment_is_primary(a.flags) DESC, a.position;
 ```
 
@@ -389,7 +379,7 @@ WHERE alignment_is_primary(flags)
 
 | read_id | position | cigar |
 |---|---|---|
-| 10317.000004216_6599 | 1565200 | 151= |
+| ERR1074767.6600 | 1565200 | 151= |
 
 Unlike the 16S reads, which have multiple secondary alignments across operons,
 this read has **no secondary alignments** &mdash; the DosP location is its
@@ -402,7 +392,7 @@ SELECT alignment_is_primary(flags) AS is_primary,
        round(alignment_seq_identity(cigar, tag_nm, tag_md, 'blast'), 3)
            AS identity
 FROM alignments
-WHERE read_id = '10317.000004216_6599'
+WHERE read_id = 'ERR1074767.6600'
 ORDER BY position;
 ```
 

--- a/onboarding-tutorials/beginner.md
+++ b/onboarding-tutorials/beginner.md
@@ -71,22 +71,22 @@ SQL it uses. For a broader introduction, see DuckDB's
 ## Reading a FASTQ file
 
 The
-[`read_fastx`](../docs/table-functions.md#read_fastxfilename-sequence2filename-include_filepathfalse-qual_offset33)
-table function reads FASTA and FASTQ files. It works with local paths, glob
-patterns, and HTTPS URLs. Let's read an amplicon sequencing run from the
-[American Gut Project](https://americangut.org/) (McDonald et al., 2018):
+[`read_ena_sequences`](../docs/table-functions.md#read_ena_sequencesaccession-include_filepathfalse-qual_offset33-max_sequences0)
+table function streams FASTA/FASTQ data straight from the European Nucleotide
+Archive (ENA) given a run, sample, study, or experiment accession &mdash; it
+looks up the download URLs for you, so you never have to hardcode a file path.
+Let's read an amplicon sequencing run from the
+[American Gut Project](https://americangut.org/) (McDonald et al., 2018), ENA
+run [`ERR1074767`](https://www.ebi.ac.uk/ena/browser/view/ERR1074767):
 
 ```python
-FASTQ_URL = (
-    "https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/"
-    "ERR1074767/10317.000004216.fastq.gz"
-)
+ACCESSION = "ERR1074767"
 
 df = con.sql(f"""
     SELECT read_id,
            comment,
            sequence1
-    FROM read_fastx('{FASTQ_URL}')
+    FROM read_ena_sequences('{ACCESSION}')
     LIMIT 5
 """).df()
 
@@ -97,8 +97,9 @@ Let's break this query down:
 
 - **`SELECT read_id, comment, sequence1`** &mdash; we want three columns from
   each sequencing read.
-- **`FROM read_fastx(...)`** &mdash; the data comes from a FASTQ file. `read_fastx`
-  is a miint function that opens the file and presents each read as a row.
+- **`FROM read_ena_sequences(...)`** &mdash; the data comes from an ENA run.
+  `read_ena_sequences` resolves the accession to its FASTQ download(s) and
+  presents each read as a row.
 - **`LIMIT 5`** &mdash; only return the first five reads (useful for a quick peek).
 
 The columns are:
@@ -106,12 +107,13 @@ The columns are:
 | Column | Description |
 |---|---|
 | `read_id` | Unique identifier for the read |
-| `comment` | Header metadata (here, barcode information) |
+| `comment` | Header metadata (here, the original submission read name) |
 | `sequence1` | The nucleotide sequence (A, C, G, T) |
 
-There are additional columns such as `qual1` (per-base quality scores) and
-`sequence_index` (0-based read number) &mdash; see the
-[`read_fastx` reference](../docs/table-functions.md#read_fastxfilename-sequence2filename-include_filepathfalse-qual_offset33)
+There are additional columns such as `qual1` (per-base quality scores),
+`sequence_index` (1-based read number), and the `run_accession` /
+`sample_accession` / `experiment_accession` provenance columns &mdash; see the
+[`read_ena_sequences` reference](../docs/table-functions.md#read_ena_sequencesaccession-include_filepathfalse-qual_offset33-max_sequences0)
 for the full schema.
 
 ## How many reads are there?
@@ -126,7 +128,7 @@ counts = con.sql(f"""
     SELECT count(*) AS n_reads,
            min(len(sequence1)) AS min_length,
            max(len(sequence1)) AS max_length
-    FROM read_fastx('{FASTQ_URL}')
+    FROM read_ena_sequences('{ACCESSION}')
 """).df()
 
 print(counts)
@@ -146,16 +148,16 @@ Every base call in a FASTQ file has an associated
 score of 30 means a 1-in-1,000 chance the base call is wrong; 40 means
 1-in-10,000.
 
-`read_fastx` returns quality scores as a list of integers in the `qual1`
-column. We can compute the mean quality per read and bring the result into
-pandas:
+`read_ena_sequences` returns quality scores as a list of integers in the
+`qual1` column. We can compute the mean quality per read and bring the result
+into pandas:
 
 ```python
 quality = con.sql(f"""
     SELECT read_id,
            round(list_aggregate(qual1, 'avg'), 1)
                AS mean_quality
-    FROM read_fastx('{FASTQ_URL}')
+    FROM read_ena_sequences('{ACCESSION}')
 """).df()
 
 print(quality.describe())
@@ -203,7 +205,7 @@ gc = con.sql(f"""
                len(replace(replace(upper(sequence1), 'A', ''), 'T', ''))
                * 100.0 / len(sequence1),
            1) AS gc_pct
-    FROM read_fastx('{FASTQ_URL}')
+    FROM read_ena_sequences('{ACCESSION}')
 """).df()
 
 fig, ax = plt.subplots(figsize=(8, 4))
@@ -241,7 +243,7 @@ con.sql(f"""
                sequence1,
                round(list_aggregate(qual1, 'avg'), 1)
                    AS mean_quality
-        FROM read_fastx('{FASTQ_URL}')
+        FROM read_ena_sequences('{ACCESSION}')
     ) TO '{parquet_path}' (FORMAT parquet)
 """)
 
@@ -265,7 +267,7 @@ print(df.head())
 ## What's next?
 
 You've learned how to:
-- Read a remote FASTQ file into a pandas DataFrame
+- Read a sequencing run directly from ENA into a pandas DataFrame
 - Compute per-read quality and GC content
 - Save processed data to Parquet
 

--- a/onboarding-tutorials/intermediate.md
+++ b/onboarding-tutorials/intermediate.md
@@ -66,13 +66,12 @@ K-12 MG1655 complete genome (4,641,652 bp).
 ```sql
 CREATE TABLE reads AS
     SELECT *
-    FROM read_fastx(
-        'https://ftp.sra.ebi.ac.uk/vol1/run/ERR107/ERR1074767/10317.000004216.fastq.gz'
-    );
+    FROM read_ena_sequences('ERR1074767');
 ```
 
-This loads all 20,939 reads into memory. For larger files you could query the
-file directly, but loading into a table avoids re-downloading on every query.
+This loads all 20,939 reads into memory. For larger runs you could query
+`read_ena_sequences` directly, but loading into a table avoids re-downloading on
+every query.
 
 ## Step 2: Align reads to the reference
 


### PR DESCRIPTION
## What

Switch all three onboarding tutorials (beginner / intermediate / advanced) from reading run **ERR1074767** via `read_fastx('https://ftp.sra.ebi.ac.uk/vol1/run/...')` to the purpose-built `read_ena_sequences('ERR1074767')`.

## Why

`read_ena_sequences` is the correct function for ENA-by-accession data, and it is more robust: it resolves the accession to its FASTQ download(s) and **retries once on a transient open failure**. `read_fastx` has no retry, which is exactly why the **Test with Bowtie2** lane on #110 hard-failed on a single `HTTP HEAD` timeout to `ftp.sra.ebi.ac.uk` while running the tutorial tests. Using accessions also removes the hardcoded mirror URL.

This does **not** eliminate the network dependency (ENA can still be down), but it removes the no-retry hard-fail on a transient HEAD timeout and stops hardcoding a raw FTP path.

## Behavioral note (read IDs)

`read_ena_sequences` fetches ENA's canonical `ERR1074767.fastq.gz`, which renames reads:

| | submitted file (old docs) | ENA canonical (`read_ena_sequences`) |
|---|---|---|
| `read_id` | `10317.000004216_0` | `ERR1074767.1` |
| `comment` | `orig_bc=… new_bc=…` | `10317.000004216_0/1` |

It is the **same 20,939 SINGLE-end reads with identical sequences**, so every numeric result in the tutorials (199 alignments, the 16S operon coordinates, V4 identity, the DosP finding, woltka counts, genome coverage) is unchanged. Two consequences are handled here:

- `advanced.md`'s two read-id-keyed tracing examples are re-keyed to the new IDs (`ERR1074767.6976`, `ERR1074767.6600`), **verified against the actual file**.
- `beginner.md`'s `comment`-column description is updated (it's now the original submission read name, not barcode info), and the pre-existing wrong `sequence_index` "0-based" note is corrected to **1-based** (both `read_fastx` and `read_ena_sequences` are 1-based).

## Verification

Ran `onboarding-tutorials/run_tutorial_tests.sh` against the local v1.5.3 build:

- **intermediate.md** ✅ and **advanced.md** (SQL + bash) ✅ pass the harness via the CLI. The re-keyed `WHERE read_id = 'ERR1074767.6600'` returns the DosP primary (`151=`, identity `1.0`); the `ERR1074767.6976` example returns its 1 primary + 5 secondary hits.
- **beginner.md**'s SQL verified directly via the v1.5.3 CLI (20,939 reads × 151 bp, parquet round-trip OK). Its Python path only fails locally on a DuckDB **ABI mismatch** (extension is v1.5.3; no local v1.5.3 Python env) — not on these changes; CI builds Python and the extension at the same version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)