### PR TITLE
feat(id-types): UUID + BIGINT identifier columns across alignment, COPY SAM/BAM, vsearch, and blast

### DIFF
--- a/docs/copy-formats.md
+++ b/docs/copy-formats.md
@@ -121,21 +121,21 @@ TO 'output.fasta.gz' (FORMAT FASTA, INCLUDE_COMMENT true);
 Write query results to SAM or BAM format files. Requires all mandatory SAM columns from `read_alignments` output.
 
 **Required columns:**
-- `read_id` (VARCHAR or BIGINT): Query template name
+- `read_id` (VARCHAR, BIGINT, or UUID): Query template name
 - `flags` (USMALLINT): Bitwise flags
-- `reference` (VARCHAR or BIGINT): Reference sequence name
+- `reference` (VARCHAR, BIGINT, or UUID): Reference sequence name
 - `position` (BIGINT): 1-based leftmost mapping position
 - `mapq` (UTINYINT): Mapping quality
 - `cigar` (VARCHAR): CIGAR string
-- `mate_reference` (VARCHAR or BIGINT): Reference name of mate/next read
+- `mate_reference` (VARCHAR, BIGINT, or UUID): Reference name of mate/next read
 - `mate_position` (BIGINT): Position of mate/next read
 - `template_length` (BIGINT): Observed template length
 
 **Identifier-column types (`read_id`, `reference`, `mate_reference`):**
-- Each column is independently `VARCHAR` or `BIGINT`. The three need not match. Other numeric types are rejected at bind time with the message `Column '<name>' must be VARCHAR or BIGINT`.
-- `BIGINT` values are stringified to decimal on write — the on-disk SAM/BAM record always carries text. NULL `BIGINT` values are written as the SAM `*` sentinel.
-- Round-trip through `read_alignments` / `read_sam` returns these columns as `VARCHAR` regardless of how they were written; the BIGINT type is not preserved on disk.
-- HTSlib normalises `RNEXT` to `=` when it equals `RNAME` at the reference-tid level. This applies to both VARCHAR and BIGINT writes — a `BIGINT` mate_reference that matches `reference` still appears as `=` when the file is read back.
+- Each column is independently `VARCHAR`, `BIGINT`, or `UUID`. The three need not match. Other numeric types are rejected at bind time with the message `Column '<name>' must be VARCHAR, BIGINT, or UUID`.
+- `BIGINT` values are stringified to decimal on write; `UUID` values are stringified to their canonical 36-char lowercase form. The on-disk SAM/BAM record always carries text. NULL `BIGINT`/`UUID` values are written as the SAM `*` sentinel.
+- Round-trip through `read_alignments` / `read_sam` returns these columns as `VARCHAR` regardless of how they were written; the `BIGINT`/`UUID` type is not preserved on disk.
+- HTSlib normalises `RNEXT` to `=` when it equals `RNAME` at the reference-tid level. This applies to all id types — a `BIGINT`/`UUID` mate_reference that matches `reference` still appears as `=` when the file is read back.
 
 **Optional columns:**
 - `tag_as`, `tag_xs`, `tag_ys`, `tag_xn`, `tag_xm`, `tag_xo`, `tag_xg`, `tag_nm` (BIGINT): Optional integer tags

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -936,7 +936,7 @@ Search sequences against NCBI's remote BLAST databases. Sends query sequences to
 - Network access to NCBI BLAST servers (blast.ncbi.nlm.nih.gov)
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns. TEMP tables are not supported — use persistent tables.
+- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR, BIGINT, or UUID — see *Identifier-column types* below) and `sequence1` (VARCHAR) columns. TEMP tables are not supported — use persistent tables.
 - `program` (VARCHAR, optional, default `'blastn'`): BLAST program. One of: `blastn`, `blastp`, `blastx`, `tblastn`, `tblastx`.
 - `database` (VARCHAR, optional, default `'nt'`): Target database (e.g., `'nt'`, `'nr'`, `'refseq_rna'`, `'swissprot'`).
 - `evalue` (DOUBLE, optional, default 10.0): E-value threshold. Only hits with e-value at or below this threshold are returned.
@@ -948,8 +948,8 @@ Search sequences against NCBI's remote BLAST databases. Sends query sequences to
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `query_id` | VARCHAR | Query sequence identifier (from `read_id` column) |
-| `subject_id` | VARCHAR | Subject (hit) accession |
+| `query_id` | VARCHAR, BIGINT, or UUID | Query sequence identifier (mirrors the query table's `read_id` type) |
+| `subject_id` | VARCHAR | Subject (hit) accession (always VARCHAR — an NCBI accession) |
 | `pct_identity` | DOUBLE | Percentage of identical matches |
 | `alignment_length` | INTEGER | Alignment length |
 | `mismatches` | INTEGER | Number of mismatches |
@@ -960,6 +960,10 @@ Search sequences against NCBI's remote BLAST databases. Sends query sequences to
 | `subject_end` | BIGINT | End of alignment in subject |
 | `evalue` | DOUBLE | Expect value |
 | `bit_score` | DOUBLE | Bit score |
+
+**Identifier-column types (`query_id`):**
+- The query table's `read_id` may be `VARCHAR`, `BIGINT`, or `UUID` (other numeric types — INTEGER, UBIGINT, HUGEINT, DOUBLE — are rejected at bind time with `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`). The output `query_id` mirrors that type. `subject_id` is always `VARCHAR` — it is an NCBI accession, not a user-table id.
+- `BIGINT`/`UUID` query ids are sent to NCBI as the FASTA defline (decimal / canonical-lowercase) and parsed back to the original type on output. The round-trip therefore depends on NCBI echoing the submitted query id verbatim.
 
 **Behavior:**
 - Loads all sequences from the query table into memory, then submits them to NCBI BLAST as FASTA
@@ -1733,8 +1737,8 @@ Align query sequences to subject sequences using minimap2. This function enables
 **Performance:** For large reference databases (e.g., human genome), use pre-built indexes via `index_path` for 10-30x faster alignment. Build indexes once with `save_minimap2_index`, then reuse them across multiple queries.
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR` or `BIGINT` (see *Identifier-column types* below).
-- `subject_table` (VARCHAR, optional): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR` or `BIGINT`. **Either `subject_table` OR `index_path` must be provided, but not both.**
+- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID` (see *Identifier-column types* below).
+- `subject_table` (VARCHAR, optional): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID`. **Either `subject_table` OR `index_path` must be provided, but not both.**
 - `index_path` (VARCHAR, optional): Path to pre-built minimap2 index file (.mmi). Use `save_minimap2_index()` to create index files. **Either `subject_table` OR `index_path` must be provided, but not both.**
 - `per_subject_database` (BOOLEAN, default: false): Build separate index for each subject sequence (only valid with `subject_table`, not with `index_path`)
   - `false` (default): Build single index from all subjects, align all queries once (efficient for many subjects)
@@ -1751,14 +1755,14 @@ Align query sequences to subject sequences using minimap2. This function enables
 
 **Output schema:**
 Returns the same schema as `read_alignments` (21 columns):
-- `read_id` (VARCHAR or BIGINT — mirrors `query_table.read_id`): Query sequence identifier
+- `read_id` (VARCHAR, BIGINT, or UUID — mirrors `query_table.read_id`): Query sequence identifier
 - `flags` (USMALLINT): SAM alignment flags
-- `reference` (VARCHAR or BIGINT — mirrors `subject_table.read_id`; always VARCHAR when using `index_path`): Subject sequence identifier
+- `reference` (VARCHAR, BIGINT, or UUID — mirrors `subject_table.read_id`; always VARCHAR when using `index_path`): Subject sequence identifier
 - `position` (BIGINT): 1-based start position on reference
 - `stop_position` (BIGINT): 1-based stop position on reference
 - `mapq` (UTINYINT): Mapping quality
 - `cigar` (VARCHAR): CIGAR string (with =/X by default)
-- `mate_reference` (VARCHAR or BIGINT — same type as `reference`): Mate reference (for paired-end)
+- `mate_reference` (VARCHAR, BIGINT, or UUID — same type as `reference`): Mate reference (for paired-end)
 - `mate_position` (BIGINT): Mate position (for paired-end)
 - `template_length` (BIGINT): Template length (for paired-end)
 - `tag_as` (BIGINT): Alignment score
@@ -1774,10 +1778,11 @@ Returns the same schema as `read_alignments` (21 columns):
 - `tag_sa` (VARCHAR): Supplementary alignment info
 
 **Identifier-column types (`read_id`, `reference`, `mate_reference`):**
-- The input columns may be `VARCHAR` or `BIGINT`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column '<name>' in table '<table>' must be VARCHAR or BIGINT`.
+- The input columns may be `VARCHAR`, `BIGINT`, or `UUID`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column '<name>' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
 - The output `read_id` column type mirrors the query side. The output `reference` and `mate_reference` types mirror the subject side, **except when using `index_path`** — subject names stored in a `.mmi` file are opaque bytes, so both default to `VARCHAR` regardless of what the source table looked like when the index was built.
-- For `BIGINT` subjects, the SAM `=` mate-reference sentinel (which has no BIGINT encoding) is resolved to the primary reference value before being emitted; downstream consumers see the resolved numeric id, never `'='`.
-- For `BIGINT` columns, NULL input values and the SAM `'*'` unmapped sentinel are both surfaced as SQL NULL in the output. VARCHAR sentinels (`'*'`, `'='`) pass through verbatim, preserving pre-existing behaviour.
+- `BIGINT` ids are stringified to decimal on the wire; `UUID` ids are stringified to their canonical 36-char lowercase form. Both are parsed back to the original storage type on output (a `UUID` round-trips case-insensitively — uppercase input comes back canonical lowercase).
+- For non-VARCHAR subjects (`BIGINT`/`UUID`), the SAM `=` mate-reference sentinel (which has no `BIGINT`/`UUID` encoding) is resolved to the primary reference value before being emitted; downstream consumers see the resolved id, never `'='`.
+- For `BIGINT`/`UUID` columns, NULL input values and the SAM `'*'` unmapped sentinel are both surfaced as SQL NULL in the output. VARCHAR sentinels (`'*'`, `'='`) pass through verbatim, preserving pre-existing behaviour.
 
 **Behavior:**
 - Subject sequences are loaded into memory at bind time (must fit in RAM)
@@ -1891,7 +1896,7 @@ Build and save a minimap2 index to disk for reuse. This provides 10-30x performa
 **Use case:** Build indexes once for large reference databases (e.g., WoLr2 phylogenetic markers, RefSeq genomes, custom OGU databases), then use them repeatedly with `align_minimap2(..., index_path='file.mmi')` instead of rebuilding the index each time.
 
 **Parameters:**
-- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR` or `BIGINT`; `BIGINT` ids are stringified to decimal before being written into the index. When the index is later loaded via `align_minimap2(..., index_path=...)`, the recovered subject names are always `VARCHAR` (see *Identifier-column types* in `align_minimap2`).
+- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID`; `BIGINT` ids are stringified to decimal before being written into the index. When the index is later loaded via `align_minimap2(..., index_path=...)`, the recovered subject names are always `VARCHAR` (see *Identifier-column types* in `align_minimap2`).
 - `output_path` (VARCHAR): Path where the index file (.mmi) will be saved
 - `preset` (VARCHAR, default: 'sr'): Minimap2 preset (same options as `align_minimap2`)
 - `k` (INTEGER, optional): K-mer size (overrides preset default if specified)
@@ -1988,7 +1993,7 @@ SELECT * FROM save_minimap2_index('marker_genes', 'markers.mmi');
 Align query sequences against multiple pre-built minimap2 index shards in parallel. Each shard is a separate `.mmi` index file, and a mapping table specifies which reads should be aligned against which shard. This is designed for large-scale metagenomic workflows where the reference database is split across multiple shards and reads have been pre-assigned to shards (e.g., by a prior classification step).
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR` or `BIGINT` (see *Identifier-column types* below).
+- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID` (see *Identifier-column types* below).
 - `shard_directory` (VARCHAR, required): Path to directory containing pre-built minimap2 index files. Each shard's index is expected at `<shard_directory>/<shard_name>.mmi`
 - `read_to_shard` (VARCHAR, required): Name of table or view that maps reads to shards. Must have columns:
   - `read_id`: Read identifier. Must match the storage type of `query_table.read_id` exactly — VARCHAR with VARCHAR, BIGINT with BIGINT. Mismatched types are rejected at bind time.
@@ -2001,10 +2006,10 @@ Align query sequences against multiple pre-built minimap2 index shards in parall
 Returns the same 21-column schema as `align_minimap2` and `read_alignments`.
 
 **Identifier-column types (`read_id`, `reference`, `mate_reference`):**
-- The query side (`query_table.read_id` and `read_to_shard.read_id`) may be `VARCHAR` or `BIGINT`. Both must share the same type — `ValidateReadToShardSchema` enforces strict equality so the underlying JOIN never relies on implicit casts. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR or BIGINT`.
+- The query side (`query_table.read_id` and `read_to_shard.read_id`) may be `VARCHAR`, `BIGINT`, or `UUID`. Both must share the same type — `ValidateReadToShardSchema` enforces strict equality so the underlying JOIN never relies on implicit casts. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
 - The output `read_id` column mirrors the query side.
 - The output `reference` and `mate_reference` columns are **always VARCHAR** in sharded mode. Sharded alignment always loads prebuilt `.mmi` indexes, and subject names inside an `.mmi` are opaque bytes — the same contract as `align_minimap2(index_path=...)`. If the index was built from a `BIGINT` subject table via `save_minimap2_index`, the values come back as their decimal string form (e.g. `'2001'`); cast in SQL if you need integer semantics downstream.
-- For `BIGINT` `read_id`, NULL input rows that have no entry in `read_to_shard` are silently skipped (the pipeline never sees them). The SAM `'='` mate-reference sentinel is irrelevant here because the subject side is VARCHAR — `'='` passes through verbatim, matching the existing VARCHAR contract.
+- For `BIGINT`/`UUID` `read_id`, NULL input rows that have no entry in `read_to_shard` are silently skipped (the pipeline never sees them). The SAM `'='` mate-reference sentinel is irrelevant here because the subject side is VARCHAR — `'='` passes through verbatim, matching the existing VARCHAR contract.
 
 **Behavior:**
 - At bind time, reads the `read_to_shard` table to discover shards and validate that each `<shard_name>.mmi` file exists in `shard_directory`
@@ -2089,8 +2094,8 @@ Bowtie2 runs out of process via the `gpl-boundary` daemon (an Apache-licensed pr
 - The `gpl-boundary` daemon must be installed. Easiest path: `SELECT install_gpl_boundary();`. The miint extension itself does not link bowtie2.
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR` or `BIGINT` (see *Identifier-column types* below).
-- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR` or `BIGINT`.
+- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID` (see *Identifier-column types* below).
+- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID`.
 - `preset` (VARCHAR, optional): Bowtie2 preset for alignment sensitivity
   - `'very-fast'`: Fastest, least sensitive
   - `'fast'`: Fast alignment
@@ -2134,14 +2139,14 @@ Unknown parameters are rejected at bind time by DuckDB's binder (e.g. `presset :
 
 **Output schema:**
 Returns the same schema as `read_alignments` (21 columns):
-- `read_id` (VARCHAR or BIGINT — mirrors the query side): Query sequence identifier
+- `read_id` (VARCHAR, BIGINT, or UUID — mirrors the query side): Query sequence identifier
 - `flags` (USMALLINT): SAM alignment flags
-- `reference` (VARCHAR or BIGINT — mirrors the subject side): Subject sequence identifier
+- `reference` (VARCHAR, BIGINT, or UUID — mirrors the subject side): Subject sequence identifier
 - `position` (BIGINT): 1-based start position on reference
 - `stop_position` (BIGINT): 1-based stop position on reference
 - `mapq` (UTINYINT): Mapping quality
 - `cigar` (VARCHAR): CIGAR string
-- `mate_reference` (VARCHAR or BIGINT — mirrors the subject side): Mate reference (for paired-end)
+- `mate_reference` (VARCHAR, BIGINT, or UUID — mirrors the subject side): Mate reference (for paired-end)
 - `mate_position` (BIGINT): Mate position (for paired-end)
 - `template_length` (BIGINT): Template length (for paired-end)
 - `tag_as` (BIGINT): Alignment score
@@ -2157,11 +2162,11 @@ Returns the same schema as `read_alignments` (21 columns):
 - `tag_sa` (VARCHAR): Supplementary alignment info
 
 **Identifier-column types (`read_id`, `reference`, `mate_reference`):**
-- The input columns may be `VARCHAR` or `BIGINT`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column '<name>' in table '<table>' must be VARCHAR or BIGINT`.
+- The input columns may be `VARCHAR`, `BIGINT`, or `UUID`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column '<name>' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
 - The output `read_id` column type mirrors the query side; `reference` and `mate_reference` mirror the subject side. Query and subject id types are independent (mixed BIGINT/VARCHAR is allowed).
 - The daemon wire schema is always strings — BIGINT support is C++/DuckDB-only. On egress, the codec parses decimal strings back to `int64_t`; on ingress, `BIGINT` values are stringified by DuckDB's implicit `Value::GetValue<std::string>()` cast before crossing the Arrow IPC boundary.
-- For `BIGINT` subjects, the SAM `=` mate-reference sentinel is resolved to the row's `reference` value before being emitted (the literal `=` has no BIGINT encoding); VARCHAR output preserves `=` verbatim, matching pre-existing behavior.
-- For `BIGINT` columns, the SAM `*` unmapped sentinel surfaces as SQL NULL. VARCHAR sentinels pass through verbatim.
+- For `BIGINT`/`UUID` subjects, the SAM `=` mate-reference sentinel is resolved to the row's `reference` value before being emitted (the literal `=` has no BIGINT/UUID encoding); VARCHAR output preserves `=` verbatim, matching pre-existing behavior.
+- For `BIGINT`/`UUID` columns, the SAM `*` unmapped sentinel surfaces as SQL NULL. VARCHAR sentinels pass through verbatim.
 - NULL `read_id` rows are rejected at row time with `NULL read_id or sequence1 in query table` — same contract as VARCHAR. The daemon's input schema requires both columns non-null.
 
 **Behavior:**
@@ -2245,7 +2250,7 @@ The sharded path emits only mapped reads (the daemon is invoked with `--no-unal`
 - The `gpl-boundary` daemon must be installed (see `SELECT install_gpl_boundary();`).
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR` or `BIGINT` (see *Identifier-column types* below).
+- `query_table` (VARCHAR): Name of table or view containing query sequences. Must have `read_fastx`-compatible schema (read_id, sequence1, optional sequence2/qual1/qual2). The `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID` (see *Identifier-column types* below).
 - `shard_directory` (VARCHAR, required): Path to directory containing shard subdirectories. Each shard's Bowtie2 index is expected at `<shard_directory>/<shard_name>/index` (i.e., files like `<shard_name>/index.1.bt2`, `<shard_name>/index.rev.1.bt2`, etc.)
 - `read_to_shard` (VARCHAR, required): Name of table or view that maps reads to shards. Must have columns:
   - `read_id`: Read identifier. Must match the storage type of `query_table.read_id` exactly — VARCHAR with VARCHAR, BIGINT with BIGINT. Mismatched types are rejected at bind time.
@@ -2266,10 +2271,10 @@ The `no_unal` knob is intentionally not exposed: the sharded path always emits o
 Returns the same 21-column schema as `align_bowtie2` and `read_alignments`.
 
 **Identifier-column types (`read_id`, `reference`, `mate_reference`):**
-- The query side (`query_table.read_id` and `read_to_shard.read_id`) may be `VARCHAR` or `BIGINT`. Both must share the same type — `ValidateReadToShardSchema` enforces strict equality so the underlying JOIN never relies on implicit casts. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time.
+- The query side (`query_table.read_id` and `read_to_shard.read_id`) may be `VARCHAR`, `BIGINT`, or `UUID`. Both must share the same type — `ValidateReadToShardSchema` enforces strict equality so the underlying JOIN never relies on implicit casts. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time.
 - The output `read_id` column mirrors the query side.
 - The output `reference` and `mate_reference` columns are **always VARCHAR** in sharded mode. Sharded alignment always loads prebuilt Bowtie2 indexes, and reference names inside those indexes are opaque bytes — the same contract as `align_minimap2_sharded`. Cast in SQL (`CAST(reference AS BIGINT)`) if you need integer semantics downstream.
-- For `BIGINT` `read_id`, NULL input rows that have no entry in `read_to_shard` are silently skipped (the JOIN filters them out before they reach the daemon).
+- For `BIGINT`/`UUID` `read_id`, NULL input rows that have no entry in `read_to_shard` are silently skipped (the JOIN filters them out before they reach the daemon).
 
 **Behavior:**
 - At bind time, reads the `read_to_shard` table to discover shards; per-shard index existence is verified at InitGlobal (not Bind) so the planner doesn't pay filesystem-stat cost on wide shard sets.
@@ -2529,7 +2534,7 @@ rRNA filtering / alignment against one or more rRNA reference databases using [S
 Emits the standard 21-column SAM schema shared with `align_minimap2` / `align_bowtie2`. For a schema preserving SortMeRNA's native identity / coverage / e-value / edit-distance fields, use [`align_sortmerna_rrna`](#align_sortmerna_rrnaquery_table-ref_pathspaths-options) below.
 
 **Parameters:**
-- `query_table` (VARCHAR, positional): Name of a table or view with columns `read_id` (VARCHAR or BIGINT — see *Identifier-column types* below), `sequence1` (VARCHAR), and optionally `sequence2` (VARCHAR) when `paired := true`.
+- `query_table` (VARCHAR, positional): Name of a table or view with columns `read_id` (VARCHAR, BIGINT, or UUID — see *Identifier-column types* below), `sequence1` (VARCHAR), and optionally `sequence2` (VARCHAR) when `paired := true`.
 - `ref_paths` (VARCHAR[], required): List of FASTA paths for the reference database(s). The index is built once per query in-memory — re-using references across queries rebuilds the index each time.
 - `num_threads` (INTEGER, default = DuckDB's thread count): Number of threads SortMeRNA's internal pool uses. The DuckDB function runs on a single DuckDB thread; parallelism is inside SortMeRNA.
 - `match`, `mismatch`, `gap_open`, `gap_ext`, `score_N` (INTEGER): SW scoring. Defaults `2 / -3 / 5 / 2 / 0`.
@@ -2548,10 +2553,10 @@ Emits the standard 21-column SAM schema shared with `align_minimap2` / `align_bo
 - Paired-end: `flags & 0x2` (proper pair) is set when both mates aligned, regardless of reference. This is weaker than SAM's standard "concordant orientation within insert size" meaning — SortMeRNA is an rRNA classifier with no notion of insert size or orientation. When both mates aligned but to different references, `mate_reference` reports the actual partner reference name (rather than `=`), so cross-reference pairs remain distinguishable.
 
 **Identifier-column types (`read_id`):**
-- The input `read_id` column may be `VARCHAR` or `BIGINT`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR or BIGINT`.
+- The input `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
 - The output `read_id` column type mirrors the query side. `reference` and `mate_reference` are always `VARCHAR` — SortMeRNA references come from FASTA files on disk (`ref_paths`), never a user-provided table.
 - Because the subject side is always VARCHAR, the SAM `=` mate-reference sentinel is preserved verbatim for paired-end output when both mates map to the same reference (no resolution needed — VARCHAR carries `=` directly, unlike the BIGINT-subject path in `align_minimap2` / `align_bowtie2`).
-- For `BIGINT` `read_id`, rows with NULL `read_id` are skipped at ingress (matching the existing `ProcessSingleChunk` row-skip convention used by VARCHAR query tables).
+- For `BIGINT`/`UUID` `read_id`, rows with NULL `read_id` are skipped at ingress (matching the existing `ProcessSingleChunk` row-skip convention used by VARCHAR query tables).
 
 **Caveats:**
 - **No minimum-score filter:** the embedded library returns every positive Smith-Waterman hit. The `sortmerna` CLI applies an internal minimum-score threshold that our streaming API path bypasses; to reproduce CLI output row-for-row, filter on `score` (`tag_as`) or on `e_value` in SQL. Be aware that e-values are not directly comparable between the library and the CLI (see below), so a library-side e-value threshold is not guaranteed to reproduce the exact CLI row set.
@@ -2582,7 +2587,7 @@ Same aligner as `align_sortmerna` but emits SortMeRNA's native output schema, wh
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `read_id` | VARCHAR or BIGINT | Query read identifier from the input table (mirrors the query column type — see *Identifier-column types* below) |
+| `read_id` | VARCHAR, BIGINT, or UUID | Query read identifier from the input table (mirrors the query column type — see *Identifier-column types* below) |
 | `aligned` | INTEGER | `1` if the read aligned, `0` otherwise |
 | `strand` | INTEGER | `1` for forward, `0` for reverse-complement. `0` for unaligned rows has no meaning. |
 | `ref_name` | VARCHAR | Reference sequence ID (empty for unaligned rows) |
@@ -2599,9 +2604,9 @@ Same aligner as `align_sortmerna` but emits SortMeRNA's native output schema, wh
 Paired-end mode produces two rows per input row with `segment_idx` 0 (forward) and 1 (reverse), even when one or both mates failed to align.
 
 **Identifier-column types (`read_id`):**
-- The input `read_id` column may be `VARCHAR` or `BIGINT`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR or BIGINT`.
+- The input `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
 - The output `read_id` column type mirrors the query side. `ref_name` is always `VARCHAR` — it carries the free-form FASTA header text from `ref_paths`, not an identifier column.
-- For `BIGINT` `read_id`, rows with NULL `read_id` are skipped at ingress (matching the existing `ProcessSingleChunk` row-skip convention used by VARCHAR query tables).
+- For `BIGINT`/`UUID` `read_id`, rows with NULL `read_id` are skipped at ingress (matching the existing `ProcessSingleChunk` row-skip convention used by VARCHAR query tables).
 
 **Example:**
 
@@ -2763,8 +2768,8 @@ ORDER BY ref_pos, query_base;
 Reference-based chimera detection using the UCHIME algorithm (Edgar et al. 2011, Bioinformatics 27:2194-2200), powered by the [vsearch](https://github.com/torognes/vsearch) library (Rognes et al. 2016, PeerJ 4:e2584). Detects chimeric sequences by comparing queries against a trusted chimera-free reference database.
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns.
-- `db` (VARCHAR, required): Name of a table or view containing reference sequences. Same schema requirements as `query_table`.
+- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR, BIGINT, or UUID — see *Identifier-column types* below) and `sequence1` (VARCHAR) columns.
+- `db` (VARCHAR, required): Name of a table or view containing reference sequences. Same schema requirements as `query_table` (its `read_id` type is independent of the query's).
 - `sample_id` (VARCHAR, optional): Name of a column in `query_table` to partition by. When provided, queries are scored per-sample against the (shared, load-once) reference database, and the sample column is prepended to the output. Execution is serialized (the vsearch wrapper is not thread-safe across concurrent calls).
 - `minh` (DOUBLE, default 0.28): Minimum h-score to flag as chimeric. Range [0, 1].
 - `xn` (DOUBLE, default 8.0): Weight of "no" votes in h-score computation. Must be >= 1.0.
@@ -2778,10 +2783,10 @@ Reference-based chimera detection using the UCHIME algorithm (Edgar et al. 2011,
 | Column | Type | Description |
 |--------|------|-------------|
 | `score` | DOUBLE | Chimera h-score (higher = more likely chimeric) |
-| `read_id` | VARCHAR | Query sequence identifier |
-| `parent_a_id` | VARCHAR | Parent A identifier (NULL if non-chimeric) |
-| `parent_b_id` | VARCHAR | Parent B identifier (NULL if non-chimeric) |
-| `closest_parent_id` | VARCHAR | Closest parent to query (NULL if non-chimeric) |
+| `read_id` | VARCHAR, BIGINT, or UUID | Query sequence identifier (mirrors `query_table.read_id`) |
+| `parent_a_id` | VARCHAR, BIGINT, or UUID | Parent A identifier (mirrors `db.read_id`; NULL if non-chimeric) |
+| `parent_b_id` | VARCHAR, BIGINT, or UUID | Parent B identifier (mirrors `db.read_id`; NULL if non-chimeric) |
+| `closest_parent_id` | VARCHAR, BIGINT, or UUID | Closest parent to query (mirrors `db.read_id`; NULL if non-chimeric) |
 | `id_query_model` | DOUBLE | Query-to-chimeric-model identity % |
 | `id_query_a` | DOUBLE | Query-to-parent-A identity % |
 | `id_query_b` | DOUBLE | Query-to-parent-B identity % |
@@ -2795,6 +2800,10 @@ Reference-based chimera detection using the UCHIME algorithm (Edgar et al. 2011,
 | `right_abstain` | INTEGER | Right segment abstain votes |
 | `divergence` | DOUBLE | Model divergence (id_query_model - id_query_top) |
 | `flag` | VARCHAR | Classification: `Y` (chimera), `N` (non-chimera), `?` (borderline) |
+
+**Identifier-column types (`read_id`, `parent_a_id`, `parent_b_id`, `closest_parent_id`):**
+- The query and reference `read_id` columns may each be `VARCHAR`, `BIGINT`, or `UUID`, independently. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
+- The output `read_id` mirrors the query table's type; the three parent columns (reference labels) mirror the reference table's type, and they can differ (e.g. a `UUID` query against a `BIGINT` reference). `BIGINT`/`UUID` ids round-trip through their decimal / canonical-lowercase forms. The parent columns stay SQL NULL for non-chimeric rows regardless of id type.
 
 **Example:**
 ```sql
@@ -2845,7 +2854,7 @@ SELECT flag, count(*) FROM detect_chimera_uchime('queries', db:='refs') GROUP BY
 De novo chimera detection using the UCHIME algorithm, powered by the [vsearch](https://github.com/torognes/vsearch) library (Rognes et al. 2016, PeerJ 4:e2584). Detects chimeric sequences without a reference database by using abundance information: more abundant sequences are assumed to be non-chimeric and serve as parents for less abundant sequences.
 
 **Parameters:**
-- `input_table` (VARCHAR): Name of a table or view containing sequences with abundance. By default must have `read_id` (VARCHAR), `sequence1` (VARCHAR), and `size` (integer type) columns; use `id_col`/`sequence_col`/`count_col` to override.
+- `input_table` (VARCHAR): Name of a table or view containing sequences with abundance. By default must have `read_id` (VARCHAR, BIGINT, or UUID — see *Identifier-column types* below), `sequence1` (VARCHAR), and `size` (integer type) columns; use `id_col`/`sequence_col`/`count_col` to override.
 - `sample_id` (VARCHAR, optional): Name of a column in `input_table` to partition by. Each sample gets its own k-mer index and bootstrap; a read_id that appears in multiple samples is therefore scored independently. The sample column is prepended to the output. Execution is serialized per the vsearch wrapper's thread-safety constraints.
 - `id_col` (VARCHAR, default `'read_id'`): Name of the read identifier column in `input_table`.
 - `sequence_col` (VARCHAR, default `'sequence1'`): Name of the sequence column.
@@ -2854,6 +2863,8 @@ De novo chimera detection using the UCHIME algorithm, powered by the [vsearch](h
 - `minh`, `xn`, `dn`, `mindiv`, `mindiffs`: Same as `detect_chimera_uchime`. (No `threads` parameter — de novo detection is sequential by construction; vsearch is run with `opt_threads=1`.)
 
 **Output schema:** Same 18 columns as `detect_chimera_uchime`.
+
+**Identifier-column types:** The `id_col` column may be `VARCHAR`, `BIGINT`, or `UUID` (other numeric types — INTEGER, UBIGINT, HUGEINT, DOUBLE — are rejected at bind time with `Column '<id_col>' in table '<table>' must be VARCHAR, BIGINT, or UUID`). De novo detection has a single id source, so `read_id` and all three parent columns share that one type; the parent columns stay NULL for non-chimeric rows. `BIGINT`/`UUID` ids round-trip through their decimal / canonical-lowercase forms. The `;size=` abundance annotation is never embedded in the id — the count comes from `count_col`, so a numeric id never collides with abundance.
 
 **Example:**
 ```sql
@@ -2894,8 +2905,8 @@ WHERE u.flag != 'Y';
 Global pairwise sequence search, powered by the [vsearch](https://github.com/torognes/vsearch) library (Rognes et al. 2016, PeerJ 4:e2584). Finds the best matching sequences in a reference database for each query sequence using SIMD-optimized Needleman-Wunsch alignment with k-mer candidate filtering.
 
 **Parameters:**
-- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns.
-- `db` (VARCHAR, required): Name of a table or view containing reference sequences. Same schema requirements as `query_table`.
+- `query_table` (VARCHAR): Name of a table or view containing query sequences. Must have `read_id` (VARCHAR, BIGINT, or UUID — see *Identifier-column types* below) and `sequence1` (VARCHAR) columns.
+- `db` (VARCHAR, required): Name of a table or view containing reference sequences. Same schema requirements as `query_table` (its `read_id` type is independent of the query's).
 - `id` (DOUBLE, required): Minimum identity threshold (0.0-1.0). No silent default — must be specified explicitly.
 - `maxaccepts` (INTEGER, default 1): Maximum number of accepted hits per query. Must be >= 1.
 - `maxrejects` (INTEGER, default 32): Maximum rejected targets before stopping search. Must be >= 1.
@@ -2905,8 +2916,8 @@ Global pairwise sequence search, powered by the [vsearch](https://github.com/tor
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `read_id` | VARCHAR | Query sequence identifier |
-| `target_id` | VARCHAR | Reference sequence identifier |
+| `read_id` | VARCHAR, BIGINT, or UUID | Query sequence identifier (mirrors `query_table.read_id`) |
+| `target_id` | VARCHAR, BIGINT, or UUID | Reference sequence identifier (mirrors `db.read_id`) |
 | `identity` | DOUBLE | Percent identity (0-100) |
 | `matches` | INTEGER | Number of matching columns |
 | `mismatches` | INTEGER | Number of mismatching columns |
@@ -2915,6 +2926,10 @@ Global pairwise sequence search, powered by the [vsearch](https://github.com/tor
 | `query_length` | INTEGER | Query sequence length |
 | `target_length` | INTEGER | Target sequence length |
 | `accepted` | BOOLEAN | True if hit passes identity threshold |
+
+**Identifier-column types (`read_id`, `target_id`):**
+- The query and reference `read_id` columns may each be `VARCHAR`, `BIGINT`, or `UUID`, independently. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
+- The output `read_id` mirrors the query table's type; `target_id` (a reference label) mirrors the reference table's type. They can differ (e.g. a `UUID` query against a `BIGINT` reference). `BIGINT`/`UUID` ids round-trip through their decimal / canonical-lowercase forms. Search emits one row per hit, so neither id is ever NULL.
 
 **Example:**
 ```sql
@@ -2952,7 +2967,7 @@ SELECT count(DISTINCT read_id) FROM search_sequences_vsearch('queries', db:='ref
 Greedy sequence clustering, powered by the [vsearch](https://github.com/torognes/vsearch) library (Rognes et al. 2016, PeerJ 4:e2584). Clusters sequences by iterating in input order: each sequence is compared against existing centroids, and either joins the best matching cluster (if above the identity threshold) or becomes a new centroid.
 
 **Parameters:**
-- `input_table` (VARCHAR): Name of a table or view containing sequences. Must have `read_id` (VARCHAR) and `sequence1` (VARCHAR) columns.
+- `input_table` (VARCHAR): Name of a table or view containing sequences. Must have `read_id` (VARCHAR, BIGINT, or UUID — see *Identifier-column types* below) and `sequence1` (VARCHAR) columns.
 - `id` (DOUBLE, required): Minimum identity threshold (0.0-1.0). No silent default — must be specified explicitly.
 - `strand` (VARCHAR, default `'plus'`): `'plus'` for plus-strand only, `'both'` to also search reverse complements.
 - `threads` (INTEGER, optional): Number of threads vsearch uses for its internal `cluster_assign_batch` parallel scan. Defaults to DuckDB's configured thread count (`SET threads=N`) at bind time; pass an explicit value to override. Must be 1–1024 (matching vsearch's CLI ceiling).
@@ -2961,13 +2976,17 @@ Greedy sequence clustering, powered by the [vsearch](https://github.com/torognes
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `read_id` | VARCHAR | Input sequence identifier |
+| `read_id` | VARCHAR, BIGINT, or UUID | Input sequence identifier (mirrors the input `read_id` type) |
 | `is_centroid` | BOOLEAN | True if this sequence started a new cluster |
 | `cluster_id` | INTEGER | Cluster number (0-based) |
-| `centroid_id` | VARCHAR | Identifier of the cluster's centroid |
+| `centroid_id` | VARCHAR, BIGINT, or UUID | Identifier of the cluster's centroid (mirrors the input `read_id` type) |
 | `identity` | DOUBLE | Percent identity to centroid (100.0 if centroid) |
 | `cigar` | VARCHAR | CIGAR alignment to centroid (empty if centroid) |
 | `cigar_truncated` | BOOLEAN | True if CIGAR was truncated (>4096 chars) |
+
+**Identifier-column types (`read_id`, `centroid_id`):**
+- The input `read_id` column may be `VARCHAR`, `BIGINT`, or `UUID`. Other numeric types (INTEGER, UBIGINT, HUGEINT, DOUBLE) are rejected at bind time with the message `Column 'read_id' in table '<table>' must be VARCHAR, BIGINT, or UUID`.
+- Both output id columns mirror the input type. `centroid_id` is itself one of the input `read_id`s, so it always shares `read_id`'s type. `BIGINT` ids round-trip through their decimal form; `UUID` ids round-trip through their canonical 36-char lowercase form (uppercase input comes back lowercase).
 
 **Sort order is the caller's responsibility.** The function clusters sequences in the order they appear in the input table. For `cluster_fast`-equivalent behavior (longest first), sort by length descending. For `cluster_size`-equivalent behavior (most abundant first), sort by abundance descending:
 

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -594,43 +594,19 @@ std::string read_arrow_string_owned(const ArrowArray &col, idx_t logical_index) 
 	return std::string(data + start, static_cast<size_t>(len));
 }
 
-// Emit one id-column cell into a flat output Vector. Branches on id_type:
-// VARCHAR writes the string verbatim; BIGINT parses via the codec. Caller
-// is responsible for SAM `=` resolution before invoking (substitute the
-// reference value into `s` for mate_reference rows where s == "=" and the
-// subject is BIGINT).
-void emit_id_cell(Vector &v, idx_t out_row, const std::string &s, const LogicalType &id_type) {
-	if (id_type.id() == LogicalTypeId::BIGINT) {
-		try {
-			auto parsed = ::miint::ParseIdAsInt64(s);
-			auto out_data = FlatVector::GetData<int64_t>(v);
-			auto &validity = FlatVector::Validity(v);
-			if (parsed.has_value()) {
-				out_data[out_row] = *parsed;
-				validity.SetValid(out_row);
-			} else {
-				validity.SetInvalid(out_row);
-			}
-		} catch (const std::exception &e) {
-			throw InvalidInputException("align_bowtie2: cannot parse id value '%s' as BIGINT: %s", s, e.what());
-		}
-		return;
-	}
-	// VARCHAR
-	FlatVector::GetData<string_t>(v)[out_row] = StringVector::AddString(v, s);
-}
-
 } // namespace
 
 void EmitChunkRows(DataChunk &output, idx_t to_emit, idx_t row_start, const ArrowArray &batch,
                    const LogicalType &query_id_type, const LogicalType &subject_id_type) {
 	if (!IsAllowedIdType(query_id_type) || !IsAllowedIdType(subject_id_type)) {
-		throw InternalException("align_bowtie2 EmitChunkRows: id types must be VARCHAR or BIGINT (got query=%s, "
-		                        "subject=%s)",
-		                        query_id_type.ToString(), subject_id_type.ToString());
+		throw InternalException("align_bowtie2 EmitChunkRows: id types must be %s (got query=%s, subject=%s)",
+		                        AllowedIdTypeList(), query_id_type.ToString(), subject_id_type.ToString());
 	}
-	const bool query_is_bigint = query_id_type.id() == LogicalTypeId::BIGINT;
-	const bool subject_is_bigint = subject_id_type.id() == LogicalTypeId::BIGINT;
+	// Non-VARCHAR ids (BIGINT, UUID) round-trip through the codec: read the
+	// Arrow string and let EmitIdCell parse it back to the storage type. VARCHAR
+	// ids copy straight from Arrow via emit_string.
+	const bool query_needs_codec = query_id_type.id() != LogicalTypeId::VARCHAR;
+	const bool subject_needs_codec = subject_id_type.id() != LogicalTypeId::VARCHAR;
 	auto &v_read_id = output.data[0];
 	auto *out_flags = FlatVector::GetData<uint16_t>(output.data[1]);
 	auto &v_reference = output.data[2];
@@ -691,27 +667,27 @@ void EmitChunkRows(DataChunk &output, idx_t to_emit, idx_t row_start, const Arro
 		const idx_t li = row_start + i;
 
 		// read_id: dispatch on query id type.
-		if (query_is_bigint) {
-			emit_id_cell(v_read_id, i, read_arrow_string_owned(col_read_id, li), query_id_type);
+		if (query_needs_codec) {
+			EmitIdCell(v_read_id, i, read_arrow_string_owned(col_read_id, li), query_id_type);
 		} else {
 			emit_string(v_read_id, i, col_read_id, li);
 		}
 		out_flags[i] = read_fixed<uint16_t>(col_flags, li);
 
-		// reference + mate_reference: dispatch on subject id type. For BIGINT
-		// subjects, cache the reference string so mate_reference "=" can
-		// resolve into it without re-reading the Arrow cell.
-		if (subject_is_bigint) {
+		// reference + mate_reference: dispatch on subject id type. For non-VARCHAR
+		// subjects, cache the reference string so mate_reference "=" can resolve
+		// into it without re-reading the Arrow cell.
+		if (subject_needs_codec) {
 			const std::string ref_str = read_arrow_string_owned(col_reference, li);
-			emit_id_cell(v_reference, i, ref_str, subject_id_type);
+			EmitIdCell(v_reference, i, ref_str, subject_id_type);
 			std::string mr_str = read_arrow_string_owned(col_mate_ref, li);
 			if (mr_str == "=") {
 				// SAM "=" sentinel: mate maps to the same reference as the
-				// primary alignment. The literal "=" has no BIGINT encoding,
+				// primary alignment. The literal "=" has no BIGINT/UUID encoding,
 				// so substitute the row's reference value before parsing.
 				mr_str = ref_str;
 			}
-			emit_id_cell(v_mate_ref, i, mr_str, subject_id_type);
+			EmitIdCell(v_mate_ref, i, mr_str, subject_id_type);
 		} else {
 			emit_string(v_reference, i, col_reference, li);
 			emit_string(v_mate_ref, i, col_mate_ref, li);

--- a/src/blast_search.cpp
+++ b/src/blast_search.cpp
@@ -1,4 +1,5 @@
 #include "blast_search.hpp"
+#include "id_column_utils.hpp"
 #include "miint_log.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types/value.hpp"
@@ -12,8 +13,10 @@ static std::vector<std::string> GetBlastOutputNames() {
 	        "query_start", "query_end",  "subject_start", "subject_end",      "evalue",     "bit_score"};
 }
 
-static std::vector<LogicalType> GetBlastOutputTypes() {
-	return {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::INTEGER,
+// query_id (col 0) mirrors the query table's read_id type. subject_id (col 1)
+// stays VARCHAR — it is an NCBI accession, not an id drawn from a user table.
+static std::vector<LogicalType> GetBlastOutputTypes(const LogicalType &query_id_type) {
+	return {query_id_type,        LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::INTEGER,
 	        LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::BIGINT, LogicalType::BIGINT,
 	        LogicalType::BIGINT,  LogicalType::BIGINT,  LogicalType::DOUBLE, LogicalType::DOUBLE};
 }
@@ -77,10 +80,13 @@ unique_ptr<FunctionData> BlastSearchTableFunction::Bind(ClientContext &context, 
 		throw BinderException("blast: megablast is only valid with program='blastn' (got program='%s')", data->program);
 	}
 
-	ValidateSequenceTableSchema(context, data->query_table);
+	// Capture the query read_id type (VARCHAR/BIGINT/UUID) so the output query_id
+	// mirrors it; subject_id stays VARCHAR.
+	auto query_schema = ValidateSequenceTableSchema(context, data->query_table, /*allow_bigint=*/true);
+	data->query_id_type = query_schema.id_type;
 
 	data->names = GetBlastOutputNames();
-	data->types = GetBlastOutputTypes();
+	data->types = GetBlastOutputTypes(data->query_id_type);
 	for (auto &n : data->names) {
 		names.emplace_back(n);
 	}
@@ -141,10 +147,12 @@ bool BlastSearchTableFunction::GlobalState::FetchNextBatch(ClientContext &contex
 	return false;
 }
 
-static void OutputBlastHits(DataChunk &output, const std::vector<miint::BlastHit> &hits, idx_t offset, idx_t count) {
+static void OutputBlastHits(DataChunk &output, const std::vector<miint::BlastHit> &hits, idx_t offset, idx_t count,
+                            const LogicalType &query_id_type) {
 	for (idx_t i = 0; i < count; i++) {
 		const auto &hit = hits[offset + i];
-		FlatVector::GetData<string_t>(output.data[0])[i] = StringVector::AddString(output.data[0], hit.query_id);
+		// query_id mirrors the query table's id type; subject_id is always VARCHAR.
+		EmitIdCell(output.data[0], i, hit.query_id, query_id_type);
 		FlatVector::GetData<string_t>(output.data[1])[i] = StringVector::AddString(output.data[1], hit.subject_id);
 		FlatVector::GetData<double>(output.data[2])[i] = hit.pct_identity;
 		FlatVector::GetData<int32_t>(output.data[3])[i] = hit.alignment_length;
@@ -161,6 +169,7 @@ static void OutputBlastHits(DataChunk &output, const std::vector<miint::BlastHit
 }
 
 void BlastSearchTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<Data>();
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
 	// Lock held during FetchNextBatch (which blocks on HTTP). Safe because
 	// MaxThreads()=1 guarantees a single caller. Same pattern as read_ncbi.cpp.
@@ -177,7 +186,7 @@ void BlastSearchTableFunction::Execute(ClientContext &context, TableFunctionInpu
 
 	idx_t remaining = gstate.result_buffer.size() - gstate.result_offset;
 	idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
-	OutputBlastHits(output, gstate.result_buffer, gstate.result_offset, count);
+	OutputBlastHits(output, gstate.result_buffer, gstate.result_offset, count, data.query_id_type);
 	gstate.result_offset += count;
 }
 

--- a/src/cluster_sequences.cpp
+++ b/src/cluster_sequences.cpp
@@ -1,4 +1,5 @@
 #include "cluster_sequences.hpp"
+#include "id_column_utils.hpp"
 #include "sequence_table_reader.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -13,13 +14,21 @@ static std::vector<std::string> GetClusterOutputNames() {
 	return {"read_id", "is_centroid", "cluster_id", "centroid_id", "identity", "cigar", "cigar_truncated"};
 }
 
-static std::vector<LogicalType> GetClusterOutputTypes() {
-	return {LogicalType::VARCHAR, LogicalType::BOOLEAN, LogicalType::INTEGER, LogicalType::VARCHAR,
-	        LogicalType::DOUBLE,  LogicalType::VARCHAR, LogicalType::BOOLEAN};
+// read_id (col 0) and centroid_id (col 3) mirror the input read_id type; the
+// centroid_id values are themselves drawn from the input read_ids, so the two
+// id columns always share one type.
+static std::vector<LogicalType> GetClusterOutputTypes(const LogicalType &id_type) {
+	return {id_type,
+	        LogicalType::BOOLEAN,
+	        LogicalType::INTEGER,
+	        id_type,
+	        LogicalType::DOUBLE,
+	        LogicalType::VARCHAR,
+	        LogicalType::BOOLEAN};
 }
 
 static idx_t OutputClusterResults(DataChunk &output, const std::vector<miint::ClusterResult> &results, idx_t offset,
-                                  idx_t count) {
+                                  idx_t count, const LogicalType &id_type) {
 	idx_t actual = std::min(count, static_cast<idx_t>(results.size()) - offset);
 	if (actual == 0) {
 		output.SetCardinality(0);
@@ -30,8 +39,7 @@ static idx_t OutputClusterResults(DataChunk &output, const std::vector<miint::Cl
 
 	auto &read_id_vec = output.data[col++];
 	for (idx_t i = 0; i < actual; i++) {
-		FlatVector::GetData<string_t>(read_id_vec)[i] =
-		    StringVector::AddString(read_id_vec, results[offset + i].read_id);
+		EmitIdCell(read_id_vec, i, results[offset + i].read_id, id_type);
 	}
 
 	auto is_centroid_data = FlatVector::GetData<bool>(output.data[col++]);
@@ -46,8 +54,7 @@ static idx_t OutputClusterResults(DataChunk &output, const std::vector<miint::Cl
 
 	auto &centroid_id_vec = output.data[col++];
 	for (idx_t i = 0; i < actual; i++) {
-		FlatVector::GetData<string_t>(centroid_id_vec)[i] =
-		    StringVector::AddString(centroid_id_vec, results[offset + i].centroid_id);
+		EmitIdCell(centroid_id_vec, i, results[offset + i].centroid_id, id_type);
 	}
 
 	auto identity_data = FlatVector::GetData<double>(output.data[col++]);
@@ -77,8 +84,10 @@ unique_ptr<FunctionData> ClusterSequencesTableFunction::Bind(ClientContext &cont
 
 	data->input_table = input.inputs[0].GetValue<std::string>();
 
-	// Validate table has read_id (VARCHAR) and sequence1 (VARCHAR)
-	ValidateSequenceTableSchema(context, data->input_table);
+	// Validate table has read_id (VARCHAR, BIGINT, or UUID) and sequence1
+	// (VARCHAR). Capture the read_id type so the output id columns mirror it.
+	auto schema = ValidateSequenceTableSchema(context, data->input_table, /*allow_bigint=*/true);
+	data->id_type = schema.id_type;
 
 	// id is required — no silent default.
 	auto id_it = input.named_parameters.find("id");
@@ -123,7 +132,7 @@ unique_ptr<FunctionData> ClusterSequencesTableFunction::Bind(ClientContext &cont
 	get_int("threads", data->params.threads, 1, 1024, ">= 1 and <= 1024");
 
 	data->names = GetClusterOutputNames();
-	data->types = GetClusterOutputTypes();
+	data->types = GetClusterOutputTypes(data->id_type);
 	for (auto &n : data->names) {
 		names.push_back(n);
 	}
@@ -153,6 +162,7 @@ unique_ptr<GlobalTableFunctionState> ClusterSequencesTableFunction::InitGlobal(C
 }
 
 void ClusterSequencesTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<Data>();
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
 
 	if (gstate.result_offset >= gstate.results.size()) {
@@ -162,7 +172,7 @@ void ClusterSequencesTableFunction::Execute(ClientContext &context, TableFunctio
 
 	idx_t remaining = gstate.results.size() - gstate.result_offset;
 	idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-	OutputClusterResults(output, gstate.results, gstate.result_offset, count);
+	OutputClusterResults(output, gstate.results, gstate.result_offset, count, data.id_type);
 	gstate.result_offset += count;
 }
 

--- a/src/copy_sam.cpp
+++ b/src/copy_sam.cpp
@@ -224,13 +224,13 @@ static unique_ptr<FunctionData> SAMCopyBindInternal(ClientContext &context, Copy
 
 	// Validate column types
 	if (!IsAllowedIdType(sql_types[indices.read_id_idx])) {
-		throw BinderException("Column 'read_id' must be VARCHAR or BIGINT");
+		throw BinderException("Column 'read_id' must be %s", AllowedIdTypeList());
 	}
 	if (sql_types[indices.flags_idx].id() != LogicalTypeId::USMALLINT) {
 		throw BinderException("Column 'flags' must be USMALLINT");
 	}
 	if (!IsAllowedIdType(sql_types[indices.reference_idx])) {
-		throw BinderException("Column 'reference' must be VARCHAR or BIGINT");
+		throw BinderException("Column 'reference' must be %s", AllowedIdTypeList());
 	}
 	if (sql_types[indices.position_idx].id() != LogicalTypeId::BIGINT) {
 		throw BinderException("Column 'position' must be BIGINT");
@@ -242,7 +242,7 @@ static unique_ptr<FunctionData> SAMCopyBindInternal(ClientContext &context, Copy
 		throw BinderException("Column 'cigar' must be VARCHAR");
 	}
 	if (!IsAllowedIdType(sql_types[indices.mate_reference_idx])) {
-		throw BinderException("Column 'mate_reference' must be VARCHAR or BIGINT");
+		throw BinderException("Column 'mate_reference' must be %s", AllowedIdTypeList());
 	}
 
 	// Capture id-column types for the Sink's per-row dispatch.
@@ -659,6 +659,13 @@ static inline string ExtractSamIdField(const UnifiedVectorFormat &fmt, idx_t row
 		}
 		auto data = UnifiedVectorFormat::GetData<int64_t>(fmt);
 		return miint::FormatIdFromInt64(data[idx]);
+	}
+	if (id_type.id() == LogicalTypeId::UUID) {
+		if (!fmt.validity.RowIsValid(idx)) {
+			return "*";
+		}
+		auto data = UnifiedVectorFormat::GetData<hugeint_t>(fmt);
+		return UUID::ToString(data[idx]);
 	}
 	auto data = UnifiedVectorFormat::GetData<string_t>(fmt);
 	return data[idx].GetString();

--- a/src/include/align_bowtie2_daemon_common.hpp
+++ b/src/include/align_bowtie2_daemon_common.hpp
@@ -110,12 +110,12 @@ void DecodeListQualToPhred33(const Value &v, const char *col_name, const std::st
 // daemon's wire schema.
 // Emit one DuckDB chunk's worth of rows from a decoded Arrow batch into
 // `output`. `query_id_type` drives `read_id`; `subject_id_type` drives
-// `reference` and `mate_reference`. Both must be VARCHAR or BIGINT. For
-// BIGINT subjects, the SAM "=" mate-reference sentinel is resolved to the
-// row's reference value before invoking the codec (the literal "=" has no
-// BIGINT encoding); VARCHAR output preserves "=" verbatim, matching
-// pre-existing user-observable behavior. No defaults — every caller must
-// explicitly commit to id types.
+// `reference` and `mate_reference`. Both must be VARCHAR, BIGINT, or UUID. For
+// non-VARCHAR (BIGINT/UUID) subjects, the SAM "=" mate-reference sentinel is
+// resolved to the row's reference value before invoking the codec (the literal
+// "=" has no BIGINT/UUID encoding); VARCHAR output preserves "=" verbatim,
+// matching pre-existing user-observable behavior. No defaults — every caller
+// must explicitly commit to id types.
 void EmitChunkRows(DataChunk &output, idx_t to_emit, idx_t row_start, const ArrowArray &batch,
                    const LogicalType &query_id_type, const LogicalType &subject_id_type);
 

--- a/src/include/align_common.hpp
+++ b/src/include/align_common.hpp
@@ -37,7 +37,7 @@ inline std::vector<std::string> GetAlignmentOutputNames() {
 
 // Get the standard alignment output column types.
 // `query_id_type` drives `read_id`; `subject_id_type` drives `reference` and
-// `mate_reference`. Both must be VARCHAR or BIGINT. No default arguments —
+// `mate_reference`. Both must be VARCHAR, BIGINT, or UUID. No default arguments —
 // every caller must make the choice explicit so the audit can't slip.
 inline std::vector<LogicalType> GetAlignmentOutputTypes(const LogicalType &query_id_type,
                                                         const LogicalType &subject_id_type) {
@@ -112,10 +112,10 @@ inline void ParseMinimap2ConfigParams(const named_parameter_map_t &params, miint
 
 // Output SAMRecordBatch to DataChunk using the standard alignment schema.
 // `query_id_type` and `subject_id_type` drive the three id columns
-// (read_id / reference / mate_reference). Both must be VARCHAR or BIGINT.
-// For BIGINT subject output, the SAM "=" sentinel in mate_reference is
-// resolved to the row's `reference` value before emit (the literal "="
-// has no BIGINT encoding). VARCHAR output preserves "=" as-is, matching
+// (read_id / reference / mate_reference). Both must be VARCHAR, BIGINT, or UUID.
+// For non-VARCHAR subject output, the SAM "=" sentinel in mate_reference is
+// resolved to the row's `reference` value before emit (the literal "=" has no
+// BIGINT/UUID encoding). VARCHAR output preserves "=" as-is, matching
 // pre-existing user-observable behavior.
 // Returns the number of records output.
 inline idx_t OutputSAMRecordBatch(DataChunk &output, const miint::SAMRecordBatch &batch, idx_t offset, idx_t count,
@@ -129,11 +129,11 @@ inline idx_t OutputSAMRecordBatch(DataChunk &output, const miint::SAMRecordBatch
 	SetAlignResultUInt8(output.data[field_idx++], batch.mapqs, offset, count);
 	SetAlignResultString(output.data[field_idx++], batch.cigars, offset, count);
 
-	// Emit mate_reference. For BIGINT subjects, resolve any "=" sentinel
-	// (mate maps to same reference as primary) into the row's reference
-	// value via a local copy — the codec rejects "=" for BIGINT and there
-	// is no in-band way to encode it.
-	if (subject_id_type.id() == LogicalTypeId::BIGINT) {
+	// Emit mate_reference. For non-VARCHAR subjects, resolve any "=" sentinel
+	// (mate maps to same reference as primary) into the row's reference value
+	// via a local copy — the codec rejects "=" for BIGINT/UUID and there is no
+	// in-band way to encode it.
+	if (subject_id_type.id() != LogicalTypeId::VARCHAR) {
 		std::vector<std::string> resolved_mate_refs;
 		resolved_mate_refs.reserve(count);
 		for (idx_t j = 0; j < count; j++) {
@@ -287,8 +287,9 @@ inline void ValidateReadToShardSchema(ClientContext &context, const std::string 
 			throw BinderException("Column 'read_id' in read_to_shard table '%s' must be VARCHAR", table_name);
 		}
 	} else {
-		if (actual_id_type.id() != LogicalTypeId::VARCHAR && actual_id_type.id() != LogicalTypeId::BIGINT) {
-			throw BinderException("Column 'read_id' in read_to_shard table '%s' must be VARCHAR or BIGINT", table_name);
+		if (!IsAllowedIdType(actual_id_type)) {
+			throw BinderException("Column 'read_id' in read_to_shard table '%s' must be %s", table_name,
+			                      AllowedIdTypeList());
 		}
 		if (actual_id_type.id() != expected_read_id_type.id()) {
 			throw BinderException("Column 'read_id' in read_to_shard table '%s' is %s but must match the query "

--- a/src/include/blast_search.hpp
+++ b/src/include/blast_search.hpp
@@ -22,6 +22,12 @@ public:
 		bool megablast = true;
 		std::string api_key;
 
+		// Storage type of the query table's read_id column (VARCHAR, BIGINT, or
+		// UUID), captured at bind. Only the output query_id mirrors this; subject_id
+		// is always VARCHAR (it is an NCBI accession, not a user-table id). INVALID
+		// until Bind sets it (fails loud at the egress dispatcher otherwise).
+		LogicalType query_id_type = LogicalType(LogicalTypeId::INVALID);
+
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 	};

--- a/src/include/cluster_sequences.hpp
+++ b/src/include/cluster_sequences.hpp
@@ -21,6 +21,13 @@ public:
 		std::string input_table;
 		miint::ClusterParams params;
 
+		// Storage type of the input read_id column (VARCHAR, BIGINT, or UUID),
+		// captured at bind. Both output id columns (read_id and centroid_id, which
+		// is itself one of the input read_ids) mirror this type. Defaults to
+		// INVALID so any path that reaches the egress dispatcher without Bind
+		// having set it fails loud rather than misreading the carrier.
+		LogicalType id_type = LogicalType(LogicalTypeId::INVALID);
+
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 	};

--- a/src/include/id_column_utils.hpp
+++ b/src/include/id_column_utils.hpp
@@ -16,6 +16,7 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/types/uuid.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 
@@ -27,7 +28,29 @@ namespace duckdb {
 
 // True for the set of column types accepted as an identifier column.
 inline bool IsAllowedIdType(const LogicalType &t) {
-	return t.id() == LogicalTypeId::VARCHAR || t.id() == LogicalTypeId::BIGINT;
+	return t.id() == LogicalTypeId::VARCHAR || t.id() == LogicalTypeId::BIGINT || t.id() == LogicalTypeId::UUID;
+}
+
+// Human-readable description of the accepted identifier-column types, kept in
+// lockstep with IsAllowedIdType so error messages never drift from the actual
+// accepted set. Used as the `%s` / type-desc in every "must be ..." id-type
+// rejection across the codebase (single source of truth).
+inline const char *AllowedIdTypeList() {
+	return "VARCHAR, BIGINT, or UUID";
+}
+
+// Parse a canonical UUID string back to its INT128 storage value. duckdb's
+// UUID::FromString returns false (it does NOT throw) on malformed input, and the
+// argument-less convenience overload silently swallows that — so we check the
+// bool here and fail loud, mirroring the BIGINT codec's throw-on-unparseable
+// contract. The SAM sentinels ("", "*", "=") are not valid UUIDs and must be
+// handled by the caller before reaching here; passing one (correctly) throws.
+inline hugeint_t ParseUuidOrThrow(const std::string &s) {
+	hugeint_t result;
+	if (!UUID::FromString(s, result)) {
+		throw InvalidInputException("cannot parse value '%s' as UUID", s);
+	}
+	return result;
 }
 
 // Extract `chunk.data[col_idx]` as strings, dispatching on `id_type`.
@@ -73,56 +96,83 @@ inline void ExtractIdColumnAsStrings(DataChunk &chunk, idx_t col_idx, const Logi
 			// duckdb::miint first and fails to find the codec functions there.
 			out_values[i] = ::miint::FormatIdFromInt64(data[idx]);
 		}
+	} else if (id_type.id() == LogicalTypeId::UUID) {
+		// UUID is stored physically as INT128; stringify to the canonical 36-char
+		// form so the carrier holds the same lexical id the user sees.
+		auto data = UnifiedVectorFormat::GetData<hugeint_t>(fmt);
+		for (idx_t i = 0; i < n; i++) {
+			auto idx = fmt.sel->get_index(i);
+			if (!fmt.validity.RowIsValid(idx)) {
+				out_nulls[i] = true;
+				continue;
+			}
+			out_values[i] = UUID::ToString(data[idx]);
+		}
 	} else {
-		throw InternalException("ExtractIdColumnAsStrings: unsupported id type '%s' (must be VARCHAR or BIGINT)",
-		                        id_type.ToString());
+		throw InternalException("ExtractIdColumnAsStrings: unsupported id type '%s' (must be %s)", id_type.ToString(),
+		                        AllowedIdTypeList());
 	}
 }
 
-// Emit `ids[offset..offset+count)` into `out`, dispatching on `id_type`.
-// VARCHAR: emits bytes verbatim (empty string passes through; validity is
-//          reset to all-valid since VARCHAR ingress doesn't carry a NULL
-//          encoding here).
-// BIGINT:  parses each string via ParseIdAsInt64; empty string and "*" become
-//          NULL; any other unparseable value throws InvalidInputException.
+// Emit one id cell at `row` into flat vector `out`, dispatching on `id_type`.
+// This is the single per-row egress primitive shared by EmitIdColumnFromStrings
+// (minimap2/sortmerna output) and the bowtie2 Arrow emit path — keeping the
+// VARCHAR/BIGINT dispatch in one place so adding an id type touches one function
+// rather than several divergent codecs.
+// VARCHAR: writes the bytes verbatim, row marked valid (empty string passes
+//          through since VARCHAR ingress carries no NULL encoding here).
+// BIGINT:  parses via ParseIdAsInt64; empty string and "*" become NULL; any
+//          other unparseable value throws InvalidInputException.
 // The caller must resolve SAM sentinels (e.g. "=" for mate_reference) before
 // invoking — the codec deliberately fails loud on "=" to surface that contract.
-// Precondition: `out` is a FlatVector sized for at least `count` rows. Both
-// branches set the validity mask explicitly so reusing the vector is safe.
-inline void EmitIdColumnFromStrings(Vector &out, const std::vector<std::string> &ids, idx_t offset, idx_t count,
-                                    const LogicalType &id_type) {
+// Validity is always set explicitly (valid or invalid) so reusing the vector is
+// safe. Precondition: `out` is a FlatVector sized for at least `row + 1` rows.
+inline void EmitIdCell(Vector &out, idx_t row, const std::string &s, const LogicalType &id_type) {
+	auto &validity = FlatVector::Validity(out);
 	if (id_type.id() == LogicalTypeId::VARCHAR) {
-		auto out_data = FlatVector::GetData<string_t>(out);
-		FlatVector::Validity(out).SetAllValid(count);
-		for (idx_t j = 0; j < count; j++) {
-			out_data[j] = StringVector::AddString(out, ids[offset + j]);
-		}
+		FlatVector::GetData<string_t>(out)[row] = StringVector::AddString(out, s);
+		validity.SetValid(row);
 		return;
 	}
 	if (id_type.id() == LogicalTypeId::BIGINT) {
 		auto out_data = FlatVector::GetData<int64_t>(out);
-		auto &validity = FlatVector::Validity(out);
-		validity.SetAllInvalid(count);
-		for (idx_t j = 0; j < count; j++) {
-			const auto &s = ids[offset + j];
-			try {
-				auto parsed = ::miint::ParseIdAsInt64(s);
-				if (parsed.has_value()) {
-					out_data[j] = *parsed;
-					validity.SetValid(j);
-				} else {
-					out_data[j] = 0;
-				}
-			} catch (const std::exception &e) {
-				throw InvalidInputException(
-				    "EmitIdColumnFromStrings: cannot parse value '%s' at row %llu as BIGINT: %s", s,
-				    static_cast<unsigned long long>(offset + j), e.what());
+		try {
+			auto parsed = ::miint::ParseIdAsInt64(s);
+			if (parsed.has_value()) {
+				out_data[row] = *parsed;
+				validity.SetValid(row);
+			} else {
+				out_data[row] = 0;
+				validity.SetInvalid(row);
 			}
+		} catch (const std::exception &e) {
+			throw InvalidInputException("EmitIdCell: cannot parse value '%s' as BIGINT: %s", s, e.what());
 		}
 		return;
 	}
-	throw InternalException("EmitIdColumnFromStrings: unsupported id type '%s' (must be VARCHAR or BIGINT)",
-	                        id_type.ToString());
+	if (id_type.id() == LogicalTypeId::UUID) {
+		auto out_data = FlatVector::GetData<hugeint_t>(out);
+		if (s.empty() || s == "*") {
+			out_data[row] = 0;
+			validity.SetInvalid(row);
+		} else {
+			out_data[row] = ParseUuidOrThrow(s);
+			validity.SetValid(row);
+		}
+		return;
+	}
+	throw InternalException("EmitIdCell: unsupported id type '%s' (must be %s)", id_type.ToString(),
+	                        AllowedIdTypeList());
+}
+
+// Emit `ids[offset..offset+count)` into `out` via EmitIdCell. See EmitIdCell for
+// the per-type contract and the SAM-sentinel caveat.
+// Precondition: `out` is a FlatVector sized for at least `count` rows.
+inline void EmitIdColumnFromStrings(Vector &out, const std::vector<std::string> &ids, idx_t offset, idx_t count,
+                                    const LogicalType &id_type) {
+	for (idx_t j = 0; j < count; j++) {
+		EmitIdCell(out, j, ids[offset + j], id_type);
+	}
 }
 
 } // namespace duckdb

--- a/src/include/search_sequences.hpp
+++ b/src/include/search_sequences.hpp
@@ -25,7 +25,12 @@ public:
 		std::string ref_table;
 		miint::SearchParams params;
 
+		// Schemas captured at bind. The output read_id mirrors the query table's
+		// read_id type; the output target_id mirrors the reference table's read_id
+		// type (target_id values are reference labels). Carried separately because
+		// the two tables may have different id types.
 		SequenceTableSchema query_schema;
+		SequenceTableSchema ref_schema;
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;

--- a/src/include/sortmerna_result_utils.hpp
+++ b/src/include/sortmerna_result_utils.hpp
@@ -61,7 +61,7 @@ inline void OutputSortMeRNARRNABatch(DataChunk &output, const miint::SortMeRNARe
 // row j can be read from batch[j ^ 1] without cross-chunk lookups.
 //
 // `query_id_type` drives `read_id`; `subject_id_type` drives `reference` and
-// `mate_reference`. Both must be VARCHAR or BIGINT. The parameter mirrors the
+// `mate_reference`. Both must be VARCHAR, BIGINT, or UUID. The parameter mirrors the
 // shape of OutputSAMRecordBatch (align_common.hpp) and lets the entry-point
 // asserts catch a forgetful caller, but for sortmerna `subject_id_type` is
 // always VARCHAR — subject names come from FASTA files on disk via

--- a/src/include/uchime_common.hpp
+++ b/src/include/uchime_common.hpp
@@ -48,15 +48,22 @@ struct UchimeResult {
 namespace duckdb {
 
 // Output column names and types for the 18-column uchimeout format.
-// Shared between uchime_ref and uchime_denovo.
+// Shared between uchime_ref and uchime_denovo. `read_id_type` is the SQL type of
+// the read_id column (mirrors the query table); `parent_type` is the type of the
+// three parent id columns (parent_a_id, parent_b_id, closest_parent_id — they are
+// reference labels, so they mirror the reference table). For uchime_denovo there
+// is a single id source, so both arguments are the same type.
 std::vector<std::string> GetUchimeOutputNames();
-std::vector<LogicalType> GetUchimeOutputTypes();
+std::vector<LogicalType> GetUchimeOutputTypes(const LogicalType &read_id_type, const LogicalType &parent_type);
 
 // Write a batch of UchimeResults into a DataChunk starting at column `start_col`.
 // When start_col > 0 (per-sample callers), callers must populate columns [0, start_col)
 // before/after this call; this function sets the chunk cardinality itself.
+// `read_id_type` / `parent_type` govern how the id columns are emitted (must match
+// the types from GetUchimeOutputTypes). The three parent id columns stay NULL for
+// non-chimeric rows (empty parent label) regardless of id type.
 // Returns the number of rows written (min of count and remaining results).
 idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResult> &results, idx_t offset, idx_t count,
-                          idx_t start_col = 0);
+                          const LogicalType &read_id_type, const LogicalType &parent_type, idx_t start_col = 0);
 
 } // namespace duckdb

--- a/src/include/uchime_denovo.hpp
+++ b/src/include/uchime_denovo.hpp
@@ -29,6 +29,11 @@ public:
 		std::string sequence_col = "sequence1";
 		std::string count_col = "size";
 
+		// Storage type of the id_col (VARCHAR, BIGINT, or UUID), captured at bind.
+		// denovo has a single id source, so read_id and all three parent columns
+		// mirror this one type. INVALID until Bind sets it (fails loud otherwise).
+		LogicalType id_type = LogicalType(LogicalTypeId::INVALID);
+
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 

--- a/src/search_sequences.cpp
+++ b/src/search_sequences.cpp
@@ -1,4 +1,5 @@
 #include "search_sequences.hpp"
+#include "id_column_utils.hpp"
 #include "table_function_common.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -17,18 +18,24 @@ static std::vector<std::string> GetSearchOutputNames() {
 	        "gaps",    "alignment_length", "query_length", "target_length", "accepted"};
 }
 
-static std::vector<LogicalType> GetSearchOutputTypes() {
+// read_id (col 0) mirrors the query table's read_id type; target_id (col 1)
+// mirrors the reference table's read_id type (target_id values are reference
+// labels). All other columns are fixed.
+static std::vector<LogicalType> GetSearchOutputTypes(const LogicalType &query_id_type,
+                                                     const LogicalType &target_id_type) {
 	// accepted: true for strong hits passing the identity threshold,
 	// false for "weak" hits (vsearch returns both accepted and weak hits
 	// from search_single; weak hits are near-misses that didn't pass).
-	return {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE,  LogicalType::INTEGER,
+	return {query_id_type,        target_id_type,       LogicalType::DOUBLE,  LogicalType::INTEGER,
 	        LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
 	        LogicalType::INTEGER, LogicalType::BOOLEAN};
 }
 
-// Write a batch of SearchResults into a DataChunk.
+// Write a batch of SearchResults into a DataChunk. read_id and target_id are
+// emitted through the shared id codec so they mirror their respective input
+// types; search emits one row per real hit, so neither id is ever empty.
 static idx_t OutputSearchResults(DataChunk &output, const std::vector<miint::SearchResult> &results, idx_t offset,
-                                 idx_t count) {
+                                 idx_t count, const LogicalType &query_id_type, const LogicalType &target_id_type) {
 	idx_t actual = std::min(count, static_cast<idx_t>(results.size()) - offset);
 	if (actual == 0) {
 		output.SetCardinality(0);
@@ -39,14 +46,12 @@ static idx_t OutputSearchResults(DataChunk &output, const std::vector<miint::Sea
 
 	auto &read_id_vec = output.data[col++];
 	for (idx_t i = 0; i < actual; i++) {
-		FlatVector::GetData<string_t>(read_id_vec)[i] =
-		    StringVector::AddString(read_id_vec, results[offset + i].query_id);
+		EmitIdCell(read_id_vec, i, results[offset + i].query_id, query_id_type);
 	}
 
 	auto &target_vec = output.data[col++];
 	for (idx_t i = 0; i < actual; i++) {
-		FlatVector::GetData<string_t>(target_vec)[i] =
-		    StringVector::AddString(target_vec, results[offset + i].target_id);
+		EmitIdCell(target_vec, i, results[offset + i].target_id, target_id_type);
 	}
 
 	auto identity_data = FlatVector::GetData<double>(output.data[col++]);
@@ -118,10 +123,10 @@ unique_ptr<FunctionData> SearchSequencesTableFunction::Bind(ClientContext &conte
 		                            data->params.id);
 	}
 
-	data->query_schema = ValidateSequenceTableSchema(context, data->query_table);
-
-	// Validate ref table exists and has required columns
-	ValidateSequenceTableSchema(context, data->ref_table);
+	// Capture both schemas (accepting VARCHAR/BIGINT/UUID) so the output read_id
+	// mirrors the query type and target_id mirrors the reference type.
+	data->query_schema = ValidateSequenceTableSchema(context, data->query_table, /*allow_bigint=*/true);
+	data->ref_schema = ValidateSequenceTableSchema(context, data->ref_table, /*allow_bigint=*/true);
 
 	auto get_int = [&](const std::string &name, int &out, int min_val, int max_val, const char *constraint) {
 		auto it = input.named_parameters.find(name);
@@ -143,7 +148,7 @@ unique_ptr<FunctionData> SearchSequencesTableFunction::Bind(ClientContext &conte
 	get_int("threads", data->params.threads, 1, 1024, ">= 1 and <= 1024");
 
 	data->names = GetSearchOutputNames();
-	data->types = GetSearchOutputTypes();
+	data->types = GetSearchOutputTypes(data->query_schema.id_type, data->ref_schema.id_type);
 	for (auto &n : data->names) {
 		names.push_back(n);
 	}
@@ -172,6 +177,7 @@ unique_ptr<GlobalTableFunctionState> SearchSequencesTableFunction::InitGlobal(Cl
 }
 
 void SearchSequencesTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &data = data_p.bind_data->Cast<Data>();
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
 
 	while (true) {
@@ -179,7 +185,8 @@ void SearchSequencesTableFunction::Execute(ClientContext &context, TableFunction
 		if (gstate.result_offset < gstate.result_buffer.size()) {
 			idx_t remaining = gstate.result_buffer.size() - gstate.result_offset;
 			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputSearchResults(output, gstate.result_buffer, gstate.result_offset, count);
+			OutputSearchResults(output, gstate.result_buffer, gstate.result_offset, count, data.query_schema.id_type,
+			                    data.ref_schema.id_type);
 			gstate.result_offset += count;
 			return;
 		}

--- a/src/sequence_table_reader.cpp
+++ b/src/sequence_table_reader.cpp
@@ -50,9 +50,10 @@ SequenceTableSchema ValidateSequenceTableSchema(ClientContext &context, const st
 		return true;
 	};
 
-	// Required columns: read_id (VARCHAR; or BIGINT if allow_bigint), sequence1 (VARCHAR)
+	// Required columns: read_id (VARCHAR; or BIGINT/UUID if allow_bigint), sequence1 (VARCHAR)
 	if (allow_bigint) {
-		check_column("read_id", {LogicalTypeId::VARCHAR, LogicalTypeId::BIGINT}, "VARCHAR or BIGINT", true);
+		check_column("read_id", {LogicalTypeId::VARCHAR, LogicalTypeId::BIGINT, LogicalTypeId::UUID},
+		             AllowedIdTypeList(), true);
 	} else {
 		check_column("read_id", {LogicalTypeId::VARCHAR}, "VARCHAR", true);
 	}
@@ -404,34 +405,22 @@ std::vector<std::string> ReadShardIds(ClientContext &context, const std::string 
 	auto &materialized = query_result->Cast<MaterializedQueryResult>();
 
 	if (!IsAllowedIdType(id_type)) {
-		throw InternalException("ReadShardIds: id_type must be VARCHAR or BIGINT, got '%s'", id_type.ToString());
+		throw InternalException("ReadShardIds: id_type must be %s, got '%s'", AllowedIdTypeList(), id_type.ToString());
 	}
-	const bool is_bigint = id_type.id() == LogicalTypeId::BIGINT;
 
+	// Stringify each chunk through the shared id ingress dispatcher (VARCHAR /
+	// BIGINT / UUID) and keep only the non-NULL ids, in order.
+	std::vector<std::string> chunk_vals;
+	std::vector<bool> chunk_nulls;
 	while (true) {
 		auto chunk = materialized.Fetch();
 		if (!chunk || chunk->size() == 0) {
 			break;
 		}
-
-		UnifiedVectorFormat id_data;
-		chunk->data[0].ToUnifiedFormat(chunk->size(), id_data);
-
-		if (is_bigint) {
-			auto id_ints = UnifiedVectorFormat::GetData<int64_t>(id_data);
-			for (idx_t i = 0; i < chunk->size(); i++) {
-				auto idx = id_data.sel->get_index(i);
-				if (id_data.validity.RowIsValid(idx)) {
-					ids.push_back(miint::FormatIdFromInt64(id_ints[idx]));
-				}
-			}
-		} else {
-			auto id_strings = UnifiedVectorFormat::GetData<string_t>(id_data);
-			for (idx_t i = 0; i < chunk->size(); i++) {
-				auto idx = id_data.sel->get_index(i);
-				if (id_data.validity.RowIsValid(idx)) {
-					ids.push_back(id_strings[idx].GetString());
-				}
+		ExtractIdColumnAsStrings(*chunk, 0, id_type, chunk_vals, chunk_nulls);
+		for (idx_t i = 0; i < chunk_vals.size(); i++) {
+			if (!chunk_nulls[i]) {
+				ids.push_back(std::move(chunk_vals[i]));
 			}
 		}
 	}
@@ -461,7 +450,7 @@ void ReadBatchByIds(ClientContext &context, const std::string &query_table, cons
 	// that any SequenceTableSchema reaching this layer has been through
 	// ValidateSequenceTableSchema, which always resolves to VARCHAR or BIGINT.
 	if (!IsAllowedIdType(schema.id_type)) {
-		throw InternalException("ReadBatchByIds: schema.id_type must be VARCHAR or BIGINT, got '%s'",
+		throw InternalException("ReadBatchByIds: schema.id_type must be %s, got '%s'", AllowedIdTypeList(),
 		                        schema.id_type.ToString());
 	}
 	const LogicalType &id_type = schema.id_type;
@@ -481,6 +470,12 @@ void ReadBatchByIds(ClientContext &context, const std::string &query_table, cons
 				} else {
 					appender.AppendRow(Value(LogicalType::BIGINT));
 				}
+			} else if (id_type.id() == LogicalTypeId::UUID) {
+				// ids[i] is a canonical UUID string produced by ReadShardIds. Parse
+				// via the bool-checked helper and pass the INT128 to the hugeint
+				// overload — Value::UUID(string) silently swallows parse failures,
+				// so this fails loud on a malformed id, mirroring the BIGINT branch.
+				appender.AppendRow(Value::UUID(ParseUuidOrThrow(ids[i])));
 			} else {
 				appender.AppendRow(Value(ids[i]));
 			}

--- a/src/uchime_common.cpp
+++ b/src/uchime_common.cpp
@@ -1,4 +1,5 @@
 #include "uchime_common.hpp"
+#include "id_column_utils.hpp"
 
 #include <algorithm>
 
@@ -10,16 +11,16 @@ std::vector<std::string> GetUchimeOutputNames() {
 	        "left_abstain", "right_yes",  "right_no",    "right_abstain", "divergence",        "flag"};
 }
 
-std::vector<LogicalType> GetUchimeOutputTypes() {
-	return {LogicalType::DOUBLE,  LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
-	        LogicalType::VARCHAR, LogicalType::DOUBLE,  LogicalType::DOUBLE,  LogicalType::DOUBLE,
+std::vector<LogicalType> GetUchimeOutputTypes(const LogicalType &read_id_type, const LogicalType &parent_type) {
+	return {LogicalType::DOUBLE,  read_id_type,         parent_type,          parent_type,
+	        parent_type,          LogicalType::DOUBLE,  LogicalType::DOUBLE,  LogicalType::DOUBLE,
 	        LogicalType::DOUBLE,  LogicalType::DOUBLE,  LogicalType::INTEGER, LogicalType::INTEGER,
 	        LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::INTEGER,
 	        LogicalType::DOUBLE,  LogicalType::VARCHAR};
 }
 
 idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResult> &results, idx_t offset, idx_t count,
-                          idx_t start_col) {
+                          const LogicalType &read_id_type, const LogicalType &parent_type, idx_t start_col) {
 	idx_t actual = std::min(count, static_cast<idx_t>(results.size()) - offset);
 	if (actual == 0) {
 		output.SetCardinality(0);
@@ -34,14 +35,19 @@ idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResu
 		score_data[i] = results[offset + i].score;
 	}
 
-	// read_id — always populated
+	// read_id — always populated, mirrors the query table's id type.
 	auto &read_id_vec = output.data[col++];
 	for (idx_t i = 0; i < actual; i++) {
-		FlatVector::GetData<string_t>(read_id_vec)[i] =
-		    StringVector::AddString(read_id_vec, results[offset + i].query_label);
+		EmitIdCell(read_id_vec, i, results[offset + i].query_label, read_id_type);
 	}
 
-	// parent_a_id, parent_b_id, closest_parent_id — NULL when non-chimeric (empty label)
+	// parent_a_id, parent_b_id, closest_parent_id — reference labels, mirror the
+	// reference id type; NULL for non-chimeric rows. Explicit SetInvalid (not
+	// EmitIdCell) on the empty branch keeps NULL-ness type-independent — EmitIdCell
+	// maps "" to NULL for BIGINT/UUID but to a non-NULL empty cell for VARCHAR.
+	// Gating on parent_a_label alone is sufficient: vsearch's convert_result writes
+	// all three labels together for non-'N' rows and leaves all three empty for 'N',
+	// so the populated branch never sees an empty parent label.
 	auto &parent_a_vec = output.data[col++];
 	auto &parent_b_vec = output.data[col++];
 	auto &closest_parent_vec = output.data[col++];
@@ -55,10 +61,9 @@ idx_t OutputUchimeResults(DataChunk &output, const std::vector<miint::UchimeResu
 			pb_validity.SetInvalid(i);
 			cp_validity.SetInvalid(i);
 		} else {
-			FlatVector::GetData<string_t>(parent_a_vec)[i] = StringVector::AddString(parent_a_vec, r.parent_a_label);
-			FlatVector::GetData<string_t>(parent_b_vec)[i] = StringVector::AddString(parent_b_vec, r.parent_b_label);
-			FlatVector::GetData<string_t>(closest_parent_vec)[i] =
-			    StringVector::AddString(closest_parent_vec, r.closest_parent_label);
+			EmitIdCell(parent_a_vec, i, r.parent_a_label, parent_type);
+			EmitIdCell(parent_b_vec, i, r.parent_b_label, parent_type);
+			EmitIdCell(closest_parent_vec, i, r.closest_parent_label, parent_type);
 		}
 	}
 

--- a/src/uchime_denovo.cpp
+++ b/src/uchime_denovo.cpp
@@ -1,4 +1,5 @@
 #include "uchime_denovo.hpp"
+#include "id_column_utils.hpp"
 #include "table_function_common.hpp"
 #include "uchime_common.hpp"
 
@@ -14,10 +15,15 @@
 
 namespace duckdb {
 
-// Validate that a table has the resolved id (VARCHAR), sequence (VARCHAR), and count
-// (integer type) columns. Names are resolved from named parameters at bind time.
-static void ValidateDenovoTableSchema(ClientContext &context, const std::string &table_name, const std::string &id_col,
-                                      const std::string &sequence_col, const std::string &count_col) {
+// Validate that a table has the resolved id (VARCHAR/BIGINT/UUID), sequence
+// (VARCHAR), and count (integer type) columns. Names are resolved from named
+// parameters at bind time. Returns the id column's storage type so the caller can
+// mirror it on every output id column. The id-type check + message reuse the
+// shared IsAllowedIdType/AllowedIdTypeList helpers so this validator never drifts
+// from ValidateSequenceTableSchema's accepted set.
+static LogicalType ValidateDenovoTableSchema(ClientContext &context, const std::string &table_name,
+                                             const std::string &id_col, const std::string &sequence_col,
+                                             const std::string &count_col) {
 	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
 	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
 	if (!entry) {
@@ -51,10 +57,11 @@ static void ValidateDenovoTableSchema(ClientContext &context, const std::string 
 
 	auto it = name_to_idx.find(StringUtil::Lower(id_col));
 	if (it == name_to_idx.end()) {
-		throw BinderException("Table '%s' missing required column '%s' (VARCHAR)", table_name, id_col);
+		throw BinderException("Table '%s' missing required column '%s' (%s)", table_name, id_col, AllowedIdTypeList());
 	}
-	if (col_types[it->second].id() != LogicalTypeId::VARCHAR) {
-		throw BinderException("Column '%s' in table '%s' must be VARCHAR", id_col, table_name);
+	auto id_logical_type = col_types[it->second];
+	if (!IsAllowedIdType(id_logical_type)) {
+		throw BinderException("Column '%s' in table '%s' must be %s", id_col, table_name, AllowedIdTypeList());
 	}
 
 	it = name_to_idx.find(StringUtil::Lower(sequence_col));
@@ -78,6 +85,8 @@ static void ValidateDenovoTableSchema(ClientContext &context, const std::string 
 		throw BinderException("Column '%s' in table '%s' must be an integer type (got %s)", count_col, table_name,
 		                      col_types[it->second].ToString());
 	}
+
+	return id_logical_type;
 }
 
 // Pull (id, sequence, count) rows for a single sample (or the whole table when
@@ -174,7 +183,8 @@ unique_ptr<FunctionData> UchimeDenovoTableFunction::Bind(ClientContext &context,
 	get_col_override("sequence_col", data->sequence_col);
 	get_col_override("count_col", data->count_col);
 
-	ValidateDenovoTableSchema(context, data->input_table, data->id_col, data->sequence_col, data->count_col);
+	data->id_type =
+	    ValidateDenovoTableSchema(context, data->input_table, data->id_col, data->sequence_col, data->count_col);
 
 	auto get_double = [&](const std::string &name, double &out, double min_val, const char *constraint) {
 		auto it = input.named_parameters.find(name);
@@ -211,7 +221,9 @@ unique_ptr<FunctionData> UchimeDenovoTableFunction::Bind(ClientContext &context,
 	}
 
 	data->names = GetUchimeOutputNames();
-	data->types = GetUchimeOutputTypes();
+	// denovo has a single id source, so read_id and all three parent columns mirror
+	// the one captured id_col type.
+	data->types = GetUchimeOutputTypes(data->id_type, data->id_type);
 
 	if (data->has_sample_id) {
 		auto &db = DatabaseInstance::GetDatabase(context);
@@ -289,7 +301,7 @@ void UchimeDenovoTableFunction::Execute(ClientContext & /*context*/, TableFuncti
 		if (gstate.result_offset < gstate.results.size()) {
 			idx_t remaining = gstate.results.size() - gstate.result_offset;
 			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-			OutputUchimeResults(output, gstate.results, gstate.result_offset, count);
+			OutputUchimeResults(output, gstate.results, gstate.result_offset, count, data.id_type, data.id_type);
 			gstate.result_offset += count;
 			return;
 		}
@@ -327,7 +339,7 @@ void UchimeDenovoTableFunction::Execute(ClientContext & /*context*/, TableFuncti
 		}
 
 		idx_t count = std::min(static_cast<idx_t>(gstate.results.size()), static_cast<idx_t>(STANDARD_VECTOR_SIZE));
-		OutputUchimeResults(output, gstate.results, 0, count);
+		OutputUchimeResults(output, gstate.results, 0, count, data.id_type, data.id_type);
 		gstate.result_offset = count;
 		return;
 	}
@@ -339,7 +351,8 @@ void UchimeDenovoTableFunction::Execute(ClientContext & /*context*/, TableFuncti
 			idx_t remaining = lstate.results.size() - lstate.result_offset;
 			idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
 			output.data[0].Reference(lstate.sample_value);
-			OutputUchimeResults(output, lstate.results, lstate.result_offset, count, /*start_col=*/1);
+			OutputUchimeResults(output, lstate.results, lstate.result_offset, count, data.id_type, data.id_type,
+			                    /*start_col=*/1);
 			lstate.result_offset += count;
 			return;
 		}

--- a/src/uchime_ref.cpp
+++ b/src/uchime_ref.cpp
@@ -16,7 +16,8 @@ namespace duckdb {
 // directly into output at col 0 when not. Returns true if a chunk was emitted (and
 // output.cardinality is set); false if the buffer is drained.
 static bool EmitFromBuffer(const std::vector<miint::UchimeResult> &buffer, idx_t &result_offset, DataChunk &output,
-                           bool has_sample_id, const Value &sample_value) {
+                           bool has_sample_id, const Value &sample_value, const LogicalType &read_id_type,
+                           const LogicalType &parent_type) {
 	if (result_offset >= buffer.size()) {
 		return false;
 	}
@@ -24,9 +25,9 @@ static bool EmitFromBuffer(const std::vector<miint::UchimeResult> &buffer, idx_t
 	idx_t count = std::min(remaining, static_cast<idx_t>(STANDARD_VECTOR_SIZE));
 	if (has_sample_id) {
 		output.data[0].Reference(sample_value);
-		OutputUchimeResults(output, buffer, result_offset, count, /*start_col=*/1);
+		OutputUchimeResults(output, buffer, result_offset, count, read_id_type, parent_type, /*start_col=*/1);
 	} else {
-		OutputUchimeResults(output, buffer, result_offset, count);
+		OutputUchimeResults(output, buffer, result_offset, count, read_id_type, parent_type);
 	}
 	result_offset += count;
 	return true;
@@ -44,8 +45,10 @@ unique_ptr<FunctionData> UchimeRefTableFunction::Bind(ClientContext &context, Ta
 	}
 	data->ref_table = db_it->second.GetValue<std::string>();
 
-	data->query_schema = ValidateSequenceTableSchema(context, data->query_table);
-	data->ref_schema = ValidateSequenceTableSchema(context, data->ref_table);
+	// read_id mirrors the query table's id type; the parent id columns mirror the
+	// reference table's id type. Accept VARCHAR/BIGINT/UUID for both.
+	data->query_schema = ValidateSequenceTableSchema(context, data->query_table, /*allow_bigint=*/true);
+	data->ref_schema = ValidateSequenceTableSchema(context, data->ref_table, /*allow_bigint=*/true);
 
 	auto get_double = [&](const std::string &name, double &out, double min_val, const char *constraint) {
 		auto it = input.named_parameters.find(name);
@@ -85,7 +88,7 @@ unique_ptr<FunctionData> UchimeRefTableFunction::Bind(ClientContext &context, Ta
 	}
 
 	data->names = GetUchimeOutputNames();
-	data->types = GetUchimeOutputTypes();
+	data->types = GetUchimeOutputTypes(data->query_schema.id_type, data->ref_schema.id_type);
 
 	if (data->has_sample_id) {
 		auto &db = DatabaseInstance::GetDatabase(context);
@@ -150,7 +153,8 @@ void UchimeRefTableFunction::Execute(ClientContext & /*context*/, TableFunctionI
 
 	if (!data.has_sample_id) {
 		while (true) {
-			if (EmitFromBuffer(gstate.result_buffer, gstate.result_offset, output, /*has_sample_id=*/false, Value())) {
+			if (EmitFromBuffer(gstate.result_buffer, gstate.result_offset, output, /*has_sample_id=*/false, Value(),
+			                   data.query_schema.id_type, data.ref_schema.id_type)) {
 				return;
 			}
 			gstate.result_buffer.clear();
@@ -167,7 +171,7 @@ void UchimeRefTableFunction::Execute(ClientContext & /*context*/, TableFunctionI
 
 	while (true) {
 		if (EmitFromBuffer(lstate.result_buffer, lstate.result_offset, output, /*has_sample_id=*/true,
-		                   lstate.sample_value)) {
+		                   lstate.sample_value, data.query_schema.id_type, data.ref_schema.id_type)) {
 			return;
 		}
 		lstate.result_buffer.clear();

--- a/test/sql/align_bowtie2_bigint.test
+++ b/test/sql/align_bowtie2_bigint.test
@@ -91,7 +91,7 @@ CREATE TABLE queries_integer (read_id INTEGER, sequence1 VARCHAR);
 statement error
 SELECT * FROM align_bowtie2('queries_integer', 'subjects_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
@@ -99,7 +99,7 @@ CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
 statement error
 SELECT * FROM align_bowtie2('queries_hugeint', 'subjects_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE subjects_double (read_id DOUBLE, sequence1 VARCHAR);
@@ -107,7 +107,7 @@ CREATE TABLE subjects_double (read_id DOUBLE, sequence1 VARCHAR);
 statement error
 SELECT * FROM align_bowtie2('queries_bigint', 'subjects_double');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # ---------------------------------------------------------------------------
 # Paired-end BIGINT with `=` mate_reference resolution. For BIGINT subjects

--- a/test/sql/align_bowtie2_sharded_bigint.test
+++ b/test/sql/align_bowtie2_sharded_bigint.test
@@ -96,7 +96,7 @@ SELECT * FROM align_bowtie2_sharded('queries_integer',
     shard_directory := 'data/bowtie2_shards/',
     read_to_shard := 'read_to_shard_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
@@ -106,7 +106,7 @@ SELECT * FROM align_bowtie2_sharded('queries_hugeint',
     shard_directory := 'data/bowtie2_shards/',
     read_to_shard := 'read_to_shard_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE read_to_shard_hugeint (read_id HUGEINT, shard_name VARCHAR);
@@ -116,7 +116,7 @@ SELECT * FROM align_bowtie2_sharded('queries_bigint',
     shard_directory := 'data/bowtie2_shards/',
     read_to_shard := 'read_to_shard_hugeint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # ---------------------------------------------------------------------------
 # NULL read_id: bowtie2_sharded inherits align_bowtie2's contract — both

--- a/test/sql/align_bowtie2_sharded_uuid.test
+++ b/test/sql/align_bowtie2_sharded_uuid.test
@@ -1,0 +1,120 @@
+# name: test/sql/align_bowtie2_sharded_uuid.test
+# description: align_bowtie2_sharded accepts UUID read_id columns.
+# group: [sql]
+
+#   Sharded bowtie2 uses prebuilt indexes (one per shard directory). The query
+#   side (queries.read_id + read_to_shard.read_id) may be VARCHAR, BIGINT, or
+#   UUID and the two must match exactly. The subject side is always VARCHAR
+#   because the prebuilt bowtie2 index stores reference names as opaque bytes —
+#   same contract as align_minimap2_sharded.
+
+require miint
+
+require-env GPL_BOUNDARY_AVAILABLE
+
+# NOTE: threads=1 — the sqllogictest framework runs in a constrained mode that
+# doesn't handle parallel table function execution well.
+statement ok
+SET threads=1;
+
+# ---------------------------------------------------------------------------
+# Setup: UUID queries + UUID read_to_shard. Reuses the prebuilt shards in
+# data/bowtie2_shards/ (built from VARCHAR subject names ref1/ref2).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_uuid AS SELECT * FROM (VALUES
+    ('11111111-1111-1111-1111-111111111111'::UUID, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('22222222-2222-2222-2222-222222222222'::UUID, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE read_to_shard_uuid AS SELECT * FROM (VALUES
+    ('11111111-1111-1111-1111-111111111111'::UUID, 'shard_a'),
+    ('22222222-2222-2222-2222-222222222222'::UUID, 'shard_b')
+) AS t(read_id, shard_name);
+
+# Happy path: UUID read_id mirrors to output; reference stays VARCHAR (prebuilt
+# index opaque-bytes default).
+query II
+SELECT read_id, reference
+FROM align_bowtie2_sharded('queries_uuid',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard_uuid')
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	ref1
+22222222-2222-2222-2222-222222222222	ref2
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_bowtie2_sharded('queries_uuid',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard_uuid')
+LIMIT 1;
+----
+UUID	VARCHAR	VARCHAR
+
+# ---------------------------------------------------------------------------
+# Mixed-type rejection: read_to_shard.read_id must match query.read_id.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE read_to_shard_varchar AS
+SELECT CAST(read_id AS VARCHAR) AS read_id, shard_name FROM read_to_shard_uuid;
+
+statement error
+SELECT * FROM align_bowtie2_sharded('queries_uuid',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard_varchar');
+----
+must match the query table's read_id type
+
+statement ok
+CREATE TABLE queries_varchar AS
+SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM queries_uuid;
+
+statement error
+SELECT * FROM align_bowtie2_sharded('queries_varchar',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard_uuid');
+----
+must match the query table's read_id type
+
+# ---------------------------------------------------------------------------
+# Unsupported query type (HUGEINT) rejected at bind despite sharing UUID's
+# INT128 physical layout.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM align_bowtie2_sharded('queries_hugeint',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard_uuid');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# ---------------------------------------------------------------------------
+# NULL read_id: the NULL-keyed row has no read_to_shard entry, so the JOIN
+# filters it out before the daemon — the mapped row still produces output.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_uuid_with_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_uuid_with_null VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (NULL, 'GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG');
+
+query I
+SELECT COUNT(*)
+FROM align_bowtie2_sharded('queries_uuid_with_null',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard_uuid')
+WHERE flags & 4 = 0;
+----
+1

--- a/test/sql/align_bowtie2_uuid.test
+++ b/test/sql/align_bowtie2_uuid.test
@@ -1,0 +1,158 @@
+# name: test/sql/align_bowtie2_uuid.test
+# description: align_bowtie2 accepts UUID read_id columns.
+# group: [sql]
+
+#   Bowtie2 routes through the gpl-boundary daemon and stays string-on-the-wire
+#   end-to-end — UUID support is purely at the C++/DuckDB boundary (the same
+#   EmitChunkRows codec dispatch as BIGINT). The output read_id mirrors the
+#   query side; reference and mate_reference mirror the subject side. The SAM `=`
+#   mate-reference sentinel has no UUID encoding, so for UUID subjects it's
+#   resolved to the row's reference before emit; VARCHAR keeps `=` verbatim.
+
+require miint
+
+require-env GPL_BOUNDARY_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# Setup: UUID-keyed query + subject tables (same sequences as
+# align_bowtie2_bigint.test, so mappings are identical).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE subjects_uuid AS SELECT * FROM (VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC'),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::UUID, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAA')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE queries_uuid AS SELECT * FROM (VALUES
+    ('11111111-1111-1111-1111-111111111111'::UUID, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('22222222-2222-2222-2222-222222222222'::UUID, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE subjects_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM subjects_uuid;
+
+statement ok
+CREATE TABLE queries_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM queries_uuid;
+
+# ---------------------------------------------------------------------------
+# Happy path: UUID/UUID — output read_id and reference both UUID.
+# ---------------------------------------------------------------------------
+
+query II
+SELECT read_id, reference
+FROM align_bowtie2('queries_uuid', 'subjects_uuid')
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+22222222-2222-2222-2222-222222222222	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_bowtie2('queries_uuid', 'subjects_uuid')
+LIMIT 1;
+----
+UUID	UUID	UUID
+
+# ---------------------------------------------------------------------------
+# Mixed: UUID query / VARCHAR subject, and the reverse.
+# ---------------------------------------------------------------------------
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_bowtie2('queries_uuid', 'subjects_varchar')
+LIMIT 1;
+----
+UUID	VARCHAR	VARCHAR
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_bowtie2('queries_varchar', 'subjects_uuid')
+LIMIT 1;
+----
+VARCHAR	UUID	UUID
+
+# Mixed UUID query / BIGINT subject exercises two distinct non-VARCHAR codecs.
+statement ok
+CREATE TABLE subjects_bigint AS SELECT * FROM (VALUES
+    (2001::BIGINT, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC'),
+    (2002::BIGINT, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAA')
+) AS t(read_id, sequence1);
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_bowtie2('queries_uuid', 'subjects_bigint')
+LIMIT 1;
+----
+UUID	BIGINT	BIGINT
+
+# ---------------------------------------------------------------------------
+# Unsupported types rejected at bind (query side and subject side). HUGEINT is
+# rejected despite sharing UUID's INT128 physical layout.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM align_bowtie2('queries_hugeint', 'subjects_uuid');
+----
+must be VARCHAR, BIGINT, or UUID
+
+statement ok
+CREATE TABLE subjects_double (read_id DOUBLE, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM align_bowtie2('queries_uuid', 'subjects_double');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# ---------------------------------------------------------------------------
+# Paired-end UUID with `=` mate_reference resolution. For UUID subjects the SAM
+# `=` sentinel has no in-band encoding, so EmitChunkRows resolves it to the
+# row's reference value before the codec dispatch (a leaked `=` would throw at
+# the UUID parse).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE paired_queries_uuid AS SELECT * FROM (VALUES
+    ('33333333-3333-3333-3333-333333333333'::UUID,
+     'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT',
+     'GGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAA')
+) AS t(read_id, sequence1, sequence2);
+
+query II
+SELECT
+    SUM(CASE WHEN mate_reference IS NOT NULL AND mate_reference = reference THEN 1 ELSE 0 END) > 0 AS any_resolved,
+    SUM(CASE WHEN mate_reference IS NOT NULL AND mate_reference != reference THEN 1 ELSE 0 END) AS unexpected_diff
+FROM align_bowtie2('paired_queries_uuid', 'subjects_uuid')
+WHERE flags & 4 = 0;
+----
+true	0
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_bowtie2('paired_queries_uuid', 'subjects_uuid')
+LIMIT 1;
+----
+UUID	UUID	UUID
+
+# ---------------------------------------------------------------------------
+# NULL read_id: the daemon requires read_id + sequence1 non-null; UUID inherits
+# the same throw (IsNull check fires before any codec dispatch).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_uuid_with_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_uuid_with_null VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (NULL, 'GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG');
+
+statement error
+SELECT * FROM align_bowtie2('queries_uuid_with_null', 'subjects_uuid');
+----
+NULL read_id or sequence1

--- a/test/sql/align_minimap2_bigint.test
+++ b/test/sql/align_minimap2_bigint.test
@@ -178,7 +178,7 @@ INSERT INTO queries_int VALUES (1, 'ACGT');
 statement error
 SELECT * FROM align_minimap2('queries_int', subject_table='subjects_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE queries_double (read_id DOUBLE, sequence1 VARCHAR);
@@ -189,7 +189,7 @@ INSERT INTO queries_double VALUES (1.5, 'ACGT');
 statement error
 SELECT * FROM align_minimap2('queries_double', subject_table='subjects_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE queries_ubigint (read_id UBIGINT, sequence1 VARCHAR);
@@ -200,10 +200,10 @@ INSERT INTO queries_ubigint VALUES (1, 'ACGT');
 statement error
 SELECT * FROM align_minimap2('queries_ubigint', subject_table='subjects_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # Rejected subject-side too
 statement error
 SELECT * FROM align_minimap2('queries_bigint', subject_table='queries_int');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID

--- a/test/sql/align_minimap2_bigint_edge.test
+++ b/test/sql/align_minimap2_bigint_edge.test
@@ -59,7 +59,7 @@ CREATE TABLE queries_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequence
 statement error
 SELECT * FROM align_minimap2('queries_hugeint', subject_table='bq_subjects');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE subjects_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequence1;
@@ -67,7 +67,7 @@ CREATE TABLE subjects_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequenc
 statement error
 SELECT * FROM align_minimap2('bq_queries', subject_table='subjects_hugeint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # ---------------------------------------------------------------------------
 # 3. per_subject_database=true with BIGINT — exercises ExecutePerSubject,

--- a/test/sql/align_minimap2_sharded_bigint.test
+++ b/test/sql/align_minimap2_sharded_bigint.test
@@ -131,7 +131,7 @@ SELECT * FROM align_minimap2_sharded('queries_integer',
     shard_directory := 'data/shards/',
     read_to_shard := 'read_to_shard_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
@@ -141,7 +141,7 @@ SELECT * FROM align_minimap2_sharded('queries_hugeint',
     shard_directory := 'data/shards/',
     read_to_shard := 'read_to_shard_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE queries_double (read_id DOUBLE, sequence1 VARCHAR);
@@ -151,7 +151,7 @@ SELECT * FROM align_minimap2_sharded('queries_double',
     shard_directory := 'data/shards/',
     read_to_shard := 'read_to_shard_bigint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # A HUGEINT read_to_shard against a BIGINT query is rejected at the
 # read_to_shard validator with the VARCHAR-or-BIGINT message.
@@ -163,7 +163,7 @@ SELECT * FROM align_minimap2_sharded('queries_bigint',
     shard_directory := 'data/shards/',
     read_to_shard := 'read_to_shard_hugeint');
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # ---------------------------------------------------------------------------
 # NULL read_id rows skipped — same convention as VARCHAR sharded mode.

--- a/test/sql/align_minimap2_sharded_uuid.test
+++ b/test/sql/align_minimap2_sharded_uuid.test
@@ -1,0 +1,160 @@
+# name: test/sql/align_minimap2_sharded_uuid.test
+# description: align_minimap2_sharded accepts UUID read_id columns.
+# group: [sql]
+
+#   Sharded alignment requires prebuilt .mmi indexes; subject names in those
+#   indexes are opaque bytes, so the output `reference` / `mate_reference`
+#   columns stay VARCHAR. Only the query side (read_id and read_to_shard.read_id)
+#   participates in UUID type mirroring. This exercises the UUID branches of
+#   ReadShardIds (INT128 -> canonical string) and ReadBatchByIds (the typed
+#   temp-table JOIN via Value::UUID).
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Setup: UUID-keyed subject tables, one per shard. save_minimap2_index
+# stringifies the canonical UUID subject names into the .mmi.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE shard_a_subjects_uuid AS SELECT * FROM (VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE shard_b_subjects_uuid AS SELECT * FROM (VALUES
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::UUID, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAA')
+) AS t(read_id, sequence1);
+
+query I
+SELECT success FROM save_minimap2_index('shard_a_subjects_uuid', 'data/shards/shard_a_uuid.mmi', k := 5);
+----
+true
+
+query I
+SELECT success FROM save_minimap2_index('shard_b_subjects_uuid', 'data/shards/shard_b_uuid.mmi', k := 5);
+----
+true
+
+# ---------------------------------------------------------------------------
+# UUID query + UUID read_to_shard. Both share the type so the JOIN inside
+# ReadBatchByIds type-checks naturally.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_uuid AS SELECT * FROM (VALUES
+    ('11111111-1111-1111-1111-111111111111'::UUID, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('22222222-2222-2222-2222-222222222222'::UUID, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE read_to_shard_uuid AS SELECT * FROM (VALUES
+    ('11111111-1111-1111-1111-111111111111'::UUID, 'shard_a_uuid'),
+    ('22222222-2222-2222-2222-222222222222'::UUID, 'shard_b_uuid')
+) AS t(read_id, shard_name);
+
+# Happy path: UUID read_id propagates through ReadShardIds, ReadBatchByIds, and
+# the sharded emit path. Reference stays VARCHAR (prebuilt .mmi), carrying the
+# canonical UUID subject names that were stringified into the index.
+query II
+SELECT read_id, reference
+FROM align_minimap2_sharded('queries_uuid',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_uuid',
+    max_secondary := 0)
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+22222222-2222-2222-2222-222222222222	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+
+# Output type contract: read_id mirrors the query column (UUID); reference and
+# mate_reference stay VARCHAR (prebuilt-index opaque-bytes default).
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2_sharded('queries_uuid',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_uuid',
+    max_secondary := 0)
+LIMIT 1;
+----
+UUID	VARCHAR	VARCHAR
+
+# ---------------------------------------------------------------------------
+# Mixed-type rejection: read_to_shard.read_id must match query.read_id type.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE read_to_shard_varchar AS
+SELECT CAST(read_id AS VARCHAR) AS read_id, shard_name FROM read_to_shard_uuid;
+
+statement error
+SELECT * FROM align_minimap2_sharded('queries_uuid',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_varchar');
+----
+must match the query table's read_id type
+
+# And the reverse: VARCHAR query + UUID read_to_shard.
+statement ok
+CREATE TABLE queries_varchar AS
+SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM queries_uuid;
+
+statement error
+SELECT * FROM align_minimap2_sharded('queries_varchar',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_uuid');
+----
+must match the query table's read_id type
+
+# UUID query + BIGINT read_to_shard is also a mismatch (both are non-VARCHAR but
+# the strict equality check still rejects the cross-type pairing).
+statement ok
+CREATE TABLE read_to_shard_bigint AS SELECT * FROM (VALUES
+    (1001::BIGINT, 'shard_a_uuid')
+) AS t(read_id, shard_name);
+
+statement error
+SELECT * FROM align_minimap2_sharded('queries_uuid',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_bigint');
+----
+must match the query table's read_id type
+
+# ---------------------------------------------------------------------------
+# Unsupported query type (HUGEINT) rejected at bind even though it shares
+# UUID's INT128 physical layout.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM align_minimap2_sharded('queries_hugeint',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_uuid');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# ---------------------------------------------------------------------------
+# NULL read_id rows skipped — same convention as VARCHAR/BIGINT sharded mode.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_uuid_with_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_uuid_with_null VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (NULL, 'GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG');
+
+query II
+SELECT read_id, reference
+FROM align_minimap2_sharded('queries_uuid_with_null',
+    shard_directory := 'data/shards/',
+    read_to_shard := 'read_to_shard_uuid',
+    max_secondary := 0)
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa

--- a/test/sql/align_minimap2_uuid.test
+++ b/test/sql/align_minimap2_uuid.test
@@ -1,0 +1,84 @@
+# name: test/sql/align_minimap2_uuid.test
+# description: align_minimap2 accepts UUID read_id columns.
+# group: [sql]
+
+#   UUID is stored physically as INT128; the codec stringifies it to the
+#   canonical 36-char form on ingress and parses it back on egress, exactly as
+#   BIGINT round-trips through its decimal form. The output read_id mirrors the
+#   query input type and the output reference / mate_reference mirror the subject
+#   input type. Edge cases (raw HUGEINT reject, NULL UUID, canonicalisation,
+#   mixed UUID/BIGINT sides, "=" resolution) live in align_minimap2_uuid_edge.test.
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Setup: tables with UUID read_id storage, plus stringified projections.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_uuid VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('22222222-2222-2222-2222-222222222222', 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+statement ok
+CREATE TABLE subjects_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO subjects_uuid VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC'),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAA');
+
+statement ok
+CREATE TABLE subjects_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM subjects_uuid;
+
+# ---------------------------------------------------------------------------
+# Happy path: UUID/UUID — both ids round-trip; output types mirror input.
+# ---------------------------------------------------------------------------
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('queries_uuid', subject_table='subjects_uuid', max_secondary=0)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+22222222-2222-2222-2222-222222222222	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+
+# Output column types mirror input: query read_id → output read_id (UUID),
+# subject read_id → output reference + mate_reference (UUID).
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('queries_uuid', subject_table='subjects_uuid', max_secondary=0)
+LIMIT 1;
+----
+UUID	UUID	UUID
+
+# Single-end queries: mate_reference is always NULL for UUID subjects
+# (minimap2 emits "*" which the codec maps to NULL).
+query I
+SELECT COUNT(*) FILTER (WHERE mate_reference IS NOT NULL)
+FROM align_minimap2('queries_uuid', subject_table='subjects_uuid', max_secondary=0);
+----
+0
+
+# ---------------------------------------------------------------------------
+# Mixed: UUID queries, VARCHAR subjects — output is asymmetric
+# (read_id UUID, reference/mate_reference VARCHAR).
+# ---------------------------------------------------------------------------
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('queries_uuid', subject_table='subjects_varchar', max_secondary=0)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+22222222-2222-2222-2222-222222222222	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('queries_uuid', subject_table='subjects_varchar', max_secondary=0)
+LIMIT 1;
+----
+UUID	VARCHAR	VARCHAR

--- a/test/sql/align_minimap2_uuid_edge.test
+++ b/test/sql/align_minimap2_uuid_edge.test
@@ -1,0 +1,190 @@
+# name: test/sql/align_minimap2_uuid_edge.test
+# description: Edge case matrix for UUID read_id in align_minimap2.
+# group: [sql]
+
+#   Companion to align_minimap2_uuid.test — covers the tricky paths:
+#     1. Raw HUGEINT read_id / subject  -> rejected, even though UUID shares its
+#                                          INT128 physical layout (only the
+#                                          logical UUID type is accepted)
+#     2. NULL UUID rows                 -> skipped on ingress, NULL on egress
+#     3. Canonicalisation               -> uppercase UUID in -> lowercase out
+#     4. Mixed UUID query + BIGINT subj -> two non-VARCHAR codecs at once
+#     5. Paired-end "=" mate_reference  -> resolved to reference for UUID subj
+#     6. per_subject_database=true      -> id types threaded through
+#     7. Prebuilt-index asymmetry       -> UUID query, VARCHAR refs in output
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Reusable fixtures: 1-row UUID query and subject (query maps into subject).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE uq_queries AS SELECT
+    '11111111-1111-1111-1111-111111111111'::UUID AS read_id,
+    'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT' AS sequence1;
+
+statement ok
+CREATE TABLE uq_subjects AS SELECT
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID AS read_id,
+    'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC' AS sequence1;
+
+# BIGINT projection of the subject for the mixed-type test.
+statement ok
+CREATE TABLE uq_subjects_bigint AS SELECT 2001::BIGINT AS read_id, sequence1 FROM uq_subjects;
+
+# VARCHAR projection of the subject for the prebuilt-index asymmetry test.
+statement ok
+CREATE TABLE uq_subjects_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM uq_subjects;
+
+# ---------------------------------------------------------------------------
+# 1. Raw HUGEINT is rejected even though UUID is physically INT128 — the gate
+#    keys off the logical type, so HUGEINT must NOT be silently accepted as a
+#    UUID. This is the load-bearing guard for UUID support.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE queries_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequence1;
+
+statement error
+SELECT * FROM align_minimap2('queries_hugeint', subject_table='uq_subjects');
+----
+must be VARCHAR, BIGINT, or UUID
+
+statement ok
+CREATE TABLE subjects_hugeint AS SELECT 1::HUGEINT AS read_id, 'ACGT' AS sequence1;
+
+statement error
+SELECT * FROM align_minimap2('uq_queries', subject_table='subjects_hugeint');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# ---------------------------------------------------------------------------
+# 2. NULL UUID read_id rows are skipped (same convention as VARCHAR/BIGINT).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE uq_queries_with_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO uq_queries_with_null VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (NULL, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+# Only the non-NULL row reaches the aligner.
+query II
+SELECT read_id, reference
+FROM align_minimap2('uq_queries_with_null', subject_table='uq_subjects', max_secondary=0)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+
+# ---------------------------------------------------------------------------
+# 3. Canonicalisation: an uppercase UUID input round-trips to the canonical
+#    lowercase form on output (UUID storage is case-insensitive INT128; the
+#    codec's ToString always emits lowercase).
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE uq_queries_upper AS SELECT
+    '12345678-9ABC-DEF0-1234-56789ABCDEF0'::UUID AS read_id,
+    'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT' AS sequence1;
+
+query I
+SELECT read_id
+FROM align_minimap2('uq_queries_upper', subject_table='uq_subjects', max_secondary=0)
+ORDER BY read_id;
+----
+12345678-9abc-def0-1234-56789abcdef0
+
+# ---------------------------------------------------------------------------
+# 4. Mixed: UUID queries + BIGINT subjects — output read_id UUID, reference and
+#    mate_reference BIGINT (exercises both non-VARCHAR codecs simultaneously).
+# ---------------------------------------------------------------------------
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('uq_queries', subject_table='uq_subjects_bigint', max_secondary=0)
+LIMIT 1;
+----
+UUID	BIGINT	BIGINT
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('uq_queries', subject_table='uq_subjects_bigint', max_secondary=0)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	2001
+
+# ---------------------------------------------------------------------------
+# 5. Paired-end: the "=" mate_reference sentinel must resolve to the row's
+#    reference for UUID subjects (the literal "=" has no UUID encoding). A
+#    leaked "=" would throw at the UUID parse, so a clean run proves resolution.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE paired_subjects_uuid AS SELECT
+    'cccccccc-cccc-cccc-cccc-cccccccccccc'::UUID AS read_id,
+    'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT' AS sequence1;
+
+statement ok
+CREATE TABLE paired_queries_uuid (read_id UUID, sequence1 VARCHAR, sequence2 VARCHAR);
+
+statement ok
+INSERT INTO paired_queries_uuid VALUES
+    ('dddddddd-dddd-dddd-dddd-dddddddddddd',
+     'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+query II
+SELECT
+    SUM(CASE WHEN mate_reference IS NOT NULL AND mate_reference = reference THEN 1 ELSE 0 END) > 0 AS any_resolved,
+    SUM(CASE WHEN mate_reference IS NOT NULL AND mate_reference != reference THEN 1 ELSE 0 END) AS unexpected_diff
+FROM align_minimap2('paired_queries_uuid', subject_table='paired_subjects_uuid', max_secondary=0);
+----
+true	0
+
+# ---------------------------------------------------------------------------
+# 6. per_subject_database=true threads UUID id types through ExecutePerSubject.
+# ---------------------------------------------------------------------------
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('uq_queries', subject_table='uq_subjects', per_subject_database=true, max_secondary=0)
+LIMIT 1;
+----
+UUID	UUID	UUID
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('uq_queries', subject_table='uq_subjects', per_subject_database=true, max_secondary=0)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+
+# ---------------------------------------------------------------------------
+# 7. Prebuilt-index asymmetry: UUID queries against a VARCHAR-built index.
+#    Subject names in the .mmi are opaque, defaulting to VARCHAR on output:
+#      read_id        UUID    (from query column)
+#      reference      VARCHAR (prebuilt-index default)
+#      mate_reference VARCHAR
+# ---------------------------------------------------------------------------
+
+query III
+SELECT success, num_subjects > 0, index_path LIKE '%uuid_edge_index.mmi%'
+FROM save_minimap2_index('uq_subjects_varchar', 'uuid_edge_index.mmi', k := 5);
+----
+true	true	true
+
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_minimap2('uq_queries', index_path='uuid_edge_index.mmi', max_secondary=0)
+LIMIT 1;
+----
+UUID	VARCHAR	VARCHAR
+
+query II
+SELECT read_id, reference
+FROM align_minimap2('uq_queries', index_path='uuid_edge_index.mmi', max_secondary=0)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa

--- a/test/sql/align_sortmerna_bigint.test
+++ b/test/sql/align_sortmerna_bigint.test
@@ -65,7 +65,7 @@ statement error
 SELECT * FROM align_sortmerna(
     'smr_q_integer', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE smr_q_hugeint (read_id HUGEINT, sequence1 VARCHAR);
@@ -74,7 +74,7 @@ statement error
 SELECT * FROM align_sortmerna(
     'smr_q_hugeint', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE smr_q_double (read_id DOUBLE, sequence1 VARCHAR);
@@ -83,7 +83,7 @@ statement error
 SELECT * FROM align_sortmerna(
     'smr_q_double', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # ---------------------------------------------------------------------------
 # Empty BIGINT input → zero rows, no crash.

--- a/test/sql/align_sortmerna_rrna_bigint.test
+++ b/test/sql/align_sortmerna_rrna_bigint.test
@@ -64,7 +64,7 @@ statement error
 SELECT * FROM align_sortmerna_rrna(
     'smr_q_integer', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE smr_q_hugeint (read_id HUGEINT, sequence1 VARCHAR);
@@ -73,7 +73,7 @@ statement error
 SELECT * FROM align_sortmerna_rrna(
     'smr_q_hugeint', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 statement ok
 CREATE TABLE smr_q_double (read_id DOUBLE, sequence1 VARCHAR);
@@ -82,7 +82,7 @@ statement error
 SELECT * FROM align_sortmerna_rrna(
     'smr_q_double', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
 ----
-must be VARCHAR or BIGINT
+must be VARCHAR, BIGINT, or UUID
 
 # ---------------------------------------------------------------------------
 # Empty BIGINT input → zero rows, no crash.

--- a/test/sql/align_sortmerna_rrna_uuid.test
+++ b/test/sql/align_sortmerna_rrna_uuid.test
@@ -1,0 +1,88 @@
+# name: test/sql/align_sortmerna_rrna_uuid.test
+# description: align_sortmerna_rrna accepts UUID read_id columns.
+# group: [sql]
+
+#
+# align_sortmerna_rrna's schema has a single id-typed column (read_id) —
+# `ref_name` is a free-form string carrying FASTA header text, not an id column,
+# so it stays VARCHAR. Output read_id mirrors the query column type; UUID
+# round-trips through the shared emit helper exactly as BIGINT does.
+
+require miint
+
+require parquet
+
+require-env SORTMERNA_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# UUID query table seeded with the AB271211 16S rRNA sequence from
+# align_sortmerna_rrna.test. Same sequence → same expected alignment values.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE smr_q_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO smr_q_uuid VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'TCCAACGCGTTGGGAGCTCTCCCATATGGTCGACCTGCAGGCGGCCGCACTAGTGATTAGAGTTTGATCCTGGCTCAGGATGAACGCTGGCGGCGTGCCTAACACATGCAAGTCGAACGGGAATCTTCGGATTCTAGTGGCGGACGGGTGAGTAACGCGTAAGAATCTAACTTCAGGACGGGGACAACAGTGGGAAACGACTGCTAATACCCGATGTGCCGCGAGGTGAAACCTAATTGGCCTGAAGAGGAGCTTGCGTCTGATTAGCTAGTTGGTGGGGTAAGAGCCTACCAAGGCGACGATCAGTAGCTGGTCTGAGAGGATGAGCAGCCACACTGGGACTGAGACACGGCCCAGACTCCTACGGGAGGCAGCAGTGGGGAATTTTCCGCAATGGGCGAAAGCCTGACGGAGCAACGCCGCGTGAGGGAGGAAGGTCTTTGGATTGTAAACCTCTTTTCTCAAGGAAGAAGTTCTGACGGTACTTGAGGAATCAGCCTCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGGGGAGGCAAGCGTTATCCGGAATTATTGGGCGTAAAGCGTCCGCAGGTGGTCAGCCAAGTCTGCCGTCAAATCAGGTTGCTTAACGACCTAAAGGCGGTGGAAACTGGCAGACTAGAGAGCAGTAGGGGTAGCAGGAATTCCCAGTGTAGCGGTGAAATGCGTAGAGATTGGGAAGAACATCGGTGGCGAAAGCGTGCTACTGGGCTGTATCTGACACTCAGGGACGAAAGCTAGGGGAGCGAAAGGGATTAGATACCCCTGTAGTCCTAGCCGTAAACGATGGATACTAGGCGTGGCTTGTATCGACCCGAGCCGTGCCGAAGCTAACGCGTTAAGTATCCCGCCTGGGGAGTACGCACGCAAGTGTGAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCGGTGGAGTATGTGGTTTAATTCGATGCAACGCGAAGAACCTTACCAAGACTTGACATGTCGCGAACCCTGGTGAAAGCTGGGGGTGCCTTCGGGAGCGCGAACACAGGTGGTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTCGTTCTTAGTTGCCAGCATTAAGTTGGGGACTCTAAGGAGACTGCCGGTGACAAACCGGAGGAAGGTGGGGATGACGTCAAGTCAGCATGCCCCTTACGTCTTGGGCGACACACGTACTACAATGGTCGGGACAAAGGGCAGCGAACTTGCGAGAGCCAGCGAATCCCAGCAAACCCGGCCTCAGTTCAGATTGCAGGCTGCAACTCGCCTGCATGAAGGAGGAATCGCTAGTAATCGCCGGTCAGCATACGGCGGTGAATTCGTTCCCGGGCCTTGTACACACCGCCCGTCACACCATGGAAGCTGGTCACGCCCGAAGTCATTACCTCAACCGCAAGGAGGGGGATGCCTAAGGCAGGGCTAGTGACTGGGG'
+);
+
+# Output read_id type mirrors the UUID query column; ref_name stays VARCHAR.
+query II
+SELECT typeof(read_id), typeof(ref_name)
+FROM align_sortmerna_rrna(
+    'smr_q_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1)
+LIMIT 1;
+----
+UUID	VARCHAR
+
+# Happy path: UUID read_id round-trips; alignment values match the baseline.
+query IIIIIIIIIII
+SELECT read_id, aligned, strand, ref_name, ref_start, ref_end, cigar, score,
+       edit_distance,
+       round(identity, 1) AS identity_1dp,
+       round(coverage, 1) AS coverage_1dp
+FROM align_sortmerna_rrna(
+    'smr_q_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1);
+----
+11111111-1111-1111-1111-111111111111	1	1	Unc49508	1	1446	57S57M2I12M2D4M2I29M1D11M2I3M2D11M1I7M1D13M5D4M3D9M2D3M7D1260M	2430	94	93.5	96.2
+
+# Unsupported numeric type (HUGEINT) rejected at bind.
+statement ok
+CREATE TABLE smr_q_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM align_sortmerna_rrna(
+    'smr_q_hugeint', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
+----
+must be VARCHAR, BIGINT, or UUID
+
+# NULL UUID read_id rows skipped.
+statement ok
+CREATE TABLE smr_q_uuid_with_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO smr_q_uuid_with_null
+SELECT read_id, sequence1 FROM smr_q_uuid
+UNION ALL SELECT NULL, sequence1 FROM smr_q_uuid;
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT read_id)
+FROM align_sortmerna_rrna(
+    'smr_q_uuid_with_null', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1);
+----
+1	1
+
+# Round-trip via parquet preserves UUID natively (no SAM string coercion).
+statement ok
+COPY (
+    SELECT * FROM align_sortmerna_rrna(
+        'smr_q_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1)
+) TO '__TEST_DIR__/sortmerna_rrna_uuid.parquet' (FORMAT PARQUET);
+
+query III
+SELECT read_id, typeof(read_id), aligned
+FROM read_parquet('__TEST_DIR__/sortmerna_rrna_uuid.parquet');
+----
+11111111-1111-1111-1111-111111111111	UUID	1

--- a/test/sql/align_sortmerna_uuid.test
+++ b/test/sql/align_sortmerna_uuid.test
@@ -1,0 +1,109 @@
+# name: test/sql/align_sortmerna_uuid.test
+# description: align_sortmerna accepts UUID read_id columns.
+# group: [sql]
+
+#
+# SortMeRNA's subject side comes from FASTA files on disk (ref_paths), never a
+# user-provided table — so subject_id_type is always VARCHAR. The output read_id
+# mirrors the query column type; UUID round-trips through the shared emit helper
+# exactly as BIGINT does. Alignment values match the VARCHAR/BIGINT baselines
+# (same sequence + reference) — only the read_id type differs.
+
+require miint
+
+require-env SORTMERNA_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# UUID query table seeded with the AB271211 16S rRNA sequence used by
+# align_sortmerna.test / align_sortmerna_bigint.test.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE smr_q_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO smr_q_uuid VALUES (
+  '11111111-1111-1111-1111-111111111111',
+  'TCCAACGCGTTGGGAGCTCTCCCATATGGTCGACCTGCAGGCGGCCGCACTAGTGATTAGAGTTTGATCCTGGCTCAGGATGAACGCTGGCGGCGTGCCTAACACATGCAAGTCGAACGGGAATCTTCGGATTCTAGTGGCGGACGGGTGAGTAACGCGTAAGAATCTAACTTCAGGACGGGGACAACAGTGGGAAACGACTGCTAATACCCGATGTGCCGCGAGGTGAAACCTAATTGGCCTGAAGAGGAGCTTGCGTCTGATTAGCTAGTTGGTGGGGTAAGAGCCTACCAAGGCGACGATCAGTAGCTGGTCTGAGAGGATGAGCAGCCACACTGGGACTGAGACACGGCCCAGACTCCTACGGGAGGCAGCAGTGGGGAATTTTCCGCAATGGGCGAAAGCCTGACGGAGCAACGCCGCGTGAGGGAGGAAGGTCTTTGGATTGTAAACCTCTTTTCTCAAGGAAGAAGTTCTGACGGTACTTGAGGAATCAGCCTCGGCTAACTCCGTGCCAGCAGCCGCGGTAATACGGGGGAGGCAAGCGTTATCCGGAATTATTGGGCGTAAAGCGTCCGCAGGTGGTCAGCCAAGTCTGCCGTCAAATCAGGTTGCTTAACGACCTAAAGGCGGTGGAAACTGGCAGACTAGAGAGCAGTAGGGGTAGCAGGAATTCCCAGTGTAGCGGTGAAATGCGTAGAGATTGGGAAGAACATCGGTGGCGAAAGCGTGCTACTGGGCTGTATCTGACACTCAGGGACGAAAGCTAGGGGAGCGAAAGGGATTAGATACCCCTGTAGTCCTAGCCGTAAACGATGGATACTAGGCGTGGCTTGTATCGACCCGAGCCGTGCCGAAGCTAACGCGTTAAGTATCCCGCCTGGGGAGTACGCACGCAAGTGTGAAACTCAAAGGAATTGACGGGGGCCCGCACAAGCGGTGGAGTATGTGGTTTAATTCGATGCAACGCGAAGAACCTTACCAAGACTTGACATGTCGCGAACCCTGGTGAAAGCTGGGGGTGCCTTCGGGAGCGCGAACACAGGTGGTGCATGGCTGTCGTCAGCTCGTGTCGTGAGATGTTGGGTTAAGTCCCGCAACGAGCGCAACCCTCGTTCTTAGTTGCCAGCATTAAGTTGGGGACTCTAAGGAGACTGCCGGTGACAAACCGGAGGAAGGTGGGGATGACGTCAAGTCAGCATGCCCCTTACGTCTTGGGCGACACACGTACTACAATGGTCGGGACAAAGGGCAGCGAACTTGCGAGAGCCAGCGAATCCCAGCAAACCCGGCCTCAGTTCAGATTGCAGGCTGCAACTCGCCTGCATGAAGGAGGAATCGCTAGTAATCGCCGGTCAGCATACGGCGGTGAATTCGTTCCCGGGCCTTGTACACACCGCCCGTCACACCATGGAAGCTGGTCACGCCCGAAGTCATTACCTCAACCGCAAGGAGGGGGATGCCTAAGGCAGGGCTAGTGACTGGGG'
+);
+
+# Output column types: read_id mirrors the UUID query side; subject side is
+# always VARCHAR (sortmerna refs come from FASTA files on disk).
+query III
+SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
+FROM align_sortmerna(
+    'smr_q_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1)
+LIMIT 1;
+----
+UUID	VARCHAR	VARCHAR
+
+# Happy path: UUID read_id round-trips; alignment values match the baseline.
+query IIIIIIIIII
+SELECT read_id, flags, reference, position, stop_position, mapq, cigar,
+       mate_reference, mate_position, template_length
+FROM align_sortmerna(
+    'smr_q_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1);
+----
+11111111-1111-1111-1111-111111111111	0	Unc49508	1	1447	255	57S57M2I12M2D4M2I29M1D11M2I3M2D11M1I7M1D13M5D4M3D9M2D3M7D1260M	*	0	0
+
+# Unsupported numeric type (HUGEINT) rejected at bind even though it shares
+# UUID's INT128 physical layout.
+statement ok
+CREATE TABLE smr_q_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM align_sortmerna(
+    'smr_q_hugeint', ref_paths := ['ext/sortmerna/data/test_ref.fasta']);
+----
+must be VARCHAR, BIGINT, or UUID
+
+# NULL UUID read_id rows are skipped — the aligner never sees NULL identifiers.
+statement ok
+CREATE TABLE smr_q_uuid_with_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO smr_q_uuid_with_null
+SELECT read_id, sequence1 FROM smr_q_uuid
+UNION ALL SELECT NULL, sequence1 FROM smr_q_uuid;
+
+query II
+SELECT COUNT(*), COUNT(DISTINCT read_id)
+FROM align_sortmerna(
+    'smr_q_uuid_with_null', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1);
+----
+1	1
+
+# Paired-end UUID — read_id round-trips across paired output. Subject side stays
+# VARCHAR (refs from FASTA on disk), so mate_reference keeps the SAM `=` sentinel
+# verbatim (VARCHAR has an in-band encoding for `=`; no resolution needed).
+statement ok
+CREATE TABLE smr_pe_uuid AS
+SELECT read_id, sequence1, sequence1 AS sequence2 FROM smr_q_uuid;
+
+query IIIII
+SELECT flags, typeof(read_id), read_id, mate_reference, typeof(mate_reference)
+FROM align_sortmerna(
+    'smr_pe_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'],
+    num_threads := 1, paired := true)
+ORDER BY flags;
+----
+67	UUID	11111111-1111-1111-1111-111111111111	=	VARCHAR
+131	UUID	11111111-1111-1111-1111-111111111111	=	VARCHAR
+
+# Round-trip via COPY ... FORMAT SAM: UUID read_id stringifies to its canonical
+# form on write; read_sam returns VARCHAR (documented type loss).
+statement ok
+CREATE TABLE smr_ref_lengths AS SELECT 'Unc49508' AS name, 2000 AS length;
+
+statement ok
+COPY (
+    SELECT * FROM align_sortmerna(
+        'smr_q_uuid', ref_paths := ['ext/sortmerna/data/test_ref.fasta'], num_threads := 1)
+) TO '__TEST_DIR__/sortmerna_uuid.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'smr_ref_lengths');
+
+query III
+SELECT read_id, typeof(read_id), reference
+FROM read_sam('__TEST_DIR__/sortmerna_uuid.sam');
+----
+11111111-1111-1111-1111-111111111111	VARCHAR	Unc49508

--- a/test/sql/blast_bigint.test
+++ b/test/sql/blast_bigint.test
@@ -1,0 +1,42 @@
+# name: test/sql/blast_bigint.test
+# description: blast output query_id mirrors a BIGINT query read_id; subject_id stays VARCHAR.
+# group: [sql]
+
+#   blast has a single user id column: the query read_id, echoed back as query_id,
+#   which mirrors the query table's read_id type. subject_id is an NCBI accession
+#   and is always VARCHAR. This is a bind-time (DESCRIBE) check — the live id value
+#   round-trip needs network and is covered by blast_live.test.
+
+require miint
+
+statement ok
+CREATE TEMP TABLE seqs_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seqs_bigint VALUES (42, 'ACGTACGTACGTACGTACGT');
+
+# query_id mirrors BIGINT; subject_id stays VARCHAR; all other columns unchanged.
+query IIIIII
+DESCRIBE SELECT * FROM blast('seqs_bigint');
+----
+query_id	BIGINT	YES	NULL	NULL	NULL
+subject_id	VARCHAR	YES	NULL	NULL	NULL
+pct_identity	DOUBLE	YES	NULL	NULL	NULL
+alignment_length	INTEGER	YES	NULL	NULL	NULL
+mismatches	INTEGER	YES	NULL	NULL	NULL
+gap_opens	INTEGER	YES	NULL	NULL	NULL
+query_start	BIGINT	YES	NULL	NULL	NULL
+query_end	BIGINT	YES	NULL	NULL	NULL
+subject_start	BIGINT	YES	NULL	NULL	NULL
+subject_end	BIGINT	YES	NULL	NULL	NULL
+evalue	DOUBLE	YES	NULL	NULL	NULL
+bit_score	DOUBLE	YES	NULL	NULL	NULL
+
+# Raw HUGEINT read_id stays rejected at bind.
+statement ok
+CREATE TEMP TABLE seqs_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM blast('seqs_hugeint');
+----
+must be VARCHAR, BIGINT, or UUID

--- a/test/sql/blast_live.test
+++ b/test/sql/blast_live.test
@@ -97,6 +97,52 @@ SELECT query_id FROM blast_prot_results LIMIT 1;
 ----
 insulin_b
 
+# --- query_id identifier-type round-trip (BIGINT / UUID) ---
+# The output query_id mirrors the query table's read_id type. NCBI echoes the
+# FASTA defline token verbatim, and the id codec parses it back to the storage
+# type. subject_id is always VARCHAR (an NCBI accession). Same Lambda fragment as
+# the blastn test so a near-perfect hit is guaranteed.
+
+statement ok
+CREATE TABLE blast_bigint_queries AS SELECT * FROM (VALUES
+    (42::BIGINT, 'GGGCGGCGACCTCGCGGGTTTTCGCTATTTATGAAAATTTTCCGGTTTAAGGCGTTTCCGTTCTTCTTCGTCATAACTTAATGTTTTTATTTAAAATACCT')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE blast_bigint_results AS
+SELECT * FROM blast('blast_bigint_queries', program := 'blastn', database := 'nt', max_targets := 3, megablast := true);
+
+# query_id round-trips to the BIGINT input; subject_id stays VARCHAR.
+query TT
+SELECT DISTINCT typeof(query_id), typeof(subject_id) FROM blast_bigint_results;
+----
+BIGINT	VARCHAR
+
+query I
+SELECT DISTINCT query_id FROM blast_bigint_results;
+----
+42
+
+statement ok
+CREATE TABLE blast_uuid_queries AS SELECT * FROM (VALUES
+    ('11111111-1111-1111-1111-111111111111'::UUID, 'GGGCGGCGACCTCGCGGGTTTTCGCTATTTATGAAAATTTTCCGGTTTAAGGCGTTTCCGTTCTTCTTCGTCATAACTTAATGTTTTTATTTAAAATACCT')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE blast_uuid_results AS
+SELECT * FROM blast('blast_uuid_queries', program := 'blastn', database := 'nt', max_targets := 3, megablast := true);
+
+# query_id round-trips to the UUID input (canonical lowercase); subject_id VARCHAR.
+query TT
+SELECT DISTINCT typeof(query_id), typeof(subject_id) FROM blast_uuid_results;
+----
+UUID	VARCHAR
+
+query T
+SELECT DISTINCT query_id FROM blast_uuid_results;
+----
+11111111-1111-1111-1111-111111111111
+
 # --- Cleanup ---
 
 statement ok
@@ -110,3 +156,15 @@ DROP TABLE IF EXISTS blast_prot_queries;
 
 statement ok
 DROP TABLE IF EXISTS blast_prot_results;
+
+statement ok
+DROP TABLE IF EXISTS blast_bigint_queries;
+
+statement ok
+DROP TABLE IF EXISTS blast_bigint_results;
+
+statement ok
+DROP TABLE IF EXISTS blast_uuid_queries;
+
+statement ok
+DROP TABLE IF EXISTS blast_uuid_results;

--- a/test/sql/blast_uuid.test
+++ b/test/sql/blast_uuid.test
@@ -1,0 +1,32 @@
+# name: test/sql/blast_uuid.test
+# description: blast output query_id mirrors a UUID query read_id; subject_id stays VARCHAR.
+# group: [sql]
+
+#   Mirrors blast_bigint: query_id mirrors the query table's read_id type (UUID
+#   here), subject_id stays VARCHAR (NCBI accession). Bind-time (DESCRIBE) check;
+#   the live id value round-trip needs network and is covered by blast_live.test.
+
+require miint
+
+statement ok
+CREATE TEMP TABLE seqs_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seqs_uuid VALUES ('11111111-1111-1111-1111-111111111111', 'ACGTACGTACGTACGTACGT');
+
+# query_id mirrors UUID; subject_id stays VARCHAR; all other columns unchanged.
+query IIIIII
+DESCRIBE SELECT * FROM blast('seqs_uuid');
+----
+query_id	UUID	YES	NULL	NULL	NULL
+subject_id	VARCHAR	YES	NULL	NULL	NULL
+pct_identity	DOUBLE	YES	NULL	NULL	NULL
+alignment_length	INTEGER	YES	NULL	NULL	NULL
+mismatches	INTEGER	YES	NULL	NULL	NULL
+gap_opens	INTEGER	YES	NULL	NULL	NULL
+query_start	BIGINT	YES	NULL	NULL	NULL
+query_end	BIGINT	YES	NULL	NULL	NULL
+subject_start	BIGINT	YES	NULL	NULL	NULL
+subject_end	BIGINT	YES	NULL	NULL	NULL
+evalue	DOUBLE	YES	NULL	NULL	NULL
+bit_score	DOUBLE	YES	NULL	NULL	NULL

--- a/test/sql/cluster_sequences_bigint.test
+++ b/test/sql/cluster_sequences_bigint.test
@@ -1,0 +1,91 @@
+# name: test/sql/cluster_sequences_bigint.test
+# description: cluster_sequences_vsearch accepts BIGINT read_id; read_id and centroid_id round-trip.
+# group: [sql]
+
+#   read_id is carried internally as a string regardless of SQL type. A BIGINT
+#   read_id is stringified to decimal on ingress and parsed back on egress, so
+#   both the output read_id and centroid_id (which is one of the input read_ids)
+#   must mirror the BIGINT input type and round-trip losslessly — including the
+#   int64 extremes. A raw HUGEINT column stays rejected: only logical BIGINT/UUID
+#   widen the historically VARCHAR-only id contract.
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# Happy path: BIGINT read_id round-trips; output types mirror input.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE ident_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO ident_bigint VALUES
+    (10, 'ATCGATCGATCGATCGATCGATCG'),
+    (20, 'ATCGATCGATCGATCGATCGATCG'),
+    (30, 'ATCGATCGATCGATCGATCGATCG');
+
+# read_id and centroid_id mirror the BIGINT input type.
+query TT
+SELECT typeof(read_id), typeof(centroid_id)
+FROM cluster_sequences_vsearch('ident_bigint', id:=0.97)
+LIMIT 1;
+----
+BIGINT	BIGINT
+
+# Three identical sequences → one cluster; centroid is the first fed (id 10),
+# and every centroid_id round-trips back to that exact BIGINT.
+query ITII
+SELECT read_id, is_centroid, cluster_id, centroid_id
+FROM cluster_sequences_vsearch('ident_bigint', id:=0.97)
+ORDER BY read_id;
+----
+10	true	0	10
+20	false	0	10
+30	false	0	10
+
+# ---------------------------------------------------------------------------
+# int64 extremes round-trip through the decimal codec without overflow.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE extreme_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO extreme_bigint VALUES
+    (-9223372036854775808, 'ATCGATCGATCGATCGATCGATCG'),
+    (9223372036854775807, 'ATCGATCGATCGATCGATCGATCG');
+
+query II
+SELECT read_id, centroid_id
+FROM cluster_sequences_vsearch('extreme_bigint', id:=0.97)
+ORDER BY read_id;
+----
+-9223372036854775808	-9223372036854775808
+9223372036854775807	-9223372036854775808
+
+# ---------------------------------------------------------------------------
+# Raw HUGEINT stays rejected — only logical BIGINT/UUID widen the id contract.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE hugeint_ids (read_id HUGEINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO hugeint_ids VALUES (1, 'ATCGATCGATCGATCGATCGATCG');
+
+statement error
+SELECT * FROM cluster_sequences_vsearch('hugeint_ids', id:=0.97);
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- Cleanup ---
+statement ok
+DROP TABLE ident_bigint;
+
+statement ok
+DROP TABLE extreme_bigint;
+
+statement ok
+DROP TABLE hugeint_ids;

--- a/test/sql/cluster_sequences_uuid.test
+++ b/test/sql/cluster_sequences_uuid.test
@@ -1,0 +1,91 @@
+# name: test/sql/cluster_sequences_uuid.test
+# description: cluster_sequences_vsearch accepts UUID read_id; read_id and centroid_id round-trip.
+# group: [sql]
+
+#   UUID is stored physically as INT128; the codec stringifies it to the
+#   canonical 36-char lowercase form on ingress and parses it back on egress,
+#   exactly as BIGINT round-trips through its decimal form. Both output id
+#   columns (read_id and centroid_id) mirror the UUID input type, and an
+#   uppercase input still emits canonical lowercase (the value is compared as an
+#   int128, never as a string).
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+# ---------------------------------------------------------------------------
+# Happy path: UUID read_id round-trips; output types mirror input.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE ident_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO ident_uuid VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ATCGATCGATCGATCGATCGATCG'),
+    ('22222222-2222-2222-2222-222222222222', 'ATCGATCGATCGATCGATCGATCG'),
+    ('33333333-3333-3333-3333-333333333333', 'ATCGATCGATCGATCGATCGATCG');
+
+# read_id and centroid_id mirror the UUID input type.
+query TT
+SELECT typeof(read_id), typeof(centroid_id)
+FROM cluster_sequences_vsearch('ident_uuid', id:=0.97)
+LIMIT 1;
+----
+UUID	UUID
+
+# Three identical sequences → one cluster; centroid is the first fed, and every
+# centroid_id round-trips back to that exact UUID.
+query TTIT
+SELECT read_id, is_centroid, cluster_id, centroid_id
+FROM cluster_sequences_vsearch('ident_uuid', id:=0.97)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	true	0	11111111-1111-1111-1111-111111111111
+22222222-2222-2222-2222-222222222222	false	0	11111111-1111-1111-1111-111111111111
+33333333-3333-3333-3333-333333333333	false	0	11111111-1111-1111-1111-111111111111
+
+# ---------------------------------------------------------------------------
+# Uppercase UUID input → canonical lowercase output.
+# ---------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE upper_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO upper_uuid VALUES
+    ('AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA', 'ATCGATCGATCGATCGATCGATCG'),
+    ('BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB', 'ATCGATCGATCGATCGATCGATCG');
+
+query TT
+SELECT read_id, centroid_id
+FROM cluster_sequences_vsearch('upper_uuid', id:=0.97)
+ORDER BY read_id;
+----
+aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+
+# A UUIDv7-shaped value (version nibble 7) round-trips — FromString is
+# version-agnostic.
+statement ok
+CREATE TABLE v7_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO v7_uuid VALUES
+    ('018f6d8e-7c2a-7e3b-9f4d-1a2b3c4d5e6f', 'ATCGATCGATCGATCGATCGATCG');
+
+query TT
+SELECT read_id, centroid_id
+FROM cluster_sequences_vsearch('v7_uuid', id:=0.97);
+----
+018f6d8e-7c2a-7e3b-9f4d-1a2b3c4d5e6f	018f6d8e-7c2a-7e3b-9f4d-1a2b3c4d5e6f
+
+# --- Cleanup ---
+statement ok
+DROP TABLE ident_uuid;
+
+statement ok
+DROP TABLE upper_uuid;
+
+statement ok
+DROP TABLE v7_uuid;

--- a/test/sql/copy_sam_uuid.test
+++ b/test/sql/copy_sam_uuid.test
@@ -1,43 +1,40 @@
-# name: test/sql/copy_sam_bigint.test
-# description: COPY FORMAT SAM/BAM accepts BIGINT for read_id, reference, mate_reference (PR 1, Cycle 4).
+# name: test/sql/copy_sam_uuid.test
+# description: COPY FORMAT SAM/BAM accepts UUID for read_id, reference, mate_reference.
 # group: [sql]
 
-#   COPY FORMAT SAM previously required VARCHAR for the three identifier columns
-#   (read_id, reference, mate_reference). Cycle 4 of the BIGINT-id work relaxes
-#   that to accept either VARCHAR or BIGINT, with BIGINT values stringified to
-#   decimal on write and NULL → SAM '*' sentinel. Round-trip via read_sam
-#   produces VARCHAR (type loss is documented).
+#   COPY FORMAT SAM accepts VARCHAR, BIGINT, or UUID for the three identifier
+#   columns. UUID values are stringified to their canonical 36-char form on
+#   write (NULL -> SAM '*'); round-trip via read_sam produces VARCHAR (type loss
+#   is documented). BAM coverage lives here too (same ExtractSamIdField path,
+#   mirroring copy_sam_bigint.test which has no separate copy_bam_bigint.test).
 
 require miint
 
 # ---------------------------------------------------------------------------
-# Common setup: a reference-lengths table addressable by the BIGINT decimal
-# stringification of subject identifiers (2001, 2002).
+# Reference-lengths table addressable by the canonical UUID stringification of
+# the subject identifiers used as `reference` / `mate_reference`.
 # ---------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE ref_bigint_lengths AS
-SELECT '2001' AS name, 10000 AS length
-UNION ALL SELECT '2002', 10000;
+CREATE TABLE ref_uuid_lengths AS
+SELECT 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' AS name, 10000 AS length
+UNION ALL SELECT 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 10000;
 
 # ---------------------------------------------------------------------------
-# Test 1: All three id columns BIGINT — happy path. Use distinct reference and
-# mate_reference values so the BIGINT decimal stringification of mate_reference
-# is observable in the round-trip. (HTSlib normalises RNEXT to '=' when it
-# matches RNAME at the tid level — that's identical for VARCHAR and BIGINT
-# inputs and is covered separately below.)
+# Test 1: All three id columns UUID — happy path. Distinct reference and
+# mate_reference so the canonical stringification of mate_reference is visible.
 # ---------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE result_all_bigint AS SELECT
-    1001::BIGINT AS read_id,
+CREATE TABLE result_all_uuid AS SELECT
+    '11111111-1111-1111-1111-111111111111'::UUID AS read_id,
     0::USMALLINT AS flags,
-    2001::BIGINT AS reference,
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID AS reference,
     1::BIGINT AS position,
     51::BIGINT AS stop_position,
     60::UTINYINT AS mapq,
     '50M' AS cigar,
-    2002::BIGINT AS mate_reference,
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::UUID AS mate_reference,
     150::BIGINT AS mate_position,
     200::BIGINT AS template_length,
     NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
@@ -46,38 +43,38 @@ CREATE TABLE result_all_bigint AS SELECT
     NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
 
 statement ok
-COPY result_all_bigint TO '__TEST_DIR__/all_bigint.sam'
-(FORMAT SAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+COPY result_all_uuid TO '__TEST_DIR__/all_uuid.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'ref_uuid_lengths');
 
-# Decimal stringification on write, VARCHAR on read-back.
+# Canonical stringification on write, VARCHAR on read-back.
 query III
 SELECT read_id, reference, mate_reference
-FROM read_sam('__TEST_DIR__/all_bigint.sam');
+FROM read_sam('__TEST_DIR__/all_uuid.sam');
 ----
-1001	2001	2002
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
 
 query III
 SELECT typeof(read_id), typeof(reference), typeof(mate_reference)
-FROM read_sam('__TEST_DIR__/all_bigint.sam')
+FROM read_sam('__TEST_DIR__/all_uuid.sam')
 LIMIT 1;
 ----
 VARCHAR	VARCHAR	VARCHAR
 
 # ---------------------------------------------------------------------------
-# Test 1b: HTSlib '=' normalisation for BIGINT inputs when mate_reference
-# equals reference — parity with the VARCHAR path (see copy_sam.test test 9).
+# Test 1b: HTSlib '=' normalisation when mate_reference equals reference —
+# parity with the VARCHAR/BIGINT paths.
 # ---------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE result_bigint_eq AS SELECT
-    1002::BIGINT AS read_id,
+CREATE TABLE result_uuid_eq AS SELECT
+    '22222222-2222-2222-2222-222222222222'::UUID AS read_id,
     0::USMALLINT AS flags,
-    2001::BIGINT AS reference,
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID AS reference,
     1::BIGINT AS position,
     51::BIGINT AS stop_position,
     60::UTINYINT AS mapq,
     '50M' AS cigar,
-    2001::BIGINT AS mate_reference,
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID AS mate_reference,
     150::BIGINT AS mate_position,
     200::BIGINT AS template_length,
     NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
@@ -86,29 +83,29 @@ CREATE TABLE result_bigint_eq AS SELECT
     NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
 
 statement ok
-COPY result_bigint_eq TO '__TEST_DIR__/bigint_eq.sam'
-(FORMAT SAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+COPY result_uuid_eq TO '__TEST_DIR__/uuid_eq.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'ref_uuid_lengths');
 
 query III
 SELECT read_id, reference, mate_reference
-FROM read_sam('__TEST_DIR__/bigint_eq.sam');
+FROM read_sam('__TEST_DIR__/uuid_eq.sam');
 ----
-1002	2001	=
+22222222-2222-2222-2222-222222222222	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa	=
 
 # ---------------------------------------------------------------------------
-# Test 2: NULL BIGINT id values → SAM '*' on disk
+# Test 2: NULL UUID id values → SAM '*' on disk.
 # ---------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE result_null_ids AS SELECT
-    NULL::BIGINT AS read_id,
+CREATE TABLE result_null_uuid AS SELECT
+    NULL::UUID AS read_id,
     4::USMALLINT AS flags,
-    NULL::BIGINT AS reference,
+    NULL::UUID AS reference,
     0::BIGINT AS position,
     0::BIGINT AS stop_position,
     0::UTINYINT AS mapq,
     '*' AS cigar,
-    NULL::BIGINT AS mate_reference,
+    NULL::UUID AS mate_reference,
     0::BIGINT AS mate_position,
     0::BIGINT AS template_length,
     NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
@@ -120,30 +117,30 @@ statement ok
 CREATE TABLE ref_dummy AS SELECT 'dummy' AS name, 1000 AS length;
 
 statement ok
-COPY result_null_ids TO '__TEST_DIR__/null_bigint_ids.sam'
+COPY result_null_uuid TO '__TEST_DIR__/null_uuid_ids.sam'
 (FORMAT SAM, INCLUDE_HEADER false, REFERENCE_LENGTHS 'ref_dummy');
 
 query III
 SELECT read_id, reference, mate_reference
-FROM read_sam('__TEST_DIR__/null_bigint_ids.sam', reference_lengths='ref_dummy');
+FROM read_sam('__TEST_DIR__/null_uuid_ids.sam', reference_lengths='ref_dummy');
 ----
 *	*	*
 
 # ---------------------------------------------------------------------------
-# Test 3: Mixed — read_id VARCHAR, reference/mate_reference BIGINT
-# (independent type acceptance per column)
+# Test 3: Mixed — read_id VARCHAR, reference/mate_reference UUID
+# (independent type acceptance per column).
 # ---------------------------------------------------------------------------
 
 statement ok
-CREATE TABLE result_mixed AS SELECT
+CREATE TABLE result_mixed_uuid AS SELECT
     'read-mixed-1' AS read_id,
     0::USMALLINT AS flags,
-    2002::BIGINT AS reference,
+    'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::UUID AS reference,
     1::BIGINT AS position,
     51::BIGINT AS stop_position,
     60::UTINYINT AS mapq,
     '50M' AS cigar,
-    2001::BIGINT AS mate_reference,
+    'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::UUID AS mate_reference,
     150::BIGINT AS mate_position,
     200::BIGINT AS template_length,
     NULL::BIGINT AS tag_as, NULL::BIGINT AS tag_xs, NULL::BIGINT AS tag_ys,
@@ -152,29 +149,30 @@ CREATE TABLE result_mixed AS SELECT
     NULL::VARCHAR AS tag_yt, NULL::VARCHAR AS tag_md, NULL::VARCHAR AS tag_sa;
 
 statement ok
-COPY result_mixed TO '__TEST_DIR__/mixed.sam'
-(FORMAT SAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+COPY result_mixed_uuid TO '__TEST_DIR__/mixed_uuid.sam'
+(FORMAT SAM, REFERENCE_LENGTHS 'ref_uuid_lengths');
 
 query III
-SELECT read_id, reference, mate_reference FROM read_sam('__TEST_DIR__/mixed.sam');
+SELECT read_id, reference, mate_reference FROM read_sam('__TEST_DIR__/mixed_uuid.sam');
 ----
-read-mixed-1	2002	2001
+read-mixed-1	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
 
 # ---------------------------------------------------------------------------
-# Test 4: BAM output with BIGINT ids — same write path, binary container
+# Test 4: BAM output with UUID ids — same ExtractSamIdField write path, binary
+# container (covers the copy_bam path for UUID).
 # ---------------------------------------------------------------------------
 
 statement ok
-COPY result_all_bigint TO '__TEST_DIR__/all_bigint.bam'
-(FORMAT BAM, REFERENCE_LENGTHS 'ref_bigint_lengths');
+COPY result_all_uuid TO '__TEST_DIR__/all_uuid.bam'
+(FORMAT BAM, REFERENCE_LENGTHS 'ref_uuid_lengths');
 
 query III
-SELECT read_id, reference, mate_reference FROM read_sam('__TEST_DIR__/all_bigint.bam');
+SELECT read_id, reference, mate_reference FROM read_sam('__TEST_DIR__/all_uuid.bam');
 ----
-1001	2001	2002
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
 
 # ---------------------------------------------------------------------------
-# Test 5: Unsupported id types still rejected with a clear error
+# Test 5: Unsupported id types still rejected with a clear error.
 # ---------------------------------------------------------------------------
 
 statement error
@@ -182,24 +180,6 @@ COPY (SELECT
     1::INTEGER AS read_id, 0::USMALLINT AS flags, 'r' AS reference, 1::BIGINT AS position,
     1::BIGINT AS stop_position, 0::UTINYINT AS mapq, '*' AS cigar, '*' AS mate_reference,
     0::BIGINT AS mate_position, 0::BIGINT AS template_length
-) TO '__TEST_DIR__/bad_read_id.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
+) TO '__TEST_DIR__/bad_read_id_uuid.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
 ----
 Column 'read_id' must be VARCHAR, BIGINT, or UUID
-
-statement error
-COPY (SELECT
-    'r' AS read_id, 0::USMALLINT AS flags, 1::INTEGER AS reference, 1::BIGINT AS position,
-    1::BIGINT AS stop_position, 0::UTINYINT AS mapq, '*' AS cigar, '*' AS mate_reference,
-    0::BIGINT AS mate_position, 0::BIGINT AS template_length
-) TO '__TEST_DIR__/bad_reference.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
-----
-Column 'reference' must be VARCHAR, BIGINT, or UUID
-
-statement error
-COPY (SELECT
-    'r' AS read_id, 0::USMALLINT AS flags, 'r' AS reference, 1::BIGINT AS position,
-    1::BIGINT AS stop_position, 0::UTINYINT AS mapq, '*' AS cigar, 1::DOUBLE AS mate_reference,
-    0::BIGINT AS mate_position, 0::BIGINT AS template_length
-) TO '__TEST_DIR__/bad_mate.sam' (FORMAT SAM, REFERENCE_LENGTHS 'ref_dummy');
-----
-Column 'mate_reference' must be VARCHAR, BIGINT, or UUID

--- a/test/sql/search_sequences_bigint.test
+++ b/test/sql/search_sequences_bigint.test
@@ -1,0 +1,95 @@
+# name: test/sql/search_sequences_bigint.test
+# description: search_sequences_vsearch accepts BIGINT read_id; read_id mirrors query, target_id mirrors ref.
+# group: [sql]
+
+#   search has two independent id columns: read_id (the query label) mirrors the
+#   query table's read_id type, and target_id (a reference label) mirrors the
+#   reference table's read_id type. The two tables may differ in type — this test
+#   covers BIGINT/BIGINT and the asymmetric BIGINT-query/VARCHAR-ref case.
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+statement ok
+CREATE TABLE refs_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO refs_bigint VALUES
+    (100, 'ATCGATCGATCGATCGATCGATCG'),
+    (200, 'GGCCTTAAGGCCTTAAGGCCTTAA'),
+    (300, 'AAAAAAAACCCCCCCCGGGGGGGG');
+
+statement ok
+CREATE TABLE queries_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_bigint VALUES
+    (1, 'ATCGATCGATCGATCGATCGATCG'),
+    (2, 'GGCCTTAAGGCCTTAAGGCCTTAA');
+
+statement ok
+CREATE TABLE refs_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM refs_bigint;
+
+# Both ids round-trip; output types mirror their respective inputs.
+query IIRI
+SELECT read_id, target_id, identity, accepted
+FROM search_sequences_vsearch('queries_bigint', db:='refs_bigint', id:=0.97)
+ORDER BY read_id;
+----
+1	100	100.0	true
+2	200	100.0	true
+
+query TT
+SELECT typeof(read_id), typeof(target_id)
+FROM search_sequences_vsearch('queries_bigint', db:='refs_bigint', id:=0.97)
+LIMIT 1;
+----
+BIGINT	BIGINT
+
+# Mixed: BIGINT query, VARCHAR ref — output is asymmetric (read_id BIGINT,
+# target_id VARCHAR).
+query IT
+SELECT read_id, target_id
+FROM search_sequences_vsearch('queries_bigint', db:='refs_varchar', id:=0.97)
+ORDER BY read_id;
+----
+1	100
+2	200
+
+query TT
+SELECT typeof(read_id), typeof(target_id)
+FROM search_sequences_vsearch('queries_bigint', db:='refs_varchar', id:=0.97)
+LIMIT 1;
+----
+BIGINT	VARCHAR
+
+# Raw HUGEINT stays rejected on both the query and ref side.
+statement ok
+CREATE TABLE refs_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO refs_hugeint VALUES (1, 'ATCGATCGATCGATCGATCGATCG');
+
+statement error
+SELECT * FROM search_sequences_vsearch('queries_bigint', db:='refs_hugeint', id:=0.97);
+----
+must be VARCHAR, BIGINT, or UUID
+
+statement error
+SELECT * FROM search_sequences_vsearch('refs_hugeint', db:='refs_bigint', id:=0.97);
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- Cleanup ---
+statement ok
+DROP TABLE refs_bigint;
+
+statement ok
+DROP TABLE queries_bigint;
+
+statement ok
+DROP TABLE refs_varchar;
+
+statement ok
+DROP TABLE refs_hugeint;

--- a/test/sql/search_sequences_uuid.test
+++ b/test/sql/search_sequences_uuid.test
@@ -1,0 +1,79 @@
+# name: test/sql/search_sequences_uuid.test
+# description: search_sequences_vsearch accepts UUID read_id; read_id mirrors query, target_id mirrors ref.
+# group: [sql]
+
+#   UUID round-trips through the int128 carrier like BIGINT does through decimal.
+#   This covers UUID/UUID and the UUID-query/BIGINT-ref case, which exercises two
+#   distinct non-VARCHAR egress codecs in a single output chunk.
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+statement ok
+CREATE TABLE refs_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO refs_uuid VALUES
+    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'ATCGATCGATCGATCGATCGATCG'),
+    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'GGCCTTAAGGCCTTAAGGCCTTAA'),
+    ('cccccccc-cccc-cccc-cccc-cccccccccccc', 'AAAAAAAACCCCCCCCGGGGGGGG');
+
+statement ok
+CREATE TABLE queries_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO queries_uuid VALUES
+    ('11111111-1111-1111-1111-111111111111', 'ATCGATCGATCGATCGATCGATCG'),
+    ('22222222-2222-2222-2222-222222222222', 'GGCCTTAAGGCCTTAAGGCCTTAA');
+
+statement ok
+CREATE TABLE refs_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO refs_bigint VALUES
+    (100, 'ATCGATCGATCGATCGATCGATCG'),
+    (200, 'GGCCTTAAGGCCTTAAGGCCTTAA'),
+    (300, 'AAAAAAAACCCCCCCCGGGGGGGG');
+
+# Both ids round-trip; output types mirror their respective inputs.
+query TTRI
+SELECT read_id, target_id, identity, accepted
+FROM search_sequences_vsearch('queries_uuid', db:='refs_uuid', id:=0.97)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa	100.0	true
+22222222-2222-2222-2222-222222222222	bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb	100.0	true
+
+query TT
+SELECT typeof(read_id), typeof(target_id)
+FROM search_sequences_vsearch('queries_uuid', db:='refs_uuid', id:=0.97)
+LIMIT 1;
+----
+UUID	UUID
+
+# Mixed: UUID query, BIGINT ref — two distinct non-VARCHAR codecs in one chunk.
+query TI
+SELECT read_id, target_id
+FROM search_sequences_vsearch('queries_uuid', db:='refs_bigint', id:=0.97)
+ORDER BY read_id;
+----
+11111111-1111-1111-1111-111111111111	100
+22222222-2222-2222-2222-222222222222	200
+
+query TT
+SELECT typeof(read_id), typeof(target_id)
+FROM search_sequences_vsearch('queries_uuid', db:='refs_bigint', id:=0.97)
+LIMIT 1;
+----
+UUID	BIGINT
+
+# --- Cleanup ---
+statement ok
+DROP TABLE refs_uuid;
+
+statement ok
+DROP TABLE queries_uuid;
+
+statement ok
+DROP TABLE refs_bigint;

--- a/test/sql/uchime_denovo_bigint.test
+++ b/test/sql/uchime_denovo_bigint.test
@@ -1,0 +1,77 @@
+# name: test/sql/uchime_denovo_bigint.test
+# description: detect_chimera_uchime_denovo accepts a BIGINT id_col; all id columns mirror it.
+# group: [sql]
+
+#   denovo has a single id source (id_col), so read_id and the three parent
+#   columns all mirror that one type. Detection is label-agnostic, so the flags
+#   and resolved parents match the VARCHAR fixture; only the id type changes. The
+#   non-chimeric NULL parent mask must survive the typed egress, and the abundance
+#   (;size=) handling must not collide with a numeric id (count comes from a
+#   separate column).
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+# Map seq1->1 ... seq6->6; size parsed from the original ;size= header into a
+# separate column. seq4 is a chimera of seq1+seq2 (vsearch v2.30.5 ground truth).
+statement ok
+CREATE TABLE denovo_bigint AS
+SELECT
+    (CASE regexp_extract(read_id, '^([^;]+)', 1)
+       WHEN 'seq1' THEN 1 WHEN 'seq2' THEN 2 WHEN 'seq3' THEN 3
+       WHEN 'seq4' THEN 4 WHEN 'seq5' THEN 5 WHEN 'seq6' THEN 6 END)::BIGINT AS read_id,
+    sequence1,
+    CAST(regexp_extract(read_id, 'size=(\d+)', 1) AS INTEGER) AS size
+FROM read_fastx('data/uchime/denovo_input.fasta');
+
+# read_id and all three parent columns mirror the BIGINT id_col type.
+query TTTT
+SELECT typeof(read_id), typeof(parent_a_id), typeof(parent_b_id), typeof(closest_parent_id)
+FROM detect_chimera_uchime_denovo('denovo_bigint')
+LIMIT 1;
+----
+BIGINT	BIGINT	BIGINT	BIGINT
+
+# Detection unchanged: 6 rows, 2 chimeras.
+query II
+SELECT count(*), count(*) FILTER (WHERE flag = 'Y')
+FROM detect_chimera_uchime_denovo('denovo_bigint');
+----
+6	2
+
+# Chimeric seq (id 4): read_id round-trips and parents resolve to the BIGINT ids
+# of seq1/seq2 (1/2); closest_parent is populated (not the empty-label edge).
+query IIIT
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id IS NOT NULL
+FROM detect_chimera_uchime_denovo('denovo_bigint')
+WHERE read_id = 4;
+----
+4	1	2	true
+
+# Non-chimeric seq (id 1): NULL parent mask preserved under BIGINT egress.
+query IIII
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id
+FROM detect_chimera_uchime_denovo('denovo_bigint')
+WHERE read_id = 1;
+----
+1	NULL	NULL	NULL
+
+# Raw HUGEINT id_col stays rejected.
+statement ok
+CREATE TABLE denovo_hugeint (read_id HUGEINT, sequence1 VARCHAR, size INTEGER);
+
+statement ok
+INSERT INTO denovo_hugeint VALUES (1, 'ATCGATCGATCGATCGATCGATCG', 5);
+
+statement error
+SELECT * FROM detect_chimera_uchime_denovo('denovo_hugeint');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- Cleanup ---
+statement ok
+DROP TABLE denovo_bigint;
+
+statement ok
+DROP TABLE denovo_hugeint;

--- a/test/sql/uchime_denovo_uuid.test
+++ b/test/sql/uchime_denovo_uuid.test
@@ -1,0 +1,63 @@
+# name: test/sql/uchime_denovo_uuid.test
+# description: detect_chimera_uchime_denovo accepts a UUID id_col; all id columns mirror it.
+# group: [sql]
+
+#   UUID round-trips through the int128 carrier like BIGINT through decimal.
+#   Mirrors uchime_denovo_bigint: single id source, read_id and all three parent
+#   columns mirror the UUID type, the non-chimeric NULL parent mask survives the
+#   typed egress, and the resolved parents round-trip to the UUID seq ids.
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+# Map seq1 .. seq6 to distinct UUIDs (...0001 .. ...0006); seq4 is the chimera.
+statement ok
+CREATE TABLE denovo_uuid AS
+SELECT
+    (CASE regexp_extract(read_id, '^([^;]+)', 1)
+       WHEN 'seq1' THEN '00000000-0000-0000-0000-000000000001'
+       WHEN 'seq2' THEN '00000000-0000-0000-0000-000000000002'
+       WHEN 'seq3' THEN '00000000-0000-0000-0000-000000000003'
+       WHEN 'seq4' THEN '00000000-0000-0000-0000-000000000004'
+       WHEN 'seq5' THEN '00000000-0000-0000-0000-000000000005'
+       WHEN 'seq6' THEN '00000000-0000-0000-0000-000000000006' END)::UUID AS read_id,
+    sequence1,
+    CAST(regexp_extract(read_id, 'size=(\d+)', 1) AS INTEGER) AS size
+FROM read_fastx('data/uchime/denovo_input.fasta');
+
+# read_id and all three parent columns mirror the UUID id_col type.
+query TTTT
+SELECT typeof(read_id), typeof(parent_a_id), typeof(parent_b_id), typeof(closest_parent_id)
+FROM detect_chimera_uchime_denovo('denovo_uuid')
+LIMIT 1;
+----
+UUID	UUID	UUID	UUID
+
+# Detection unchanged: 6 rows, 2 chimeras.
+query II
+SELECT count(*), count(*) FILTER (WHERE flag = 'Y')
+FROM detect_chimera_uchime_denovo('denovo_uuid');
+----
+6	2
+
+# Chimeric seq (...0004): read_id round-trips and parents resolve to the UUID
+# ids of seq1/seq2; closest_parent is populated.
+query TTTT
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id IS NOT NULL
+FROM detect_chimera_uchime_denovo('denovo_uuid')
+WHERE read_id = '00000000-0000-0000-0000-000000000004';
+----
+00000000-0000-0000-0000-000000000004	00000000-0000-0000-0000-000000000001	00000000-0000-0000-0000-000000000002	true
+
+# Non-chimeric seq (...0001): NULL parent mask preserved under UUID egress.
+query TTTT
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id
+FROM detect_chimera_uchime_denovo('denovo_uuid')
+WHERE read_id = '00000000-0000-0000-0000-000000000001';
+----
+00000000-0000-0000-0000-000000000001	NULL	NULL	NULL
+
+# --- Cleanup ---
+statement ok
+DROP TABLE denovo_uuid;

--- a/test/sql/uchime_ref_bigint.test
+++ b/test/sql/uchime_ref_bigint.test
@@ -1,0 +1,117 @@
+# name: test/sql/uchime_ref_bigint.test
+# description: detect_chimera_uchime accepts BIGINT ids; read_id mirrors query, parents mirror ref.
+# group: [sql]
+
+#   detect_chimera_uchime has two id sources: read_id (the query label) mirrors
+#   the query table's id type, and the three parent columns (parent_a_id,
+#   parent_b_id, closest_parent_id — all reference labels) mirror the reference
+#   table's id type. Detection itself is label-agnostic, so the chimera flags and
+#   the resolved parents are identical to the VARCHAR fixture; only the id type
+#   changes. Crucially the non-chimeric NULL parent mask must survive the typed
+#   egress codec.
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+# Deterministic label->id maps so resolved parents round-trip to known values:
+# ref1->1, ref2->2, ...; query_chimera1->1101 (parents ref1/ref2 per the
+# vsearch v2.30.5 ground truth), query_clean1->1001 (non-chimeric).
+
+statement ok
+CREATE TABLE refs_varchar AS SELECT read_id, sequence1 FROM read_fastx('data/uchime/chimera_ref.fasta');
+
+statement ok
+CREATE TABLE refs_bigint AS
+SELECT (CASE read_id
+          WHEN 'ref1' THEN 1 WHEN 'ref2' THEN 2 WHEN 'ref3' THEN 3
+          WHEN 'ref4' THEN 4 WHEN 'ref5' THEN 5 WHEN 'ref6' THEN 6 END)::BIGINT AS read_id,
+       sequence1
+FROM refs_varchar;
+
+statement ok
+CREATE TABLE queries_bigint AS
+SELECT (CASE read_id
+          WHEN 'query_clean1' THEN 1001 WHEN 'query_clean2' THEN 1002
+          WHEN 'query_chimera1' THEN 1101 WHEN 'query_chimera2' THEN 1102
+          WHEN 'query_chimera3' THEN 1103 WHEN 'query_noparent' THEN 1201
+          WHEN 'query_divergent_chimera' THEN 1301 WHEN 'query_short' THEN 1401 END)::BIGINT AS read_id,
+       sequence1
+FROM read_fastx('data/uchime/chimera_queries.fasta');
+
+# read_id and all three parent columns mirror the BIGINT input type.
+query TTTT
+SELECT typeof(read_id), typeof(parent_a_id), typeof(parent_b_id), typeof(closest_parent_id)
+FROM detect_chimera_uchime('queries_bigint', db:='refs_bigint')
+LIMIT 1;
+----
+BIGINT	BIGINT	BIGINT	BIGINT
+
+# Detection is unchanged: 8 rows, 4 chimeras.
+query II
+SELECT count(*), count(*) FILTER (WHERE flag = 'Y')
+FROM detect_chimera_uchime('queries_bigint', db:='refs_bigint');
+----
+8	4
+
+# Chimeric query: read_id round-trips and parents resolve to the BIGINT ref ids
+# (ref1->1, ref2->2); closest_parent is populated.
+query IIIT
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id IS NOT NULL
+FROM detect_chimera_uchime('queries_bigint', db:='refs_bigint')
+WHERE read_id = 1101;
+----
+1101	1	2	true
+
+# Non-chimeric query: NULL parent mask preserved under BIGINT egress.
+query IIII
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id
+FROM detect_chimera_uchime('queries_bigint', db:='refs_bigint')
+WHERE read_id = 1001;
+----
+1001	NULL	NULL	NULL
+
+# Mixed: BIGINT query, VARCHAR ref — read_id BIGINT, parents VARCHAR.
+query ITT
+SELECT read_id, parent_a_id, parent_b_id
+FROM detect_chimera_uchime('queries_bigint', db:='refs_varchar')
+WHERE read_id = 1101;
+----
+1101	ref1	ref2
+
+query TTT
+SELECT typeof(read_id), typeof(parent_a_id), typeof(closest_parent_id)
+FROM detect_chimera_uchime('queries_bigint', db:='refs_varchar')
+LIMIT 1;
+----
+BIGINT	VARCHAR	VARCHAR
+
+# Raw HUGEINT stays rejected on both sides.
+statement ok
+CREATE TABLE refs_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO refs_hugeint VALUES (1, 'ATCGATCGATCGATCGATCGATCG');
+
+statement error
+SELECT * FROM detect_chimera_uchime('queries_bigint', db:='refs_hugeint');
+----
+must be VARCHAR, BIGINT, or UUID
+
+statement error
+SELECT * FROM detect_chimera_uchime('refs_hugeint', db:='refs_bigint');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- Cleanup ---
+statement ok
+DROP TABLE refs_varchar;
+
+statement ok
+DROP TABLE refs_bigint;
+
+statement ok
+DROP TABLE queries_bigint;
+
+statement ok
+DROP TABLE refs_hugeint;

--- a/test/sql/uchime_ref_uuid.test
+++ b/test/sql/uchime_ref_uuid.test
@@ -1,0 +1,104 @@
+# name: test/sql/uchime_ref_uuid.test
+# description: detect_chimera_uchime accepts UUID ids; read_id mirrors query, parents mirror ref.
+# group: [sql]
+
+#   UUID round-trips through the int128 carrier like BIGINT through decimal.
+#   Mirrors uchime_ref_bigint: read_id mirrors the query type, the three parent
+#   columns mirror the reference type, and the non-chimeric NULL parent mask
+#   survives the typed egress. Also covers the UUID-query / BIGINT-ref pairing,
+#   which drives two distinct non-VARCHAR codecs in one chunk.
+
+require miint
+
+require-env VSEARCH_AVAILABLE
+
+statement ok
+CREATE TABLE refs_uuid AS
+SELECT (CASE read_id
+          WHEN 'ref1' THEN '00000000-0000-0000-0000-000000000001'
+          WHEN 'ref2' THEN '00000000-0000-0000-0000-000000000002'
+          WHEN 'ref3' THEN '00000000-0000-0000-0000-000000000003'
+          WHEN 'ref4' THEN '00000000-0000-0000-0000-000000000004'
+          WHEN 'ref5' THEN '00000000-0000-0000-0000-000000000005'
+          WHEN 'ref6' THEN '00000000-0000-0000-0000-000000000006' END)::UUID AS read_id,
+       sequence1
+FROM read_fastx('data/uchime/chimera_ref.fasta');
+
+statement ok
+CREATE TABLE refs_bigint AS
+SELECT (CASE read_id
+          WHEN 'ref1' THEN 1 WHEN 'ref2' THEN 2 WHEN 'ref3' THEN 3
+          WHEN 'ref4' THEN 4 WHEN 'ref5' THEN 5 WHEN 'ref6' THEN 6 END)::BIGINT AS read_id,
+       sequence1
+FROM read_fastx('data/uchime/chimera_ref.fasta');
+
+statement ok
+CREATE TABLE queries_uuid AS
+SELECT (CASE read_id
+          WHEN 'query_clean1' THEN '00000000-0000-0000-0000-000000001001'
+          WHEN 'query_clean2' THEN '00000000-0000-0000-0000-000000001002'
+          WHEN 'query_chimera1' THEN '00000000-0000-0000-0000-000000001101'
+          WHEN 'query_chimera2' THEN '00000000-0000-0000-0000-000000001102'
+          WHEN 'query_chimera3' THEN '00000000-0000-0000-0000-000000001103'
+          WHEN 'query_noparent' THEN '00000000-0000-0000-0000-000000001201'
+          WHEN 'query_divergent_chimera' THEN '00000000-0000-0000-0000-000000001301'
+          WHEN 'query_short' THEN '00000000-0000-0000-0000-000000001401' END)::UUID AS read_id,
+       sequence1
+FROM read_fastx('data/uchime/chimera_queries.fasta');
+
+# read_id and all three parent columns mirror the UUID input type.
+query TTTT
+SELECT typeof(read_id), typeof(parent_a_id), typeof(parent_b_id), typeof(closest_parent_id)
+FROM detect_chimera_uchime('queries_uuid', db:='refs_uuid')
+LIMIT 1;
+----
+UUID	UUID	UUID	UUID
+
+# Detection unchanged: 8 rows, 4 chimeras.
+query II
+SELECT count(*), count(*) FILTER (WHERE flag = 'Y')
+FROM detect_chimera_uchime('queries_uuid', db:='refs_uuid');
+----
+8	4
+
+# Chimeric query: read_id round-trips and parents resolve to the UUID ref ids.
+query TTTT
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id IS NOT NULL
+FROM detect_chimera_uchime('queries_uuid', db:='refs_uuid')
+WHERE read_id = '00000000-0000-0000-0000-000000001101';
+----
+00000000-0000-0000-0000-000000001101	00000000-0000-0000-0000-000000000001	00000000-0000-0000-0000-000000000002	true
+
+# Non-chimeric query: NULL parent mask preserved under UUID egress.
+query TTTT
+SELECT read_id, parent_a_id, parent_b_id, closest_parent_id
+FROM detect_chimera_uchime('queries_uuid', db:='refs_uuid')
+WHERE read_id = '00000000-0000-0000-0000-000000001001';
+----
+00000000-0000-0000-0000-000000001001	NULL	NULL	NULL
+
+# Mixed: UUID query, BIGINT ref — read_id UUID, parents BIGINT (two non-VARCHAR
+# codecs in one chunk).
+query TII
+SELECT read_id, parent_a_id, parent_b_id
+FROM detect_chimera_uchime('queries_uuid', db:='refs_bigint')
+WHERE read_id = '00000000-0000-0000-0000-000000001101';
+----
+00000000-0000-0000-0000-000000001101	1	2
+
+query TTT
+SELECT typeof(read_id), typeof(parent_a_id), typeof(closest_parent_id)
+FROM detect_chimera_uchime('queries_uuid', db:='refs_bigint')
+LIMIT 1;
+----
+UUID	BIGINT	BIGINT
+
+# --- Cleanup ---
+statement ok
+DROP TABLE refs_uuid;
+
+statement ok
+DROP TABLE refs_bigint;
+
+statement ok
+DROP TABLE queries_uuid;


### PR DESCRIPTION
## Summary

Widens the identifier-column contract to **VARCHAR, BIGINT, or UUID**, end to end. Identifiers are carried internally as strings regardless of SQL type; UUID rides the existing carrier model as a third branch (stored physically as INT128, stringified to canonical lowercase on ingress, parsed back on egress — exactly as BIGINT round-trips through decimal). **Raw `HUGEINT` stays rejected**; only the logical `UUID` type is accepted.

### Part 1 — alignment family + COPY SAM/BAM (adds UUID to the BIGINT-capable functions)
`align_minimap2` (+sharded), `align_bowtie2` (+sharded), `align_sortmerna`, `align_sortmerna_rrna`, `save_minimap2_index`, and `COPY ... (FORMAT sam|bam)`.

- Converged the three divergent egress codecs onto one shared per-row primitive `EmitIdCell` (`src/include/id_column_utils.hpp`).
- Added `ParseUuidOrThrow` (the convenience `UUID::FromString` overload silently swallows parse errors) and a single-source `AllowedIdTypeList()` rejection message.
- Extended the SAM `=` mate-reference resolution to any non-VARCHAR subject (the literal `=` has no BIGINT/UUID encoding).

### Part 2 — vsearch suite + blast (adds BIGINT and UUID)
`cluster_sequences_vsearch`, `search_sequences_vsearch`, `detect_chimera_uchime`, `detect_chimera_uchime_denovo`, and `blast`.

- Capture id type(s) at bind, parameterize each `Get*OutputTypes(...)`, route every id-column emit through `EmitIdCell`.
- `read_id` mirrors the query type; `target_id` / uchime parent columns mirror the reference type **independently** (e.g. a UUID query against a BIGINT reference works).
- `blast`'s `subject_id` stays VARCHAR (an NCBI accession, not a user-table id).
- uchime parent columns preserve their non-chimeric NULL mask under the typed egress.
- `ValidateDenovoTableSchema` now shares the id-type check + message with `ValidateSequenceTableSchema`.

## Test plan

- New `*_uuid` / `*_bigint` SQL tests per function: round-trip, `typeof()` mirroring, mixed-type pairings (incl. the UUID-query / BIGINT-ref two-codec case), NULL handling, uppercase→canonical-lowercase, UUIDv7, and the load-bearing **HUGEINT-still-rejected** guard.
- C++ `[id_codec]` unit suite stays BIGINT-only (pure codec, no DuckDB UUID dependency).
- `blast_live.test` gains BIGINT/UUID `query_id` round-trip cases — **verified live against NCBI** (BIGINT `42` and a UUID both echoed by NCBI's defline and parsed back; `subject_id` VARCHAR; 100% identity hits).
- Full VARCHAR + `sample_id` + `realworld` + `column_overrides` regressions green; `clang-format` 11.0.1 clean.

> bowtie2/sortmerna runtime tests are env-gated and skip on the dev box (no gpl-boundary v3 / sortmerna binary); they mirror the `_bigint` equivalents and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
