### PR TITLE
perf(read_sequences_sam): ~9x faster BAM reads (BGZF threads + direct-to-vector decode)

### DIFF
--- a/src/SAMReader.cpp
+++ b/src/SAMReader.cpp
@@ -207,6 +207,13 @@ void SAMReader::set_threads(int n) {
 	}
 }
 
+const bam1_t *SAMReader::read_raw() {
+	if (sam_read1(fp.get(), hdr.get(), aln.get()) >= 0) {
+		return aln.get();
+	}
+	return nullptr;
+}
+
 SAMRecordBatch SAMReader::read(const int n) {
 	SAMRecordBatch batch;
 	batch.reserve(n);

--- a/src/SAMReader.cpp
+++ b/src/SAMReader.cpp
@@ -198,6 +198,15 @@ SAMReader::SAMReader(int fd, const std::string &name, bool include_seq_qual)
 }
 #endif
 
+void SAMReader::set_threads(int n) {
+	if (n > 1 && fp) {
+		// Adds an HTSlib worker pool that decompresses BGZF blocks ahead of the parser.
+		// Blocks are still delivered in order, so read() output is unchanged. No-op for
+		// uncompressed SAM (nothing to decompress).
+		hts_set_threads(fp.get(), n);
+	}
+}
+
 SAMRecordBatch SAMReader::read(const int n) {
 	SAMRecordBatch batch;
 	batch.reserve(n);

--- a/src/include/QualScore.hpp
+++ b/src/include/QualScore.hpp
@@ -5,6 +5,7 @@
 #include <span>
 #include <stdexcept>
 #include <cstdint>
+#include <utility>
 
 namespace miint {
 //! Object to represent Qual store data independent of offset
@@ -16,6 +17,10 @@ private:
 public:
 	//! Constructor from string: store as-is
 	explicit QualScore(const std::string &qual_str) noexcept : qual_(qual_str) {
+	}
+
+	//! Constructor from string rvalue: take ownership without copying
+	explicit QualScore(std::string &&qual_str) noexcept : qual_(std::move(qual_str)) {
 	}
 
 	//! Constructor from uint8 vector: interpret as quality scores, convert to characters

--- a/src/include/SAMReader.hpp
+++ b/src/include/SAMReader.hpp
@@ -75,6 +75,12 @@ public:
 	// Read up to n records into a batch
 	SAMRecordBatch read(const int n);
 
+	// Enable multi-threaded BGZF block decompression for this reader (n worker threads).
+	// Must be called before the first read(). No-op if n <= 1 or on uncompressed input.
+	// HTSlib decodes blocks in order, so results are identical to the single-threaded
+	// path -- just faster on BGZF-compressed (BAM / bgzipped SAM) input.
+	void set_threads(int n);
+
 	// Number of reference sequences in the header (@SQ lines).
 	// Returns 0 if no references (headerless/uBAM without synthetic header).
 	int n_targets() const {

--- a/src/include/SAMReader.hpp
+++ b/src/include/SAMReader.hpp
@@ -75,6 +75,12 @@ public:
 	// Read up to n records into a batch
 	SAMRecordBatch read(const int n);
 
+	// Read the next raw record into the reader's internal buffer. Returns a pointer to it
+	// (valid only until the next read_raw()/read() call) or nullptr at end of file. For
+	// consumers that decode fields directly into their own output instead of via the
+	// SAMRecordBatch SOA. Does not allocate. Shares the same fp/aln as read().
+	const bam1_t *read_raw();
+
 	// Enable multi-threaded BGZF block decompression for this reader (n worker threads).
 	// Must be called before the first read(). No-op if n <= 1 or on uncompressed input.
 	// HTSlib decodes blocks in order, so results are identical to the single-threaded

--- a/src/include/SAMRecord.hpp
+++ b/src/include/SAMRecord.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <utility>
 #include <htslib-1.22.1/htslib/sam.h>
 #include "QualScore.hpp"
 
@@ -387,8 +388,8 @@ inline void parse_record_to_batch(const bam1_t *aln, const sam_hdr_t *hdr, SAMRe
 			}
 		}
 
-		batch.sequences.emplace_back(sequence);
-		batch.quals.emplace_back(QualScore(qual_str));
+		batch.sequences.emplace_back(std::move(sequence));
+		batch.quals.emplace_back(QualScore(std::move(qual_str)));
 	}
 }
 } // namespace sam_utils

--- a/src/include/read_sequences_sam.hpp
+++ b/src/include/read_sequences_sam.hpp
@@ -77,6 +77,19 @@ public:
 				}
 				file_sequence_counters.emplace_back(1);
 			}
+
+			// Multi-threaded BGZF decompression, but ONLY for a single input file.
+			// With one file, MaxThreads() == 1 so the scan runs on one core while the
+			// rest sit idle; an HTSlib worker pool decompresses blocks ahead of the parser
+			// (blocks stay in order, so output is identical). With multiple files we rely
+			// on file-level parallelism instead -- giving every reader its own pool would
+			// oversubscribe (up to min(files, 8) readers run concurrently, each spawning a
+			// pool), so we deliberately leave the multi-file path single-threaded per file.
+			if (readers.size() == 1 && !uses_stdin) {
+				auto hw = std::thread::hardware_concurrency();
+				int decompress_threads = (hw > 1) ? std::min<int>(static_cast<int>(hw) - 1, 4) : 1;
+				readers[0]->set_threads(decompress_threads);
+			}
 		}
 	};
 

--- a/src/include/read_sequences_sam.hpp
+++ b/src/include/read_sequences_sam.hpp
@@ -96,6 +96,9 @@ public:
 	struct LocalState : public LocalTableFunctionState {
 		size_t current_file_idx;
 		bool has_file;
+		// Reused across Execute calls to accumulate one chunk's raw quality bytes before a
+		// single bulk copy into the qual1 LIST child (avoids per-record heap allocation).
+		std::vector<uint8_t> qual_scratch;
 
 		LocalState() : current_file_idx(0), has_file(false) {
 		}

--- a/src/read_sequences_sam.cpp
+++ b/src/read_sequences_sam.cpp
@@ -6,6 +6,8 @@
 #include "duckdb/common/vector_size.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include <read_sequences_sam.hpp>
+#include <cstring>
+#include <stdexcept>
 
 namespace duckdb {
 
@@ -87,56 +89,25 @@ unique_ptr<LocalTableFunctionState> ReadSequencesSamTableFunction::InitLocal(Exe
 	return duckdb::make_uniq<LocalState>();
 }
 
-// Per-record nullable quality scores: BAM records may individually have or lack quality
-static void SetResultVectorListUInt8PerRecordNullable(Vector &result_vector,
-                                                      const std::vector<miint::QualScore> &values) {
-	constexpr uint8_t PHRED33_OFFSET = 33;
-
-	auto &validity = FlatVector::Validity(result_vector);
-	auto list_entries = FlatVector::GetData<list_entry_t>(result_vector);
-
-	idx_t total_child_elements = 0;
-	for (auto &qual : values) {
-		total_child_elements += qual.size();
-	}
-
-	ListVector::Reserve(result_vector, total_child_elements);
-	ListVector::SetListSize(result_vector, total_child_elements);
-
-	auto &child_vector = ListVector::GetEntry(result_vector);
-	auto child_data = FlatVector::GetData<uint8_t>(child_vector);
-
-	const auto output_count = values.size();
-	validity.SetAllValid(output_count);
-	idx_t value_offset = 0;
-	for (idx_t row_offset = 0; row_offset < output_count; row_offset++) {
-		auto len = values[row_offset].size();
-		if (len == 0) {
-			list_entries[row_offset].offset = value_offset;
-			list_entries[row_offset].length = 0;
-			validity.SetInvalid(row_offset);
-		} else {
-			list_entries[row_offset].offset = value_offset;
-			list_entries[row_offset].length = len;
-
-			values[row_offset].write_decoded(child_data + value_offset, PHRED33_OFFSET);
-			value_offset += len;
-		}
-	}
-
-	auto &child_validity = FlatVector::Validity(child_vector);
-	child_validity.SetAllValid(total_child_elements);
-}
-
 void ReadSequencesSamTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &bind_data = data_p.bind_data->Cast<Data>();
 	auto &global_state = data_p.global_state->Cast<GlobalState>();
 	auto &local_state = data_p.local_state->Cast<LocalState>();
 
-	miint::SAMRecordBatch batch;
-	std::string current_filepath;
+	// Output schema (fixed): 0=sequence_index 1=read_id 2=comment 3=sequence1 4=sequence2
+	// 5=qual1 6=qual2 [7=filepath]. read_id / sequence1 / qual1 are decoded straight from
+	// the raw bam1_t into these vectors -- no intermediate std::string, no SAMRecordBatch
+	// SOA, and none of the alignment metadata read_sequences_sam discards.
+	auto read_id_data = FlatVector::GetData<string_t>(output.data[1]);
+	auto sequence1_data = FlatVector::GetData<string_t>(output.data[3]);
+	auto &qual1_vector = output.data[5];
+	auto qual1_entries = FlatVector::GetData<list_entry_t>(qual1_vector);
+	auto &qual_scratch = local_state.qual_scratch;
 
-	// Loop until we get data or run out of files
+	std::string current_filepath;
+	idx_t count = 0;
+
+	// Loop until we decode at least one record or run out of files.
 	while (true) {
 		// If this thread doesn't have a file, claim one
 		if (!local_state.has_file) {
@@ -152,53 +123,99 @@ void ReadSequencesSamTableFunction::Execute(ClientContext &context, TableFunctio
 			local_state.has_file = true;
 		}
 
-		batch = global_state.readers[local_state.current_file_idx]->read(STANDARD_VECTOR_SIZE);
+		auto &reader = *global_state.readers[local_state.current_file_idx];
 		current_filepath = global_state.filepaths[local_state.current_file_idx];
 
-		if (batch.empty()) {
+		qual_scratch.clear();
+		count = 0;
+		while (count < STANDARD_VECTOR_SIZE) {
+			const bam1_t *aln = reader.read_raw();
+			if (!aln) {
+				break; // end of this file
+			}
+
+			const int seq_len = aln->core.l_qseq;
+
+			// Primary/unmapped reads must carry sequence (matches parse_record_to_batch).
+			const bool is_unmapped = (aln->core.flag & 0x4) != 0;
+			const bool is_secondary = (aln->core.flag & 0x100) != 0;
+			const bool is_supplementary = (aln->core.flag & 0x800) != 0;
+			if (seq_len == 0 && (is_unmapped || (!is_secondary && !is_supplementary))) {
+				throw std::runtime_error("Primary/unmapped read missing sequence (SEQ='*'): " +
+				                         std::string(reinterpret_cast<const char *>(aln->data)));
+			}
+
+			// read_id: copy QNAME once into the vector's string heap.
+			read_id_data[count] = StringVector::AddString(output.data[1], reinterpret_cast<const char *>(aln->data));
+
+			// sequence1: decode 4-bit nucleotides straight into the vector buffer (one pass).
+			string_t seq_str = StringVector::EmptyString(output.data[3], seq_len);
+			char *seq_dest = seq_str.GetDataWriteable();
+			const uint8_t *seq = bam_get_seq(aln);
+			for (int i = 0; i < seq_len; i++) {
+				seq_dest[i] = seq_nt16_str[bam_seqi(seq, i)];
+			}
+			seq_str.Finalize();
+			sequence1_data[count] = seq_str;
+
+			// qual1: raw Phred scores copied straight across (no +33/-33 round trip).
+			// Absent quality (first byte 0xFF) or empty sequence -> NULL list.
+			const uint8_t *qual = bam_get_qual(aln);
+			qual1_entries[count].offset = qual_scratch.size();
+			if (seq_len > 0 && qual[0] != 0xFF) {
+				qual_scratch.insert(qual_scratch.end(), qual, qual + seq_len);
+				qual1_entries[count].length = static_cast<uint64_t>(seq_len);
+			} else {
+				qual1_entries[count].length = 0;
+			}
+
+			count++;
+		}
+
+		if (count == 0) {
+			// File exhausted before producing any record; release and try the next.
 			local_state.has_file = false;
 			continue;
 		}
-
 		break;
 	}
 
-	// Get sequence indices for this chunk
-	uint64_t start_sequence_index = global_state.file_sequence_counters[local_state.current_file_idx];
-	global_state.file_sequence_counters[local_state.current_file_idx] += batch.size();
+	// Finalize qual1 child with a single bulk copy of the accumulated raw Phred bytes.
+	ListVector::Reserve(qual1_vector, qual_scratch.size());
+	ListVector::SetListSize(qual1_vector, qual_scratch.size());
+	if (!qual_scratch.empty()) {
+		auto &qual_child = ListVector::GetEntry(qual1_vector);
+		auto qual_child_data = FlatVector::GetData<uint8_t>(qual_child);
+		std::memcpy(qual_child_data, qual_scratch.data(), qual_scratch.size());
+		FlatVector::Validity(qual_child).SetAllValid(qual_scratch.size());
+	}
+	// Per-row qual1 nullability: zero-length entries (absent quality) are NULL.
+	auto &qual1_validity = FlatVector::Validity(qual1_vector);
+	qual1_validity.SetAllValid(count);
+	for (idx_t j = 0; j < count; j++) {
+		if (qual1_entries[j].length == 0) {
+			qual1_validity.SetInvalid(j);
+		}
+	}
 
-	// Set sequence_index column
-	auto &sequence_index_vector = output.data[0];
-	auto sequence_index_data = FlatVector::GetData<int64_t>(sequence_index_vector);
-	for (idx_t j = 0; j < batch.size(); j++) {
+	// sequence_index: per-file monotonic counter.
+	uint64_t start_sequence_index = global_state.file_sequence_counters[local_state.current_file_idx];
+	global_state.file_sequence_counters[local_state.current_file_idx] += count;
+	auto sequence_index_data = FlatVector::GetData<int64_t>(output.data[0]);
+	for (idx_t j = 0; j < count; j++) {
 		sequence_index_data[j] = static_cast<int64_t>(start_sequence_index + j);
 	}
 
-	size_t field_idx = 1;
-
-	// read_id from BAM QNAME
-	SetResultVectorString(output.data[field_idx++], batch.read_ids);
-
-	// comment: always NULL (BAM has no comment field)
-	SetResultVectorNull(output.data[field_idx++]);
-
-	// sequence1 from BAM SEQ
-	SetResultVectorString(output.data[field_idx++], batch.sequences);
-
-	// sequence2: always NULL (single-end)
-	SetResultVectorNull(output.data[field_idx++]);
-
-	// qual1 from BAM QUAL (per-record nullability)
-	SetResultVectorListUInt8PerRecordNullable(output.data[field_idx++], batch.quals);
-
-	// qual2: always NULL
-	SetResultVectorNull(output.data[field_idx++]);
+	// Constant-NULL columns: comment, sequence2, qual2 (single-end BAM, no comment field).
+	SetResultVectorNull(output.data[2]);
+	SetResultVectorNull(output.data[4]);
+	SetResultVectorNull(output.data[6]);
 
 	if (bind_data.include_filepath) {
-		SetResultVectorFilepath(output.data[field_idx++], current_filepath);
+		SetResultVectorFilepath(output.data[7], current_filepath);
 	}
 
-	output.SetCardinality(batch.size());
+	output.SetCardinality(count);
 }
 
 TableFunction ReadSequencesSamTableFunction::GetFunction() {


### PR DESCRIPTION
## Summary

Two surgical performance changes to `read_sequences_sam`. On a 9.1 GB long-read BAM (2.46M reads, 27.4 Gbp) the full read goes from **209s → 23.3s (~9x)**, with **byte-identical output** (verified by order-independent content hashes of `read_id`/`sequence1`/`qual1`).

Branches off `v1.5-variegata`.

## Background

A single-file BAM read ran fully single-threaded (`MaxThreads()==1` for one file) while the other cores sat idle, and the hot path went through the shared `SAMReader::read() → parse_record_to_batch() → SAMRecordBatch` SOA — which for every record also built the CIGAR string (via `ostringstream`), did 11 `bam_aux_get` tag lookups, reference/mate-reference name lookups, etc. (all discarded by `read_sequences_sam`), and copied each decoded sequence/quality string twice. That per-record allocation storm (~9 heap allocs/record) also throttled BGZF decompression via allocator/memory-bandwidth contention.

## Changes

**1. Multithreaded BGZF decompression (`efa933e`)**
- `SAMReader::set_threads(n)` attaches an HTSlib BGZF worker pool (same `hts_set_threads` call `copy_sam.cpp` already uses for writes; blocks stay in order → identical output).
- Enabled **only for a single input file** (capped at `min(hw-1, 4)`). Multi-file / `list[varchar]` reads keep relying on file-level parallelism — giving every reader a pool would oversubscribe.
- `parse_record_to_batch` now `std::move`s the decoded strings into the batch; `QualScore` gains a move ctor.
- Result: 209s → 138s.

**2. Direct-to-vector decode (`c7301d1`)**
- `SAMReader::read_raw()` returns the next raw `bam1_t` (additive — `read()`, `parse_record_to_batch`, `SAMRecordBatch`, and `read_alignments` are untouched).
- `Execute()` decodes QNAME/SEQ/QUAL straight from `bam1_t` into the output vectors: sequence via `StringVector::EmptyString` (one pass, no `std::string`), quality as raw Phred through a reused scratch buffer + one bulk `memcpy` into the LIST child (no +33/-33, no per-record allocation), `read_id` via a single `AddString`. All discarded alignment metadata is simply never computed.
- Result: 138s → 23.3s.

For reference, `samtools fastq -@4` (same htslib, equivalent name+seq+qual extraction) is 109s — we're faster end-to-end because we land typed columns instead of serializing ~60 GB of FASTQ text.

## Verification
- Output **byte-identical** pre/post: row count, total bp, and sum+xor hashes of `read_id`/`sequence1`/`qual1` all match the pre-change baseline.
- `read_sequences_sam.test` (190), `read_alignments.test` (141 — shared path intact), `QualScore` (47), `SAMReader` (144) all pass.
- `make format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)