### PR TITLE
fix(gpl-boundary): drain daemon stderr per batch to prevent pipe deadlock

### DIFF
--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -2106,7 +2106,7 @@ Bowtie2 runs out of process via the `gpl-boundary` daemon (an Apache-licensed pr
   - `true`: Local alignment (soft-clipping allowed at ends)
 - `threads` (INTEGER, default: 1): Number of threads for Bowtie2 alignment (daemon `nthreads`)
 - `max_secondary` (INTEGER, default: 1): Maximum alignments to report per query (`-k`)
-- `quiet` (BOOLEAN, default: true): Suppress Bowtie2 stderr output (alignment statistics)
+- `quiet` (BOOLEAN, default: true): Runs Bowtie2 with `--quiet`. Keep the default. miint never surfaces Bowtie2's stderr alignment statistics to SQL, so `quiet := false` has **no user-visible effect** — it only makes the daemon emit per-batch summaries that miint immediately drains and discards, adding overhead for no benefit.
 
 The full bowtie2-align typed parameter set is also exposed (one-to-one with the daemon's `--describe`; integer ranges enforced at bind time):
 
@@ -2260,7 +2260,7 @@ The sharded path emits only mapped reads (the daemon is invoked with `--no-unal`
 - `max_secondary` (INTEGER, default: 1): Maximum alignments to report per query (`-k`)
 - `max_threads_per_shard` (INTEGER, default: 4, range 1–64): bowtie2's internal `nthreads` for each per-shard daemon worker
 - `include_shard_name` (BOOLEAN, default: false): When true, append a `shard_name` column to the output
-- `quiet` (BOOLEAN, default: true): Suppress Bowtie2 stderr output
+- `quiet` (BOOLEAN, default: true): Runs Bowtie2 with `--quiet`. Keep the default — miint never surfaces Bowtie2's stderr statistics to SQL, so `quiet := false` has no user-visible effect and only adds overhead (per-batch summaries that miint drains and discards).
 - `threads` (INTEGER): Ignored in sharded mode. Use DuckDB's `SET threads=N` to control cross-shard parallelism and `max_threads_per_shard` for per-shard bowtie2 threading. A warning is printed at bind if `threads != 1` is passed directly to this function.
 
 The full bowtie2-align typed parameter set listed under [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) above is also available here (same names, same bind-time validation): `seed`, `trim5`, `trim3`, `match_bonus`, `mismatch_penalty`, `mismatch_penalty_min`, `n_penalty`, `read_gap_open`, `read_gap_extend`, `ref_gap_open`, `ref_gap_extend`, `score_min`, `min_insert`, `max_insert`, `mate_orientation`, `no_mixed`, `no_discordant`, `dovetail`, `no_contain`, `no_overlap`, `nofw`, `norc`, `seed_mismatches`, `seed_length`, `max_dp_failures`, `max_seed_rounds`, `report_all`, `xeq`, `rg_id`, `ignore_quals`, `reorder`.

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -158,7 +158,10 @@ void AppendBowtie2AlignParams(ConfigJsonBuilder &cfg, const named_parameter_map_
 		cfg.append_int("k", n);
 	}
 
-	// 3. quiet (miint default true) inverts to daemon verbose=false.
+	// 3. quiet (miint default true) inverts to daemon verbose=false. Note that
+	//    quiet=false has no user-visible effect: the daemon's verbose stderr is
+	//    drained and discarded by Session::PumpStderr (never surfaced to SQL).
+	//    It only adds overhead — see the `quiet` param docs in table-functions.md.
 	bool quiet = true;
 	if (auto *v = get("quiet")) {
 		quiet = ValueAsBool(caller, "quiet", *v);

--- a/src/gpl_boundary/session.cpp
+++ b/src/gpl_boundary/session.cpp
@@ -48,38 +48,40 @@ YyjsonDocPtr make_doc(yj::yyjson_doc *p) {
 	return YyjsonDocPtr(p, &yj::yyjson_doc_free);
 }
 
-// Cap on how much daemon stderr we splice into a thrown exception. Big enough
-// to carry a typical bowtie2 assertion or stack trace, small enough not to
-// pollute SQL error displays. Excess is truncated from the front (we want the
-// tail — that's where the failing-batch output lives).
+// Cap on how much daemon stderr we retain (and splice into a thrown
+// exception). Big enough to carry a typical bowtie2 assertion or stack trace,
+// small enough not to pollute SQL error displays. Excess is truncated from the
+// front (we want the tail — that's where the failing-batch output lives).
 constexpr std::size_t kStderrTailCap = 4096;
 
-// Non-blocking drain of an fd. Used on the failure path to grab whatever the
-// daemon (and its worker subprocesses, if the daemon forwards their stderr)
-// has written so far. MUST be non-blocking — the daemon is typically still
-// alive at this point, so the pipe has no EOF and a blocking read would hang.
+// Non-blocking drain of an fd, appending everything currently available to
+// `sink`. Used per-batch (Session::PumpStderr — keeps the daemon's stderr pipe
+// from filling, which would wedge the daemon on a blocked write while we wait
+// for its batch response) and on the failure paths (to grab the daemon's last
+// words). MUST be non-blocking — the daemon is typically still alive, so the
+// pipe has no EOF and a blocking read would hang.
 //
 // Restores the original O_NONBLOCK state on exit so other readers (none today,
-// but defensive) aren't surprised.
-std::string DrainStderrNonblocking(int fd) {
+// but defensive) aren't surprised. Truncation is the caller's job (see
+// TruncateHead) so the rolling buffer is only trimmed once after appending.
+void AppendAvailableStderr(int fd, std::string &sink) {
 	if (fd < 0) {
-		return {};
+		return;
 	}
 	const int orig_flags = ::fcntl(fd, F_GETFL, 0);
 	if (orig_flags < 0) {
-		return {};
+		return;
 	}
 	if (!(orig_flags & O_NONBLOCK)) {
 		if (::fcntl(fd, F_SETFL, orig_flags | O_NONBLOCK) < 0) {
-			return {};
+			return;
 		}
 	}
-	std::string out;
 	std::array<char, 4096> buf {};
 	for (;;) {
 		ssize_t n = ::read(fd, buf.data(), buf.size());
 		if (n > 0) {
-			out.append(buf.data(), static_cast<size_t>(n));
+			sink.append(buf.data(), static_cast<size_t>(n));
 			continue;
 		}
 		// n == 0 (EOF) or -1 (EAGAIN/EWOULDBLOCK/other): stop draining.
@@ -88,10 +90,15 @@ std::string DrainStderrNonblocking(int fd) {
 	if (!(orig_flags & O_NONBLOCK)) {
 		(void)::fcntl(fd, F_SETFL, orig_flags); // best effort restore
 	}
-	if (out.size() > kStderrTailCap) {
-		out = "...(truncated head)...\n" + out.substr(out.size() - kStderrTailCap);
+}
+
+// Trim `s` from the front to at most `cap` bytes, prefixing a marker so the
+// reader knows output was dropped. Keeps the tail — that's where the
+// failing-batch output lives.
+void TruncateHead(std::string &s, std::size_t cap) {
+	if (s.size() > cap) {
+		s = "...(truncated head)...\n" + s.substr(s.size() - cap);
 	}
-	return out;
 }
 
 // Compose a "why did the daemon vanish" suffix for Submit's failure paths.
@@ -101,10 +108,13 @@ std::string DrainStderrNonblocking(int fd) {
 // splices the daemon's stderr tail. Without this the EPIPE path throws a bare
 // "Broken pipe" and the EOF path a bare "closed stdout", neither of which tells
 // the operator what actually happened. Reap first so the stderr pipe has hit
-// EOF and DrainStderrNonblocking captures everything the daemon last wrote.
-std::string DaemonDeathSuffix(ChildProcess &child) {
+// EOF and AppendAvailableStderr captures everything the daemon last wrote;
+// `stderr_tail` is the session's rolling buffer (already holding the prior
+// batches' output) so the dropped-head marker is applied once after appending.
+std::string DaemonDeathSuffix(ChildProcess &child, std::string &stderr_tail) {
 	std::string suffix = " [daemon " + child.ReapAndDescribe() + "]";
-	const std::string stderr_tail = DrainStderrNonblocking(child.stderr_fd());
+	AppendAvailableStderr(child.stderr_fd(), stderr_tail);
+	TruncateHead(stderr_tail, kStderrTailCap);
 	if (!stderr_tail.empty()) {
 		suffix += "\n--- daemon stderr ---\n" + stderr_tail;
 	}
@@ -195,7 +205,7 @@ Session::~Session() {
 
 Session::Session(Session &&other) noexcept
     : child_(std::move(other.child_)), reader_(std::move(other.reader_)), tools_(std::move(other.tools_)),
-      initialized_(other.initialized_), shut_down_(other.shut_down_) {
+      initialized_(other.initialized_), shut_down_(other.shut_down_), stderr_tail_(std::move(other.stderr_tail_)) {
 	other.initialized_ = false;
 	other.shut_down_ = true;
 }
@@ -206,6 +216,11 @@ Session &Session::operator=(Session &&other) noexcept {
 		new (this) Session(std::move(other));
 	}
 	return *this;
+}
+
+void Session::PumpStderr() {
+	AppendAvailableStderr(child_.stderr_fd(), stderr_tail_);
+	TruncateHead(stderr_tail_, kStderrTailCap);
 }
 
 void Session::Initialize() {
@@ -391,7 +406,7 @@ SubmitResult Session::Submit(const std::string &tool, const std::string &config_
 		// EPIPE here means the daemon's stdin read-end is gone — it died before
 		// we finished handing off this batch. Enrich the bare "Broken pipe" with
 		// how it died + its stderr so the cause is actionable.
-		throw std::runtime_error(std::string(e.what()) + DaemonDeathSuffix(child_));
+		throw std::runtime_error(std::string(e.what()) + DaemonDeathSuffix(child_, stderr_tail_));
 	}
 	++next_batch_id_;
 
@@ -402,8 +417,16 @@ SubmitResult Session::Submit(const std::string &tool, const std::string &config_
 		// it died between read and write. Same enrichment as the EPIPE path.
 		throw std::runtime_error("gpl_boundary: daemon closed stdout while waiting "
 		                         "for batch response" +
-		                         DaemonDeathSuffix(child_));
+		                         DaemonDeathSuffix(child_, stderr_tail_));
 	}
+
+	// Drain the daemon's stderr now that this batch is answered. Verbose tools
+	// (e.g. bowtie2 with quiet=false) print a per-invocation summary to stderr;
+	// undrained across many batches that fills the OS pipe buffer and wedges the
+	// daemon on a blocked write while we block in the ReadLine above. Draining
+	// every batch keeps the pipe near-empty so it can never back up. Cheap
+	// no-op when the tool is quiet.
+	PumpStderr();
 
 	// 4. Parse response.
 	auto doc = make_doc(yj::yyjson_read(reply.data(), reply.size(), 0));
@@ -417,18 +440,18 @@ SubmitResult Session::Submit(const std::string &tool, const std::string &config_
 	yj::yyjson_val *success = yj::yyjson_obj_get(root, "success");
 	if (!success || !yj::yyjson_is_true(success)) {
 		const std::string err = get_str(root, "error");
-		// Drain whatever the daemon (and forwarded worker output) printed to
-		// stderr before / during the failure. Non-blocking so we don't hang
-		// when the daemon is still alive (the pipe will never EOF). The
-		// daemon's own error JSON often says only "subprocess exited
-		// unexpectedly"; the actual segfault / assertion / OOM message is in
-		// the stderr stream we'd otherwise discard.
-		const std::string stderr_tail = DrainStderrNonblocking(child_.stderr_fd());
+		// Fold any final stderr into the rolling tail. The per-batch PumpStderr
+		// above already captured this batch's output; this catches bytes the
+		// daemon wrote between that drain and the failure. The daemon's own
+		// error JSON often says only "subprocess exited unexpectedly"; the
+		// actual segfault / assertion / OOM message is in the stderr stream we'd
+		// otherwise discard.
+		PumpStderr();
 		std::string msg = "gpl_boundary: batch failed (batch_id=" + std::to_string(batch_id) + "): ";
 		msg += (err.empty() ? std::string("(no error message): ") + reply : err);
-		if (!stderr_tail.empty()) {
+		if (!stderr_tail_.empty()) {
 			msg += "\n--- daemon stderr ---\n";
-			msg += stderr_tail;
+			msg += stderr_tail_;
 		}
 		throw std::runtime_error(msg);
 	}

--- a/src/gpl_boundary/shm.cpp
+++ b/src/gpl_boundary/shm.cpp
@@ -1,6 +1,7 @@
 #include "gpl_boundary/shm.hpp"
 
 #include <atomic>
+#include <cerrno>
 #include <cstring>
 #include <fcntl.h>
 #include <stdexcept>
@@ -32,6 +33,15 @@ std::string make_input_name() {
 	return name;
 }
 
+// Actionable suffix for shm-allocation failures that smell like a full or
+// cluttered /dev/shm. Segments leak when a miint or gpl-boundary process is
+// SIGKILL'd (no destructor runs) and pile up as /dev/shm/miint-* files; on a
+// shared HPC node that surfaces here as ENOSPC or as exhausted EEXIST retries.
+std::string ShmCleanupHint() {
+	return " /dev/shm may be full or holding stale segments from a previously killed miint process. If no other "
+	       "miint query is running, clear them with:  rm -f /dev/shm/miint-*";
+}
+
 } // namespace
 
 // =============================================================================
@@ -59,20 +69,28 @@ InputShmRegion InputShmRegion::Create(std::size_t size_bytes) {
 		if (fd >= 0) {
 			break;
 		}
-		if (errno != EEXIST) {
-			throw std::runtime_error("gpl_boundary: shm_open(" + name + ") failed: " + std::string(::strerror(errno)));
+		const int e = errno;
+		if (e != EEXIST) {
+			std::string msg = "gpl_boundary: shm_open(" + name + ") failed: " + std::string(::strerror(e));
+			if (e == ENOSPC) {
+				msg += ShmCleanupHint();
+			}
+			throw std::runtime_error(msg);
 		}
 		// EEXIST: a stale segment is squatting on this name. Re-roll.
 	}
 	if (fd < 0) {
-		throw std::runtime_error("gpl_boundary: shm_open exhausted retries on EEXIST — /dev/shm/ may "
-		                         "be full of stale miint segments. Manual cleanup required.");
+		throw std::runtime_error("gpl_boundary: shm_open exhausted 64 EEXIST retries." + ShmCleanupHint());
 	}
 	if (::ftruncate(fd, static_cast<off_t>(size_bytes)) != 0) {
 		const int err = errno;
 		::close(fd);
 		::shm_unlink(name.c_str());
-		throw std::runtime_error("gpl_boundary: ftruncate(" + name + ") failed: " + std::string(::strerror(err)));
+		std::string msg = "gpl_boundary: ftruncate(" + name + ") failed: " + std::string(::strerror(err));
+		if (err == ENOSPC) {
+			msg += ShmCleanupHint();
+		}
+		throw std::runtime_error(msg);
 	}
 	void *p = ::mmap(nullptr, size_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	::close(fd); // mmap holds its own reference; the fd is no longer needed
@@ -139,6 +157,12 @@ OutputShmRegion OutputShmRegion::Open(const std::string &name, std::size_t size_
 	::close(fd);
 	if (p == MAP_FAILED) {
 		const int err = errno;
+		// Symmetric with InputShmRegion::Create: a segment we opened but cannot
+		// map is ours to clean up — the daemon has already handed it off, and
+		// OutputShmRegion's destructor (which normally unlinks) never runs
+		// because construction failed here. Unlink so it doesn't leak in
+		// /dev/shm.
+		::shm_unlink(name.c_str());
 		throw std::runtime_error("gpl_boundary: mmap(" + name + ") failed: " + std::string(::strerror(err)));
 	}
 	return OutputShmRegion(name, size_bytes, p);

--- a/src/include/gpl_boundary/session.hpp
+++ b/src/include/gpl_boundary/session.hpp
@@ -148,12 +148,26 @@ public:
 	}
 
 private:
+	/// Non-blocking drain of the daemon's stderr fd into `stderr_tail_`,
+	/// truncating the front to the byte cap. Cheap no-op when nothing is
+	/// pending. Called once per `Submit` (so the OS pipe buffer can't fill and
+	/// wedge a verbose daemon on a blocked write) and again on the failure paths.
+	void PumpStderr();
+
 	ChildProcess child_;
 	std::unique_ptr<LineReader> reader_;
 	std::vector<ToolEntry> tools_;
 	bool initialized_ = false;
 	bool shut_down_ = false;
 	int64_t next_batch_id_ = 1;
+
+	/// Rolling tail of the daemon's stderr, accumulated across the session.
+	/// Drained once per batch by `Submit` so a chatty tool (e.g. bowtie2 with
+	/// quiet=false) can't fill the OS pipe buffer and deadlock the daemon on a
+	/// blocked stderr write while we block waiting for its response. Capped to
+	/// the last `kStderrTailCap` bytes; spliced into the exception message on
+	/// the daemon-death / batch-failure paths.
+	std::string stderr_tail_;
 };
 
 } // namespace gpl_boundary

--- a/test/cpp/test_gpl_boundary_session.cpp
+++ b/test/cpp/test_gpl_boundary_session.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <csignal>
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
@@ -346,6 +347,77 @@ sleep 5)";
 	Session session(std::move(child));
 	REQUIRE_NOTHROW(session.Initialize());
 	REQUIRE_THROWS_WITH(session.Submit("bowtie2-align", "{}", "x", 1), ContainsSubstring("signal 15"));
+}
+
+TEST_CASE("Session::Submit drains daemon stderr each batch so a verbose daemon can't deadlock",
+          "[gpl-boundary][session]") {
+	// Field repro for the align_bowtie2_sharded hang: with quiet=false, bowtie2
+	// prints a ~20-line alignment summary to stderr on every batch. The daemon's
+	// stderr is a pipe back to miint that was only ever read on the failure
+	// paths — never during normal Submit traffic. After enough batches the
+	// daemon's writes crossed the ~64 KB OS pipe buffer, the daemon blocked in
+	// write(2) before it could answer, and Submit hung forever in ReadLine (CPU
+	// flatlined; no crash). Submit now drains stderr after every response so the
+	// pipe can never back up.
+	//
+	// This shim writes 48 KB to stderr per batch across 8 batches (384 KB, far
+	// past 64 KB). Each single batch's 48 KB fits an empty pipe, so the fix
+	// (drain-per-batch) keeps every write unblocked; without it the pipe fills
+	// by batch ~2 and the shim wedges. A watchdog bounds the wait and SIGKILLs
+	// the shim on timeout so a regression fails loudly instead of hanging CI.
+	const int kBatches = 8;
+	std::string script =
+	    R"SHIM(read -r init_line
+echo '{"success":true,"protocol_version":3,"tools":[{"name":"bowtie2-align","schema_version":2}]}'
+bid=1
+while [ $bid -le )SHIM" +
+	    std::to_string(kBatches) + R"SHIM( ]; do
+  read -r batch_line || break
+  head -c 49152 /dev/zero | tr '\0' 'x' >&2
+  echo "{\"success\":true,\"schema_version\":2,\"batch_id\":$bid}"
+  bid=$((bid+1))
+done
+read -r shutdown_line
+exit 0
+)SHIM";
+
+	auto child = spawn_shim(script);
+	Session session(std::move(child));
+	REQUIRE_NOTHROW(session.Initialize());
+	const pid_t shim_pid = session.daemon_pid();
+
+	std::atomic<bool> done {false};
+	std::atomic<int> completed {0};
+	std::thread worker([&]() {
+		try {
+			for (int i = 0; i < kBatches; ++i) {
+				session.Submit("bowtie2-align", "{}", "x", 1);
+				completed.fetch_add(1, std::memory_order_relaxed);
+			}
+		} catch (...) {
+			// Watchdog SIGKILL (or any error) surfaces here as a thrown
+			// exception once ReadLine sees the closed pipe. `completed` already
+			// records how far we got; let the assertions below judge.
+		}
+		done.store(true, std::memory_order_release);
+	});
+
+	const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+	while (!done.load(std::memory_order_acquire) && std::chrono::steady_clock::now() < deadline) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(20));
+	}
+	const bool finished_in_time = done.load(std::memory_order_acquire);
+	if (!finished_in_time) {
+		// Pre-fix: the worker is blocked in ReadLine because the shim is blocked
+		// in write(2,stderr). Killing the shim closes its stdout so ReadLine
+		// returns and the worker can be joined cleanly.
+		::kill(shim_pid, SIGKILL);
+	}
+	worker.join();
+
+	REQUIRE(finished_in_time); // false on the pre-fix deadlock
+	REQUIRE(completed.load() == kBatches);
+	REQUIRE_NOTHROW(session.Shutdown());
 }
 
 TEST_CASE("Session::Submit rejects calls before Initialize", "[gpl-boundary][session]") {


### PR DESCRIPTION
## Problem

`align_bowtie2_sharded` hangs on real data when run with `quiet := false`. A user hit this on a WoL3 run: the gpl-boundary processes churned for a few minutes, then stopped consuming CPU, and after ~30–60s the query died with:

```
gpl_boundary: daemon closed stdout while waiting for batch response [daemon exited with code 0]
--- daemon stderr ---
...(truncated head)...
... 81.60% overall alignment rate
699 reads; of these: ...
```

## Root cause

Each worker thread owns its own gpl-boundary daemon (`ChildProcess`) whose **stderr is a pipe back to the extension** (`process.cpp` `err_pipe`, default ~64KB kernel buffer). Nothing read that pipe during normal operation — the only reader (`DrainStderrNonblocking`) ran **only on failure paths**. `Session::Submit` writes the request, then blocks in `LineReader::ReadLine` on **stdout**, never touching stderr.

With `quiet := false` the daemon runs bowtie2 `verbose=true`, which prints a ~20-line alignment summary to stderr on **every batch** (one `Submit` = one DuckDB chunk = one bowtie2 invocation). After enough batches the undrained writes cross the ~64KB pipe buffer, the daemon blocks in `write(2)` before it can answer, and `Submit` hangs forever in `ReadLine` (CPU flatlines — blocked on write, not crashed). The daemon then idle-shuts-down, which surfaces as the EOF error above.

It only reproduces at scale: the pipe has to fill, which depends on dataset size, batch count, and the quiet setting — toy inputs never hit it. This is consistent with the previously-uncaptured intermittent daemon-death reports.

## Fix

`Session::PumpStderr()` does a non-blocking drain of the daemon's stderr fd into a rolling, capped buffer (`kStderrTailCap`) **once per `Submit`**, right after a successful `ReadLine`. The pipe stays near-empty so it can never back up. The failure paths now splice this rolling buffer instead of draining the fd directly (and as a bonus, the diagnostic tail now spans the whole run rather than just whatever was in the pipe at the moment of death).

**Surgical by design:** no new thread and no lock — each `Session` is single-threaded (one per worker thread), so the existing move-only / fork-teardown semantics of `ChildProcess` are untouched. The alternative (a dedicated per-daemon drainer thread) would have forced a `unique_ptr<DrainerState>` indirection and teardown reordering; it's only needed if a *single* batch can emit >64KB of stderr, which a bowtie2 summary never does.

## Tests

New regression test in `test/cpp/test_gpl_boundary_session.cpp`: a bash shim writes 48KB to stderr per batch across 8 batches (384KB ≫ 64KB) with a 15s watchdog that SIGKILLs the shim on timeout so a regression fails loudly instead of hanging CI.

- Verified **red without the fix** (watchdog fires at exactly 15.0s = the deadlock).
- **Green with the fix.**
- Full C++ suite (1151 passed, 1 skipped for missing optional data), all `[gpl-boundary]` cases (56), and the bowtie2 SQL tests (`align_bowtie2_sharded`, `align_bowtie2`, `simple_bowtie2`, `miint_warnings_bowtie2`) pass against the real daemon.
- `make format-check` passes.

## User-facing note

Users who don't want the verbose output at all can also set `quiet := true` (the default), which stops the daemon from generating the per-batch summary in the first place. The fix makes `quiet := false` safe regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)