### PR TITLE
perf(deps): use zlib-ng (compat) as the zlib provider — faster gzip i…

### DIFF
--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -1,0 +1,42 @@
+# Overlay port: build zlib-ng in ZLIB_COMPAT mode and install it as the `zlib`
+# package. Because it is an overlay port named "zlib", it shadows the upstream
+# zlib port for every consumer in the dependency graph (the manifest, plus
+# transitive deps like HDF5 and RocksDB) and for kseq++/htslib via
+# find_package(ZLIB). Result: one zlib in the build, and it is zlib-ng's
+# SIMD-accelerated inflate -- the hot path for reading gzipped FASTQ/BAM.
+#
+# REF/SHA512 copied verbatim from vcpkg's upstream zlib-ng port (2.2.5). The
+# package version (1.3.1, see vcpkg.json) is intentionally decoupled from the
+# zlib-ng source tag: it advertises the zlib API level zlib-ng-compat emulates
+# so dependents that pin "zlib >= 1.x" still resolve.
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO zlib-ng/zlib-ng
+    REF 2.2.5
+    SHA512 b599ea24375d08fa098ed7c3b14548e0d9731a155a024a0904b0ae4a6d3491a69f0c0574d66b6e4af1e40f10e38b6b555d4c4b1fe3589ca83a5f97fbd92f635f
+    HEAD_REF develop
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        "-DZLIB_FULL_VERSION=1.3.1"
+        -DZLIB_ENABLE_TESTS=OFF
+        -DWITH_NEW_STRATEGIES=ON
+        -DZLIB_COMPAT=ON
+    OPTIONS_RELEASE
+        -DWITH_OPTIM=ON
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+
+vcpkg_fixup_pkgconfig()
+
+# In ZLIB_COMPAT mode zlib-ng installs its CMake config under lib/cmake/ZLIB,
+# providing the standard ZLIB::ZLIB target that find_package(ZLIB) consumes.
+vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/ZLIB)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share"
+                    "${CURRENT_PACKAGES_DIR}/debug/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.md")

--- a/ports/zlib/vcpkg.json
+++ b/ports/zlib/vcpkg.json
@@ -1,0 +1,12 @@
+{
+  "name": "zlib",
+  "version": "1.3.1",
+  "port-version": 100,
+  "description": "Overlay port: zlib-ng built in ZLIB_COMPAT mode, shadowing the upstream zlib port. Every consumer that depends on zlib (kseq++ via find_package(ZLIB), htslib, HDF5, RocksDB) transparently links zlib-ng's SIMD-optimized inflate. Version 1.3.1 mirrors the zlib API zlib-ng-compat emulates so dependents' version constraints are satisfied.",
+  "homepage": "https://github.com/zlib-ng/zlib-ng",
+  "license": "Zlib",
+  "dependencies": [
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ]
+}


### PR DESCRIPTION
…nflate

read_fastx is ~85% single-threaded zlib inflate when reading gzipped FASTQ; that decompression is the dominant cost (profiled). zlib-ng is an API/ABI drop-in for zlib with SIMD-accelerated inflate (NEON/AVX), so swapping it in speeds up every gzip path transparently: kseq++ FASTQ.gz, htslib BGZF, HDF5, RocksDB -- plain-gzip and BGZF alike, on all platforms.

Mechanism: an overlay `zlib` port (ports/zlib) that builds zlib-ng in ZLIB_COMPAT mode and installs it as the `zlib` package, so the whole dependency graph (manifest + transitive HDF5/RocksDB, plus find_package(ZLIB) for kseq++/htslib) resolves to one zlib and it is zlib-ng. No application-code change.

Also bumps the abpoa submodule to pick up an <limits.h> include fix: abpoa_output.c relied on INT_MAX arriving transitively through stock zlib.h; zlib-ng's leaner headers don't provide it, so abpoa failed to compile until utils.h includes <limits.h> explicitly (the only vendored lib that needed it).

Measured on a 2.0 GB BGZF FASTQ (500k long reads, 5.93 Gbp):
  read_fastx count(*):        31.8s -> 18.7s  (1.70x)
  read_fastx full materialize: 32.8s -> 19.7s (1.66x)
  read_sequences_sam BAM:      23.3s -> 20.6s (1.13x bonus)
Output byte-identical (read_id/sequence/qual sums match; decompression is
deterministic). read_fastx (192), read_sequences_sam (190), read_alignments
(141), copy_sam (206) and the compression round-trip suites (copy_gzip_bgzf,
copy_{fasta,fastq,sam}_compression, copy_{fastq,fasta,bam,buffering}) all pass.