### PR TITLE
fix(wasm): build generic zlib-ng for emscripten so binaryen can finalize

### DIFF
--- a/ports/zlib/portfile.cmake
+++ b/ports/zlib/portfile.cmake
@@ -17,15 +17,35 @@ vcpkg_from_github(
     HEAD_REF develop
 )
 
+# WASM (emscripten) has no zlib-ng SIMD path: zlib-ng ships no wasm arch, so it
+# falls back to generic C and gains zero speed from the optimized build anyway.
+# But on wasm the runtime-CPU-detection functable + optimized codegen produces a
+# binary that binaryen's wasm-emscripten-finalize cannot parse once the full
+# DuckDB core is statically linked into one ~41 MB MAIN_MODULE with
+# -fwasm-exceptions (the WASM load-test harness in scripts/test_wasm_load.sh):
+#   [parse exception: attempted pop from empty stack / beyond block start ...]
+# Build a plain single-implementation generic zlib-ng for emscripten so finalize
+# succeeds; native keeps the SIMD-accelerated inflate that motivated zlib-ng.
+if(VCPKG_TARGET_IS_EMSCRIPTEN)
+    set(_miint_new_strategies OFF)
+    set(_miint_extra_options -DWITH_RUNTIME_CPU_DETECTION=OFF -DWITH_OPTIM=OFF)
+    set(_miint_release_options)
+else()
+    set(_miint_new_strategies ON)
+    set(_miint_extra_options)
+    set(_miint_release_options -DWITH_OPTIM=ON)
+endif()
+
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
         "-DZLIB_FULL_VERSION=1.3.1"
         -DZLIB_ENABLE_TESTS=OFF
-        -DWITH_NEW_STRATEGIES=ON
+        "-DWITH_NEW_STRATEGIES=${_miint_new_strategies}"
         -DZLIB_COMPAT=ON
+        ${_miint_extra_options}
     OPTIONS_RELEASE
-        -DWITH_OPTIM=ON
+        ${_miint_release_options}
 )
 vcpkg_cmake_install()
 vcpkg_copy_pdbs()


### PR DESCRIPTION
## Problem
The **Test WASM extension loads** job has failed since the zlib-ng swap (#117). It links the full DuckDB core into one ~41 MB `MAIN_MODULE` with `-fwasm-exceptions`, then runs `wasm-emscripten-finalize`, which dies:

```
[parse exception: attempted pop from empty stack / beyond block start boundary at 41630588]
Fatal: error in parsing input
```

The DuckDB core compiles fine; only finalizing the linked harness fails. The prior pipeline run (parent commit) passed this exact job — the only delta affecting the harness link is `libz.a`, now zlib-ng.

## Root cause
zlib-ng ships **no wasm arch** (only x86/arm/ppc/riscv/s390/generic), so on `wasm32-emscripten` it already falls back to generic C and gains **zero** speed from the optimized build. But `WITH_OPTIM` + the runtime-CPU-detection functable emit codegen that binaryen 3.1.71 can't parse in this large EH-enabled main module. The shipped extension (a *side* module) and the wasm-compat Linux build never hit this path — which is why only this job broke.

## Fix
Build a plain single-implementation generic zlib-ng for emscripten only (`WITH_OPTIM=OFF`, `WITH_RUNTIME_CPU_DETECTION=OFF`, `WITH_NEW_STRATEGIES=OFF`). Native is untouched and keeps the SIMD-accelerated inflate that motivated zlib-ng, so the `read_fastx` perf win is unaffected.

## Verification
Can't be built locally (no emsdk here) — relies on the **Test WASM extension loads** job in this PR's CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)