### PR TITLE
fix(deps): pin vcpkg builtin-baseline so rocksdb resolves < 11.x everywhere

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+          vcpkgGitCommitId: fef715db0cad13d7db3a29797969a57b44e73531
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -165,7 +165,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+          vcpkgGitCommitId: fef715db0cad13d7db3a29797969a57b44e73531
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
@@ -276,7 +276,7 @@ jobs:
       - name: Setup vcpkg
         uses: lukka/run-vcpkg@v11.1
         with:
-          vcpkgGitCommitId: 84bab45d415d22042bd0b9081aea57f362da3f35
+          vcpkgGitCommitId: fef715db0cad13d7db3a29797969a57b44e73531
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,4 +1,5 @@
 {
+  "builtin-baseline": "fef715db0cad13d7db3a29797969a57b44e73531",
   "dependencies": [
     "zlib",
     "zstd",


### PR DESCRIPTION
## Problem
A user hit a build failure with **rocksdb ≥ 11.x**, while CI and the dev system build rocksdb < 11.x — with no obvious reason in the repo.

The project never pinned a vcpkg baseline:
- `vcpkg.json` had **no `builtin-baseline`**
- no `vcpkg-configuration.json` baseline
- vcpkg is **not** a submodule

The only version pin lived in CI's `vcpkgGitCommitId`. So every consumer resolved each port to whatever sat in *their own* vcpkg checkout:

| Consumer | vcpkg | rocksdb |
|---|---|---|
| CI (non-WASM) | `ce613c41` (Apr 2025) | 9.10.0 |
| Dev system | `fef715db` (Oct 2025) | 10.4.2 |
| External user | recent HEAD | **≥ 11.x** ← failure |

## Fix
Pin `builtin-baseline` to `fef715db` (the dev-system commit, rocksdb 10.4.2). A baseline only resolves if the commit is reachable in the checked-out vcpkg, and `fef715db` is newer than the old CI pin, so the workflow's three `vcpkgGitCommitId` values are bumped to `fef715db` to match.

Now CI, the dev system, and external users all resolve **identical** port versions, and rocksdb stays < 11.x.

> Note: this also shifts all other ports (zstd/expat/openssl/curl/hdf5) to their `fef715db` versions for every job — intentional, so builds are reproducible against one trusted commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)