### PR TITLE
feat(align_bowtie2): expose deterministic_seeds + upfront/lowseeds knobs

### DIFF
--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -2134,6 +2134,10 @@ The full bowtie2-align typed parameter set is also exposed (one-to-one with the 
 | `rg_id` | VARCHAR | `--rg-id` read group ID |
 | `ignore_quals` | BOOLEAN | Treat all qualities as Phred 30 |
 | `reorder` | BOOLEAN | Preserve input read order in output |
+| `no_exact_upfront` | BOOLEAN | `--no-exact-upfront` (disable the exact end-to-end pass before multiseed) |
+| `no_1mm_upfront` | BOOLEAN | `--no-1mm-upfront` (disable the 1-mismatch end-to-end pass before multiseed) |
+| `deterministic_seeds` | BOOLEAN | `-d`/`--deterministic-seeds`: disable random subsampling of low-quality seed ranges for fully reproducible seed selection. **Coupling:** requires `report_all := true`, `no_exact_upfront := true`, and `no_1mm_upfront := true`, and is incompatible with `max_secondary`; otherwise the aligner rejects the run. |
+| `lowseeds` | VARCHAR | `-l`/`--lowseeds`: discard low-quality seeds whose suffix-array range exceeds a threshold. Passed through verbatim, so a suffix is honored: bare = absolute count, `'%'` = /100, `'m'` = /1000, `'n'` = /1000000 of the reference |
 
 Unknown parameters are rejected at bind time by DuckDB's binder (e.g. `presset := 'fast'` → `Invalid named parameter "presset"`).
 
@@ -2263,7 +2267,7 @@ The sharded path emits only mapped reads (the daemon is invoked with `--no-unal`
 - `quiet` (BOOLEAN, default: true): Runs Bowtie2 with `--quiet`. Keep the default — miint never surfaces Bowtie2's stderr statistics to SQL, so `quiet := false` has no user-visible effect and only adds overhead (per-batch summaries that miint drains and discards).
 - `threads` (INTEGER): Ignored in sharded mode. Use DuckDB's `SET threads=N` to control cross-shard parallelism and `max_threads_per_shard` for per-shard bowtie2 threading. A warning is printed at bind if `threads != 1` is passed directly to this function.
 
-The full bowtie2-align typed parameter set listed under [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) above is also available here (same names, same bind-time validation): `seed`, `trim5`, `trim3`, `match_bonus`, `mismatch_penalty`, `mismatch_penalty_min`, `n_penalty`, `read_gap_open`, `read_gap_extend`, `ref_gap_open`, `ref_gap_extend`, `score_min`, `min_insert`, `max_insert`, `mate_orientation`, `no_mixed`, `no_discordant`, `dovetail`, `no_contain`, `no_overlap`, `nofw`, `norc`, `seed_mismatches`, `seed_length`, `max_dp_failures`, `max_seed_rounds`, `report_all`, `xeq`, `rg_id`, `ignore_quals`, `reorder`.
+The full bowtie2-align typed parameter set listed under [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) above is also available here (same names, same bind-time validation): `seed`, `trim5`, `trim3`, `match_bonus`, `mismatch_penalty`, `mismatch_penalty_min`, `n_penalty`, `read_gap_open`, `read_gap_extend`, `ref_gap_open`, `ref_gap_extend`, `score_min`, `min_insert`, `max_insert`, `mate_orientation`, `no_mixed`, `no_discordant`, `dovetail`, `no_contain`, `no_overlap`, `nofw`, `norc`, `seed_mismatches`, `seed_length`, `max_dp_failures`, `max_seed_rounds`, `report_all`, `xeq`, `rg_id`, `ignore_quals`, `reorder`, `no_exact_upfront`, `no_1mm_upfront`, `deterministic_seeds`, `lowseeds`.
 
 The `no_unal` knob is intentionally not exposed: the sharded path always emits only mapped reads (matches the pre-migration `FilterMappedOnly` contract). Use `align_bowtie2` directly if you need to inspect unaligned records.
 

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -123,6 +123,10 @@ const std::unordered_set<std::string> kCommonAlignParams = {
     "rg_id",
     "ignore_quals",
     "reorder",
+    "no_exact_upfront",
+    "no_1mm_upfront",
+    "deterministic_seeds",
+    "lowseeds",
 };
 
 void AppendBowtie2AlignParams(ConfigJsonBuilder &cfg, const named_parameter_map_t &named_params, const char *caller) {
@@ -265,6 +269,20 @@ void AppendBowtie2AlignParams(ConfigJsonBuilder &cfg, const named_parameter_map_
 	}
 	pass_bool("ignore_quals");
 	pass_bool("reorder");
+
+	// 8. v0.4 seed-behavior knobs (bowtie2 -d / --no-exact-upfront /
+	//    --no-1mm-upfront / -l). `deterministic_seeds` gives reproducible seed
+	//    selection but bowtie2 couples it: it requires report_all AND both
+	//    upfront-disable flags set, and is incompatible with -k. We forward the
+	//    values verbatim and let the daemon's config parser enforce the coupling
+	//    (it returns a clear "deterministic_seeds requires ..." error) rather
+	//    than duplicate that interdependency here.
+	pass_bool("no_exact_upfront");
+	pass_bool("no_1mm_upfront");
+	pass_bool("deterministic_seeds");
+	if (auto *v = get("lowseeds")) {
+		cfg.append_str("lowseeds", ValueAsStr(caller, "lowseeds", *v));
+	}
 }
 
 void RegisterBowtie2AlignNamedParameterTypes(TableFunction &tf) {
@@ -304,6 +322,10 @@ void RegisterBowtie2AlignNamedParameterTypes(TableFunction &tf) {
 	tf.named_parameters["rg_id"] = LogicalType::VARCHAR;
 	tf.named_parameters["ignore_quals"] = LogicalType::BOOLEAN;
 	tf.named_parameters["reorder"] = LogicalType::BOOLEAN;
+	tf.named_parameters["no_exact_upfront"] = LogicalType::BOOLEAN;
+	tf.named_parameters["no_1mm_upfront"] = LogicalType::BOOLEAN;
+	tf.named_parameters["deterministic_seeds"] = LogicalType::BOOLEAN;
+	tf.named_parameters["lowseeds"] = LogicalType::VARCHAR;
 }
 
 const char *const kOutputColumnNames[kNumOutputColumns] = {

--- a/test/sql/align_bowtie2.test
+++ b/test/sql/align_bowtie2.test
@@ -451,6 +451,52 @@ SELECT COUNT(*) FROM align_bowtie2_sharded('typed_queries',
 ----
 1
 
+# ----------------------------------------------------------------------------
+# v0.4 seed-behavior knobs: deterministic_seeds, no_exact_upfront,
+# no_1mm_upfront, lowseeds
+# ----------------------------------------------------------------------------
+# `deterministic_seeds` (-d) gives reproducible seed selection. bowtie2 couples
+# it: it requires report_all AND both upfront-disable flags, and is incompatible
+# with max_secondary (-k). miint forwards the knobs verbatim; the daemon enforces
+# the coupling with a clear knob-named error (same contract as --mp MAX,MIN).
+
+# Full valid combo accepted + forwarded; the perfect-match query still aligns.
+query I
+SELECT COUNT(*) >= 1 FROM align_bowtie2('typed_queries', 'typed_subjects',
+    report_all := true,
+    no_exact_upfront := true,
+    no_1mm_upfront := true,
+    deterministic_seeds := true);
+----
+true
+
+# lowseeds accepted + forwarded (passed verbatim to bowtie2's -l/--lowseeds).
+query I
+SELECT COUNT(*) >= 1 FROM align_bowtie2('typed_queries', 'typed_subjects',
+    lowseeds := '100');
+----
+true
+
+# Coupling enforced by the daemon: deterministic_seeds without the
+# upfront-disable flags is rejected with a knob-named error (no worker crash).
+statement error
+SELECT * FROM align_bowtie2('typed_queries', 'typed_subjects',
+    report_all := true, deterministic_seeds := true);
+----
+deterministic_seeds
+
+# Same surface for the sharded variant — valid combo accepted + forwarded.
+query I
+SELECT COUNT(*) >= 1 FROM align_bowtie2_sharded('typed_queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'typed_assoc',
+    report_all := true,
+    no_exact_upfront := true,
+    no_1mm_upfront := true,
+    deterministic_seeds := true);
+----
+true
+
 statement ok
 DROP TABLE typed_queries;
 


### PR DESCRIPTION
## Summary

gpl-boundary's `bt2_align_config_t` (bowtie2 C API v0.4) supports several alignment options that miint did not forward to the daemon. This exposes them as typed named parameters on **both** `align_bowtie2` and `align_bowtie2_sharded` (shared registration in `align_bowtie2_daemon_common`):

| Parameter | Type | bowtie2 flag |
|---|---|---|
| `deterministic_seeds` | BOOLEAN | `-d`/`--deterministic-seeds` |
| `no_exact_upfront` | BOOLEAN | `--no-exact-upfront` |
| `no_1mm_upfront` | BOOLEAN | `--no-1mm-upfront` |
| `lowseeds` | VARCHAR | `-l`/`--lowseeds` |

`deterministic_seeds` is the motivating case: it disables random subsampling of low-quality seed ranges, giving **fully reproducible seed selection** (important for reproducible/database workloads that already pin `seed`).

## Coupling

bowtie2 couples `deterministic_seeds` with `report_all` **and** `no_exact_upfront` **and** `no_1mm_upfront`, and rejects it alongside `max_secondary` (`-k`). The daemon already enforces this with a clear `BT2_ERR_INVALID_CONFIG` error, so miint forwards the knobs verbatim rather than duplicating the interdependency at bind time (the test pins the daemon-enforced error).

## Deliberately not exposed

- `no_unal` — the sharded path manages it (per the existing comment in `align_bowtie2_daemon_common.cpp`).
- `memory_mapped` — the daemon hardcodes `--mm`.

## Tests

`test/sql/align_bowtie2.test` (require-env `GPL_BOUNDARY_AVAILABLE`): valid full combo aligns, `lowseeds` accepted/forwarded, and the daemon-enforced coupling error. Passing locally — 110 assertions; sharded regression clean; `clang-format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)