### PR TITLE
perf(align_bowtie2_sharded): batch reads + adaptive -p ramp; pin daemon idle timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1513,6 +1513,7 @@ set(TEST_SOURCES
     test/cpp/test_InsertFullyResolved.cpp
     src/Minimap2Aligner.cpp
     test/cpp/test_Minimap2Aligner.cpp
+    test/cpp/test_AlignBowtie2Sharded.cpp
     src/ncbi_parser.cpp
     src/zip_utils.cpp
     duckdb/third_party/miniz/miniz.cpp  # For ExtractFromZip tests

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -2262,7 +2262,7 @@ The sharded path emits only mapped reads (the daemon is invoked with `--no-unal`
 - `preset` (VARCHAR, optional): Bowtie2 sensitivity preset ('very-fast', 'fast', 'sensitive', 'very-sensitive')
 - `local` (BOOLEAN, default: false): Use local alignment mode instead of end-to-end
 - `max_secondary` (INTEGER, default: 1): Maximum alignments to report per query (`-k`)
-- `max_threads_per_shard` (INTEGER, default: 4, range 1–64): bowtie2's internal `nthreads` for each per-shard daemon worker
+- `max_threads_per_shard` (INTEGER, default: 4, range 1–64): bowtie2's internal `nthreads` *floor* for each per-shard daemon worker. This is the baseline per-shard thread count while shards are still being distributed across DuckDB workers. Once every shard has been claimed, a surviving worker grows its `nthreads` to reclaim cores freed by finished workers (up to `SET threads`), so a lone large shard at the end of a run isn't pinned to this value while the rest of the box sits idle. Total CPU stays bounded by `SET threads`; alignments are unaffected (bowtie2 `-p` only partitions reads across threads).
 - `include_shard_name` (BOOLEAN, default: false): When true, append a `shard_name` column to the output
 - `quiet` (BOOLEAN, default: true): Runs Bowtie2 with `--quiet`. Keep the default — miint never surfaces Bowtie2's stderr statistics to SQL, so `quiet := false` has no user-visible effect and only adds overhead (per-batch summaries that miint drains and discards).
 - `threads` (INTEGER): Ignored in sharded mode. Use DuckDB's `SET threads=N` to control cross-shard parallelism and `max_threads_per_shard` for per-shard bowtie2 threading. A warning is printed at bind if `threads != 1` is passed directly to this function.
@@ -2282,7 +2282,7 @@ Returns the same 21-column schema as `align_bowtie2` and `read_alignments`.
 
 **Behavior:**
 - At bind time, reads the `read_to_shard` table to discover shards; per-shard index existence is verified at InitGlobal (not Bind) so the planner doesn't pay filesystem-stat cost on wide shard sets.
-- Cross-shard parallelism is driven by `SET threads`: each DuckDB worker thread owns its own gpl-boundary daemon and claims shards atomically. Per-shard bowtie2 internal threading is driven by `max_threads_per_shard`.
+- Cross-shard parallelism is driven by `SET threads`: each DuckDB worker thread owns its own gpl-boundary daemon and claims shards atomically. Per-shard bowtie2 internal threading starts at `max_threads_per_shard` and ramps up for surviving shards once all shards are claimed (see `max_threads_per_shard` above) — this keeps the box saturated when a skewed shard-size distribution would otherwise leave a large shard running alone at the end of a run.
 - For each shard, only the reads assigned to that shard (via the `read_to_shard` mapping) are streamed across the gpl-boundary as Arrow IPC
 - A read can appear in multiple shards and will be aligned against each
 - Unmapped reads (flag 0x4) are filtered out of results (daemon `--no-unal`)

--- a/src/align_bowtie2_sharded.cpp
+++ b/src/align_bowtie2_sharded.cpp
@@ -53,6 +53,7 @@ std::unordered_set<std::string> MakeKnownShardedParams() {
 	s.insert("threads"); // sharded-mode warning; not forwarded to daemon
 	s.insert("max_threads_per_shard");
 	s.insert("include_shard_name");
+	s.insert("submit_batch_reads");
 	return s;
 }
 
@@ -149,6 +150,15 @@ struct AlignBowtie2ShardedBindData : public TableFunctionData {
 
 	idx_t max_threads_per_shard = 4;
 	bool include_shard_name = false;
+
+	// Lower-bound threshold on reads accumulated into one daemon Submit. Larger
+	// batches amortize bowtie2's per-batch FM-index reload and keep `bowtie2 -p N`
+	// fed; throughput knob only — alignment results are identical to any other
+	// value because each read is aligned independently. Accumulation is
+	// chunk-granular (one DuckDB chunk <= STANDARD_VECTOR_SIZE at a time in
+	// FetchShardBatch), so a value below the chunk size still submits a full
+	// chunk per round-trip.
+	idx_t submit_batch_reads = 16384;
 };
 
 struct AlignBowtie2ShardedGlobalState : public GlobalTableFunctionState {
@@ -204,6 +214,13 @@ struct AlignBowtie2ShardedLocalState : public LocalTableFunctionState {
 	idx_t current_shard_idx = DConstants::INVALID_INDEX;
 	std::unique_ptr<QueryResult> input_stream;
 	std::string current_shard_name; // copied for `include_shard_name`
+	// Set once `input_stream->Fetch()` returns EOF. A streaming QueryResult
+	// throws "closed pending query result" if Fetch() is called again after it
+	// has returned its final (empty) chunk, so once a FetchShardBatch loop
+	// consumes EOF we must not Fetch this stream again — the next call returns
+	// false immediately. Reset when a new shard stream is opened. Plain bool,
+	// order-independent — safe to declare outside the SHM/Arrow ordering block.
+	bool stream_exhausted = false;
 
 	// Latest Submit response + its decoder. The ArrowArrayWrapper batches
 	// inside `current_batches` hold pointers into SubmitResult's SHM regions,
@@ -386,6 +403,16 @@ unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &in
 		    bt2_daemon::ValueAsBool("align_bowtie2_sharded", "include_shard_name", include_shard_param->second);
 	}
 
+	auto batch_param = input.named_parameters.find("submit_batch_reads");
+	if (batch_param != input.named_parameters.end() && !batch_param->second.IsNull()) {
+		const int64_t val = bt2_daemon::ValueAsInt("align_bowtie2_sharded", "submit_batch_reads", batch_param->second);
+		if (val < 1 || val > 1000000) {
+			throw BinderException("submit_batch_reads must be between 1 and 1000000 (got %lld)",
+			                      static_cast<long long>(val));
+		}
+		bd->submit_batch_reads = static_cast<idx_t>(val);
+	}
+
 	DetectQueryColumns(context, *bd);
 
 	bd->shards = EnumerateShards(context, bd->read_to_shard_table, bd->shard_directory);
@@ -508,6 +535,7 @@ void OpenCurrentShardStream(AlignBowtie2ShardedLocalState &local, const AlignBow
 	select += " WHERE rts.shard_name = " + KeywordHelper::WriteQuoted(shard.name, '\'');
 
 	local.input_stream = local.input_conn->SendQuery(select);
+	local.stream_exhausted = false;
 	if (local.input_stream->HasError()) {
 		throw InvalidInputException("align_bowtie2_sharded: failed to open cursor for shard '%s': %s", shard.name,
 		                            local.input_stream->GetError());
@@ -518,14 +546,16 @@ void OpenCurrentShardStream(AlignBowtie2ShardedLocalState &local, const AlignBow
 // Quality decoding lives in align_bowtie2_daemon_common — see
 // bt2_daemon::DecodeListQualToPhred33. Shared with align_bowtie2.
 
-// Pull one DuckDB chunk worth of reads from the current shard's stream.
+// Accumulate reads from the current shard's stream into one daemon Submit:
+// pull whole DuckDB chunks (each <= STANDARD_VECTOR_SIZE) until reaching
+// `submit_batch_reads` or the stream exhausts. Larger batches amortize
+// bowtie2's per-batch FM-index reload and keep `bowtie2 -p N` fed; results are
+// identical to one-chunk-per-Submit because each read is aligned independently.
 bool FetchShardBatch(AlignBowtie2ShardedLocalState &local, const AlignBowtie2ShardedBindData &bd,
                      bt2_daemon::QueryBatch &out) {
-	auto chunk = local.input_stream->Fetch();
-	if (!chunk || chunk->size() == 0) {
-		return false;
+	if (local.stream_exhausted) {
+		return false; // never Fetch() past EOF — see stream_exhausted note
 	}
-	const idx_t n = chunk->size();
 	out.read_ids.clear();
 	out.sequence1.clear();
 	out.sequence2.clear();
@@ -534,8 +564,6 @@ bool FetchShardBatch(AlignBowtie2ShardedLocalState &local, const AlignBowtie2Sha
 	out.qual1_valid.clear();
 	out.qual2.clear();
 	out.qual2_valid.clear();
-	out.read_ids.reserve(n);
-	out.sequence1.reserve(n);
 	int col = 0;
 	const int col_read_id = col++;
 	const int col_sequence1 = col++;
@@ -544,49 +572,76 @@ bool FetchShardBatch(AlignBowtie2ShardedLocalState &local, const AlignBowtie2Sha
 	const int col_qual2 = bd.query_has_qual2 ? col++ : -1;
 	std::vector<uint8_t> qual_scratch; // reused across rows to amortize allocs
 	std::string qual_encoded;
-	for (idx_t i = 0; i < n; ++i) {
-		auto rid = chunk->GetValue(col_read_id, i);
-		auto s1 = chunk->GetValue(col_sequence1, i);
-		if (rid.IsNull() || s1.IsNull()) {
-			throw InvalidInputException("align_bowtie2_sharded: NULL read_id or sequence1 in query table '%s'",
-			                            bd.query_table);
+	idx_t accumulated = 0;
+	while (accumulated < bd.submit_batch_reads) {
+		auto chunk = local.input_stream->Fetch();
+		if (!chunk || chunk->size() == 0) {
+			local.stream_exhausted = true;
+			break;
 		}
-		out.read_ids.push_back(rid.GetValue<std::string>());
-		out.sequence1.push_back(s1.GetValue<std::string>());
+		const idx_t n = chunk->size();
+		out.read_ids.reserve(out.read_ids.size() + n);
+		out.sequence1.reserve(out.sequence1.size() + n);
+		// Reserve the optional columns too: with batching these vectors span
+		// many chunks, so growing them by push_back alone would repeatedly
+		// reallocate (and copy the std::strings) as the batch fills.
 		if (col_sequence2 >= 0) {
-			auto v = chunk->GetValue(col_sequence2, i);
-			if (v.IsNull()) {
-				out.sequence2.emplace_back();
-				out.sequence2_valid.push_back(0);
-			} else {
-				out.sequence2.push_back(v.GetValue<std::string>());
-				out.sequence2_valid.push_back(1);
-			}
+			out.sequence2.reserve(out.sequence2.size() + n);
+			out.sequence2_valid.reserve(out.sequence2_valid.size() + n);
 		}
 		if (col_qual1 >= 0) {
-			auto v = chunk->GetValue(col_qual1, i);
-			if (v.IsNull()) {
-				out.qual1.emplace_back();
-				out.qual1_valid.push_back(0);
-			} else {
-				bt2_daemon::DecodeListQualToPhred33(v, "qual1", bd.query_table, qual_encoded, qual_scratch);
-				out.qual1.push_back(qual_encoded);
-				out.qual1_valid.push_back(1);
-			}
+			out.qual1.reserve(out.qual1.size() + n);
+			out.qual1_valid.reserve(out.qual1_valid.size() + n);
 		}
 		if (col_qual2 >= 0) {
-			auto v = chunk->GetValue(col_qual2, i);
-			if (v.IsNull()) {
-				out.qual2.emplace_back();
-				out.qual2_valid.push_back(0);
-			} else {
-				bt2_daemon::DecodeListQualToPhred33(v, "qual2", bd.query_table, qual_encoded, qual_scratch);
-				out.qual2.push_back(qual_encoded);
-				out.qual2_valid.push_back(1);
+			out.qual2.reserve(out.qual2.size() + n);
+			out.qual2_valid.reserve(out.qual2_valid.size() + n);
+		}
+		for (idx_t i = 0; i < n; ++i) {
+			auto rid = chunk->GetValue(col_read_id, i);
+			auto s1 = chunk->GetValue(col_sequence1, i);
+			if (rid.IsNull() || s1.IsNull()) {
+				throw InvalidInputException("align_bowtie2_sharded: NULL read_id or sequence1 in query table '%s'",
+				                            bd.query_table);
+			}
+			out.read_ids.push_back(rid.GetValue<std::string>());
+			out.sequence1.push_back(s1.GetValue<std::string>());
+			if (col_sequence2 >= 0) {
+				auto v = chunk->GetValue(col_sequence2, i);
+				if (v.IsNull()) {
+					out.sequence2.emplace_back();
+					out.sequence2_valid.push_back(0);
+				} else {
+					out.sequence2.push_back(v.GetValue<std::string>());
+					out.sequence2_valid.push_back(1);
+				}
+			}
+			if (col_qual1 >= 0) {
+				auto v = chunk->GetValue(col_qual1, i);
+				if (v.IsNull()) {
+					out.qual1.emplace_back();
+					out.qual1_valid.push_back(0);
+				} else {
+					bt2_daemon::DecodeListQualToPhred33(v, "qual1", bd.query_table, qual_encoded, qual_scratch);
+					out.qual1.push_back(qual_encoded);
+					out.qual1_valid.push_back(1);
+				}
+			}
+			if (col_qual2 >= 0) {
+				auto v = chunk->GetValue(col_qual2, i);
+				if (v.IsNull()) {
+					out.qual2.emplace_back();
+					out.qual2_valid.push_back(0);
+				} else {
+					bt2_daemon::DecodeListQualToPhred33(v, "qual2", bd.query_table, qual_encoded, qual_scratch);
+					out.qual2.push_back(qual_encoded);
+					out.qual2_valid.push_back(1);
+				}
 			}
 		}
+		accumulated += n;
 	}
-	return true;
+	return accumulated > 0;
 }
 
 void SubmitAndDecode(AlignBowtie2ShardedLocalState &local, const AlignBowtie2ShardedBindData &bd,
@@ -725,6 +780,7 @@ TableFunction AlignBowtie2ShardedTableFunction::GetFunction() {
 	tf.named_parameters["threads"] = LogicalType::INTEGER; // ignored in sharded mode; warning at bind
 	tf.named_parameters["max_threads_per_shard"] = LogicalType::INTEGER;
 	tf.named_parameters["include_shard_name"] = LogicalType::BOOLEAN;
+	tf.named_parameters["submit_batch_reads"] = LogicalType::INTEGER;
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	return tf;
 }

--- a/src/align_bowtie2_sharded.cpp
+++ b/src/align_bowtie2_sharded.cpp
@@ -176,6 +176,17 @@ struct AlignBowtie2ShardedGlobalState : public GlobalTableFunctionState {
 	// is roughly max_active_shards × max_threads_per_shard ≈ db_threads.
 	idx_t max_active_shards = 1;
 
+	// Live count of worker threads currently holding a shard (++ on claim, -- on
+	// release in Execute). Read at submit time to redistribute idle cores to
+	// survivors via `EffectiveShardThreads` once `next_shard_idx` shows all
+	// shards are claimed. Advisory only (never affects alignment results), so
+	// relaxed ordering is sufficient.
+	std::atomic<idx_t> active_workers {0};
+
+	// DuckDB thread-pool size, captured in InitGlobal. The ceiling for a
+	// survivor's bowtie2 `-p` when it grows to fill freed cores.
+	idx_t db_threads = 1;
+
 	idx_t MaxThreads() const override {
 		// DuckDB clamps to its own scheduler concurrency anyway, but
 		// returning the per-shard ceiling here keeps the planner honest
@@ -485,6 +496,7 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 	const idx_t db_threads = NumericCast<idx_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
 	const idx_t derived = (db_threads + bd.max_threads_per_shard - 1) / bd.max_threads_per_shard;
 	gs->max_active_shards = std::max<idx_t>(1, std::min<idx_t>(derived, bd.shards.size()));
+	gs->db_threads = db_threads;
 	return std::move(gs);
 }
 
@@ -645,9 +657,16 @@ bool FetchShardBatch(AlignBowtie2ShardedLocalState &local, const AlignBowtie2Sha
 }
 
 void SubmitAndDecode(AlignBowtie2ShardedLocalState &local, const AlignBowtie2ShardedBindData &bd,
-                     const bt2_daemon::QueryBatch &qb) {
+                     const AlignBowtie2ShardedGlobalState &gs, const bt2_daemon::QueryBatch &qb) {
 	const auto &shard = bd.shards[local.current_shard_idx];
-	const std::string config_json = BuildAlignConfigJson(bd.named_params, shard.index_prefix, bd.max_threads_per_shard);
+	// Once every shard has been handed out, surviving workers grow their `-p` to
+	// reclaim the cores that finished workers freed (see EffectiveShardThreads).
+	// Changing nthreads re-fingerprints this shard in the daemon (one warm
+	// ~60ms index reload), but it only steps up a bounded number of times.
+	const bool all_shards_claimed = gs.next_shard_idx.load(std::memory_order_relaxed) >= bd.shards.size();
+	const idx_t nthreads = EffectiveShardThreads(bd.max_threads_per_shard, gs.db_threads,
+	                                             gs.active_workers.load(std::memory_order_relaxed), all_shards_claimed);
+	const std::string config_json = BuildAlignConfigJson(bd.named_params, shard.index_prefix, nthreads);
 	bt2_daemon::QueryArrowSchema schema_flags {bd.query_has_sequence2, bd.query_has_qual1, bd.query_has_qual2};
 	const auto ipc = bt2_daemon::BuildQueryIpc(qb, schema_flags);
 	auto submit_result = local.session->Submit("bowtie2-align", config_json, ipc.data(), ipc.size());
@@ -739,12 +758,14 @@ void Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output
 		if (local.current_shard_idx != DConstants::INVALID_INDEX) {
 			bt2_daemon::QueryBatch qb;
 			if (FetchShardBatch(local, bd, qb)) {
-				SubmitAndDecode(local, bd, qb);
+				SubmitAndDecode(local, bd, gs, qb);
 				continue; // loop back to drain decoded rows
 			}
-			// Shard exhausted — release for re-claim attempt.
+			// Shard exhausted — release for re-claim attempt. Drop this worker
+			// from the active count so a surviving worker can grow its `-p`.
 			local.input_stream.reset();
 			local.current_shard_idx = DConstants::INVALID_INDEX;
+			gs.active_workers.fetch_sub(1, std::memory_order_relaxed);
 		}
 
 		// 3. Claim the next shard atomically. fetch_add is the entire
@@ -762,6 +783,10 @@ void Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output
 			return;
 		}
 		local.current_shard_idx = shard_idx;
+		// Count this worker as active for the duration of the shard (balanced by
+		// the fetch_sub on exhaustion above). Done only after a valid claim, so
+		// the failed-claim path that ends the worker never touches the count.
+		gs.active_workers.fetch_add(1, std::memory_order_relaxed);
 		OpenCurrentShardStream(local, bd);
 	}
 }

--- a/src/gpl_boundary/session.cpp
+++ b/src/gpl_boundary/session.cpp
@@ -26,7 +26,17 @@ namespace {
 // fast at session boot.
 constexpr int kRequiredProtocolVersion = 3;
 
-constexpr const char *kInitLine = R"({"init":{}})";
+// Pin the daemon's idle (stdin-silence) auto-shutdown to 60 minutes. Without
+// an explicit value the daemon defaults to 60s (GPL-boundary main.rs:
+// DEFAULT_IDLE_TIMEOUT_MS), which kills a live session whenever miint takes
+// >60s to hand off the next batch — e.g. the per-shard reads⋈read_to_shard
+// join blocking on its first chunk, or a slow per-shard index load. That
+// surfaces misleadingly as "WriteLine ... Broken pipe [daemon exited with
+// code 0]" on the *next* Submit. The daemon is already reaped deterministically
+// via PR_SET_PDEATHSIG (parent death) and Session::Shutdown / ~ChildProcess
+// SIGTERM, so the idle timer is only a backstop against a wedged-but-alive
+// miint; 60 min keeps that backstop while tolerating any realistic batch gap.
+constexpr const char *kInitLine = R"({"init":{"idle_timeout_ms":3600000}})";
 constexpr const char *kShutdownLine = R"({"shutdown":true})";
 
 // Get a string field from a yyjson object; returns empty string if absent

--- a/src/include/align_bowtie2_sharded.hpp
+++ b/src/include/align_bowtie2_sharded.hpp
@@ -5,6 +5,30 @@
 
 namespace duckdb {
 
+// Effective bowtie2 `-p` (nthreads) for one shard's batch submit. As worker
+// threads finish the tail of small shards and exit, the survivors should grow
+// their thread count to fill the cores those workers freed — otherwise a lone
+// big shard runs at the base `-p` with the rest of the box idle (measured: a
+// dominant shard pinned at -p4 leaves half an 8-core box unused for most of a
+// run). bowtie2's `-p` only partitions reads across threads, so the alignments
+// produced are independent of its value — this is a pure throughput knob.
+//
+// Gated on `all_shards_claimed`: while shards are still being handed out we keep
+// every worker at the base so nobody oversubscribes the workers about to claim
+// the rest. Once the last shard is claimed `active_workers` only decreases, so
+// the result is monotonic non-decreasing per surviving worker (bounded daemon
+// index reloads, no fingerprint flapping). Never drops below
+// `base_threads_per_shard` (the user's floor) and never exceeds `db_threads`
+// (the cores actually available).
+inline idx_t EffectiveShardThreads(idx_t base_threads_per_shard, idx_t db_threads, idx_t active_workers,
+                                   bool all_shards_claimed) {
+	if (!all_shards_claimed || active_workers == 0) {
+		return base_threads_per_shard;
+	}
+	const idx_t fair_share = db_threads / active_workers; // <= db_threads (active_workers >= 1)
+	return fair_share > base_threads_per_shard ? fair_share : base_threads_per_shard;
+}
+
 // align_bowtie2_sharded routes per-shard through the gpl-boundary daemon's
 // bowtie2-align tool. Each shard is a pre-built bowtie2 index on disk; the
 // table function visits shards sequentially, submitting that shard's

--- a/test/cpp/test_AlignBowtie2Sharded.cpp
+++ b/test/cpp/test_AlignBowtie2Sharded.cpp
@@ -1,0 +1,55 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "align_bowtie2_sharded.hpp"
+
+using duckdb::EffectiveShardThreads;
+using duckdb::idx_t;
+
+// EffectiveShardThreads decides bowtie2's `-p` (nthreads) for one shard's batch
+// submit. The intent: as worker threads finish the tail of small shards and
+// exit, the survivors should grow their thread count to fill the cores those
+// workers freed — but never before the work is fully distributed (else they
+// oversubscribe), and never below the user's configured floor. These tests
+// encode WHY each rule exists; flip any rule and one assertion must fail.
+
+TEST_CASE("EffectiveShardThreads: stays at base while shards still being handed out", "[bowtie2_sharded]") {
+	// While work is still being distributed, bumping a worker would oversubscribe
+	// the box against the workers about to claim the remaining shards. So the
+	// gate (all_shards_claimed=false) pins everyone to base, regardless of how
+	// few workers currently hold a shard.
+	REQUIRE(EffectiveShardThreads(/*base*/ 4, /*db*/ 8, /*active*/ 1, /*all_claimed*/ false) == 4);
+	REQUIRE(EffectiveShardThreads(4, 8, 2, false) == 4);
+}
+
+TEST_CASE("EffectiveShardThreads: sole survivor takes all cores once work is distributed", "[bowtie2_sharded]") {
+	// The core win: a lone big shard left running after the tail drains should
+	// use the whole box instead of idling half of it at the base `-p`.
+	REQUIRE(EffectiveShardThreads(4, 8, 1, true) == 8);
+}
+
+TEST_CASE("EffectiveShardThreads: multiple survivors keep base (cores already full)", "[bowtie2_sharded]") {
+	// Two survivors at base already saturate an 8-core box (2*4=8); bumping
+	// either would oversubscribe. Fair share (8/2=4) equals base → no change.
+	REQUIRE(EffectiveShardThreads(4, 8, 2, true) == 4);
+}
+
+TEST_CASE("EffectiveShardThreads: never drops below the configured floor", "[bowtie2_sharded]") {
+	// More live workers than cores can back at base would give a fair share
+	// below base (8/4=2), but base is the user's floor — honor it, don't shrink.
+	REQUIRE(EffectiveShardThreads(4, 8, 4, true) == 4);
+	// Floor also wins when the box has fewer cores than the configured `-p`
+	// (e.g. SET threads=1 with max_threads_per_shard=4): keep the user's value.
+	REQUIRE(EffectiveShardThreads(4, 1, 1, true) == 4);
+}
+
+TEST_CASE("EffectiveShardThreads: ramps with a finer base as survivors drop", "[bowtie2_sharded]") {
+	// With base=2 on an 8-core box the ramp is visible at >1 survivor:
+	REQUIRE(EffectiveShardThreads(2, 8, 4, true) == 2); // 8/4=2 == base
+	REQUIRE(EffectiveShardThreads(2, 8, 2, true) == 4); // 8/2=4 > base
+	REQUIRE(EffectiveShardThreads(2, 8, 1, true) == 8); // sole survivor
+}
+
+TEST_CASE("EffectiveShardThreads: zero active workers is a safe no-op", "[bowtie2_sharded]") {
+	// A transient read where no worker holds a shard must not divide by zero.
+	REQUIRE(EffectiveShardThreads(4, 8, 0, true) == 4);
+}

--- a/test/sql/align_bowtie2_sharded.test
+++ b/test/sql/align_bowtie2_sharded.test
@@ -351,6 +351,103 @@ statement ok
 DROP TABLE paired_mapping;
 
 # ==============================================================================
+# SUBMIT_BATCH_READS PARAMETER TESTS
+# ==============================================================================
+# submit_batch_reads controls how many reads are accumulated into one daemon
+# Submit. It is a throughput knob ONLY — alignment results must be identical
+# regardless of its value (each read is aligned independently). This fixture is
+# tiny (3 reads, one DuckDB chunk) so it can only verify param acceptance +
+# tiny-case invariance + range validation; multi-chunk accumulation invariance
+# is covered by the CLI script in scratch/ against the large bench data.
+
+# Invariance: a small batch size yields the same alignments as the default.
+query II
+SELECT read_id, reference
+FROM align_bowtie2_sharded('queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard',
+    submit_batch_reads := 1,
+    max_secondary := 0)
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+query1	ref1
+query2	ref2
+
+# Invariance: a large batch size yields the same alignments.
+query II
+SELECT read_id, reference
+FROM align_bowtie2_sharded('queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard',
+    submit_batch_reads := 100000,
+    max_secondary := 0)
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+query1	ref1
+query2	ref2
+
+# Range validation: too low
+statement error
+SELECT * FROM align_bowtie2_sharded('queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard',
+    submit_batch_reads := 0);
+----
+submit_batch_reads must be between 1 and 1000000
+
+# Range validation: too high
+statement error
+SELECT * FROM align_bowtie2_sharded('queries',
+    shard_directory := 'data/bowtie2_shards/',
+    read_to_shard := 'read_to_shard',
+    submit_batch_reads := 2000000);
+----
+submit_batch_reads must be between 1 and 1000000
+
+# Multi-chunk accumulation invariance: 5000 reads (> STANDARD_VECTOR_SIZE=2048)
+# so FetchShardBatch accumulates several chunks per Submit. This is the core new
+# code path; the tiny fixture above is a single chunk and can't exercise it.
+# Assert batch=1 (one chunk/Submit, ~3 submits) and batch=8192 (one Submit)
+# produce IDENTICAL output multisets and are non-empty — without hard-coding the
+# alignment count (which would be a guessed expected value).
+statement ok
+CREATE TABLE big_queries AS
+  SELECT 'r' || i AS read_id,
+         'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT' AS sequence1
+  FROM range(5000) t(i);
+
+statement ok
+CREATE TABLE big_mapping AS SELECT read_id, 'shard_a' AS shard_name FROM big_queries;
+
+statement ok
+CREATE TEMP TABLE mc_a AS
+  SELECT read_id, flags, reference, position, cigar
+  FROM align_bowtie2_sharded('big_queries', shard_directory := 'data/bowtie2_shards/',
+       read_to_shard := 'big_mapping', submit_batch_reads := 1, max_secondary := 0);
+
+statement ok
+CREATE TEMP TABLE mc_b AS
+  SELECT read_id, flags, reference, position, cigar
+  FROM align_bowtie2_sharded('big_queries', shard_directory := 'data/bowtie2_shards/',
+       read_to_shard := 'big_mapping', submit_batch_reads := 8192, max_secondary := 0);
+
+query I
+SELECT (SELECT count(*) FROM mc_a) > 0
+   AND (SELECT count(*) FROM mc_a) = (SELECT count(*) FROM mc_b)
+   AND (SELECT count(*) FROM (SELECT * FROM mc_a EXCEPT ALL SELECT * FROM mc_b)) = 0
+   AND (SELECT count(*) FROM (SELECT * FROM mc_b EXCEPT ALL SELECT * FROM mc_a)) = 0;
+----
+true
+
+statement ok
+DROP TABLE big_queries;
+
+statement ok
+DROP TABLE big_mapping;
+
+# ==============================================================================
 # CLEANUP
 # ==============================================================================
 


### PR DESCRIPTION
Three changes to `align_bowtie2_sharded` throughput + daemon robustness, stacked smallest-blast-radius first.

## Commits

### `8d4cf3f` fix(gpl_boundary): pin daemon idle timeout to 60min
Root cause of `WriteLine ... Broken pipe [daemon exited with code 0]` in production: gpl-boundary's 60s stdin-silence idle timeout fired during a >60s gap between batches. miint now sends `{"init":{"idle_timeout_ms":3600000}}` instead of bare `{"init":{}}`. **Confirmed fixed in production.**

### `7dcdb2d` perf: batch reads per daemon Submit (`submit_batch_reads`)
bowtie2's `driver<T>()` reloads the FM-index every Submit. Accumulating whole DuckDB chunks up to `submit_batch_reads` (default 16384) before each Submit cuts the reload count, so the per-batch reload tax drops from ~35% to ~1-2%. **~2.8× faster** on the 4-bucket bench (daemon 3.3→6.8 of 8 cores). Output is identical to any batch size (each read aligns independently); verified by a multi-chunk EXCEPT-ALL invariance test.

### `ca7ac10` perf: ramp bowtie2 `-p` for surviving shards to fill idle cores
On a skewed shard-size distribution (a few big shards + a long tail of tiny ones, or one dominant host genome — the common metagenomic-classification shape), the last big shard runs **alone at `max_threads_per_shard` while the rest of the box sits idle**. A long tail of tiny shards is already hidden under the big shard's runtime, so draining it faster does nothing; the lone big shard pinned at the base `-p` is the bottleneck.

Once every shard is claimed, surviving workers grow their `-p` to reclaim cores freed by finished workers:
```
nthreads = clamp(db_threads / active_workers, max_threads_per_shard, db_threads)
```
Gated on "all shards claimed" so `active_workers` only decreases → `nthreads` is monotonic non-decreasing per surviving worker (bounded daemon index reloads, no fingerprint flapping, no oversubscription since Σ`-p` ≈ db_threads). Changing `nthreads` re-fingerprints the shard in the daemon (one warm ~60ms `--mm` reload), amortized over the survivor's remaining reads.

`-p` only partitions reads across threads, so alignments are unchanged — verified threads=8 (ramp active) vs threads=1 ground truth produce **byte-identical output** (7,127,029 alignments, 0 diff either direction). Core decision is the pure function `EffectiveShardThreads` (unit-tested, 6 cases); `active_workers` is an atomic `++`/`--` on shard claim/release.

## Benchmarks (warm, THREADS=8, MAX_TPS=4)

`-p` ramp vs fixed `-p4`:

| workload | fixed `-p4` | adaptive | gain |
|---|---|---|---|
| balanced 4-shard | 17.6s | 16.2s | ~8% |
| 2-big + 12-tiny | 42.8s | 39.8s | ~7% |
| 1-dominant + 100-tiny | 63.5s | 47.0s | **~26%** |

No regression on any shape; the ramp only adds threads to survivors when cores are free.

## Testing
- `EffectiveShardThreads` unit tests (6 cases / 10 assertions)
- bowtie2 SQL suite: `simple_bowtie2`, `align_bowtie2`, `align_bowtie2_sharded{,_bigint,_uuid}`, `miint_warnings_bowtie2`, `bowtie2_available` — all pass
- output-invariance (threads=8 adaptive vs threads=1 ground truth): 0 diff
- batch-size invariance (Phase 1): committed multi-chunk EXCEPT-ALL test
- `make format-check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)