### PR TITLE
fix(macros): register macros in system catalog so read-only databases load

### DIFF
--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -2,6 +2,9 @@
 
 #include "duckdb.hpp"
 #include "duckdb/main/extension_helper.hpp"
+#include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/statement/create_statement.hpp"
+#include "duckdb/parser/parsed_data/create_macro_info.hpp"
 
 namespace duckdb {
 
@@ -716,14 +719,31 @@ const std::string GENOME_COVERAGE = // NOLINT
 class MIINTMacros {
 public:
 	static void Register(ExtensionLoader &loader) {
-		auto &instance = loader.GetDatabaseInstance();
-		Connection con(instance);
-
+		// Register macros into the system catalog (like DuckDB's built-in macros)
+		// rather than executing CREATE statements against the default catalog.
+		// The default catalog may be a database the user attached read-only, in
+		// which case a CREATE would abort extension load with an internal error.
+		// The system catalog is always writable and resolves across all catalogs.
 		auto register_macro = [&](const std::string &sql, const char *name) {
-			auto result = con.Query(sql);
-			if (result->HasError()) {
-				throw InternalException("Failed to register macro '%s': %s", name, result->GetError());
+			Parser parser;
+			parser.ParseQuery(sql);
+			if (parser.statements.size() != 1 || parser.statements[0]->type != StatementType::CREATE_STATEMENT) {
+				throw InternalException("Failed to register macro '%s': expected a single CREATE statement", name);
 			}
+			auto &create = parser.statements[0]->Cast<CreateStatement>();
+			if (create.info->type != CatalogType::MACRO_ENTRY && create.info->type != CatalogType::TABLE_MACRO_ENTRY) {
+				throw InternalException("Failed to register macro '%s': not a macro definition", name);
+			}
+			auto &macro_info = create.info->Cast<CreateMacroInfo>();
+			// Pin to the system catalog's default schema. RegisterFunction targets
+			// the system catalog directly; the parsed statement leaves the schema
+			// empty, which GetSchema would otherwise fail to resolve there.
+			macro_info.schema = DEFAULT_SCHEMA;
+			// The system catalog only accepts internal entries (same as built-in
+			// macros and RegisterType). Mark accordingly.
+			macro_info.internal = true;
+			macro_info.temporary = true;
+			loader.RegisterFunction(macro_info);
 		};
 
 		register_macro(MIINT_WARNINGS, "miint_warnings");

--- a/test/sql/read_only_load.test
+++ b/test/sql/read_only_load.test
@@ -1,0 +1,41 @@
+# name: test/sql/read_only_load.test
+# description: miint must load into a read-only database; macros register in the system catalog, not the read-only default catalog
+# group: [sql]
+
+require miint
+
+# Create a persistent database file we can later reopen read-only.
+load __TEST_DIR__/miint_readonly.db
+
+statement ok
+CREATE TABLE t(i INTEGER);
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3);
+
+# Reopen the same file read-only. This re-loads miint into a database that is
+# attached in read-only mode. Macro registration must target the (always
+# writable) system catalog instead of the read-only default catalog; otherwise
+# extension load aborts with:
+#   INTERNAL Error: Failed to register macro 'miint_warnings': ...
+#   Cannot execute statement of type "CREATE" on database ... attached in read-only mode!
+load __TEST_DIR__/miint_readonly.db readonly
+
+# The committed data is still readable.
+query I
+SELECT count(*) FROM t;
+----
+3
+
+# A table macro registered by the extension resolves and runs even though the
+# default catalog is read-only.
+query I
+SELECT count(*) FROM miint_warnings();
+----
+0
+
+# A scalar macro is likewise callable.
+query I
+SELECT cardinality(parse_gff_attributes('a=1;b=2'));
+----
+2


### PR DESCRIPTION
## Problem

Opening (or attaching) a database **read-only** aborts extension load with an internal error:

```
INTERNAL Error: Failed to register macro 'miint_warnings': Invalid Input Error:
Cannot execute statement of type "CREATE" on database "bench" which is attached
in read-only mode!
```

Reproduce:

```bash
duckdb /tmp/x.db -c "CREATE TABLE t(i INTEGER);"   # create a file
duckdb -readonly /tmp/x.db -c "SELECT 42;"          # boom — extension load fails
```

## Root cause

`MIINTMacros::Register` opened a `Connection` and ran `CREATE OR REPLACE MACRO …`
for every macro. Those `CREATE` statements resolve against the **default** catalog.
When the default catalog is a read-only database, the very first macro
(`miint_warnings`) fails and aborts the entire extension load.

## Fix

Register the macros into the **system catalog** — exactly where DuckDB's built-in
macros and this extension's own C++ functions already live — instead of executing
`CREATE` against the default catalog.

Each macro SQL string is parsed into a `CreateMacroInfo`, pinned to `system.main`,
marked `internal`/`temporary` (the system catalog only accepts internal entries),
and registered via `loader.RegisterFunction(macro_info)`. The system catalog is
always writable and resolves across all attached catalogs, independent of
read-only mode. The macro SQL definitions themselves are unchanged.

### Behavioral notes
- Macros remain discoverable in `duckdb_functions()` (now reported under `system.main`).
- They become non-droppable `internal` entries (matching built-in macros), but can
  still be **shadowed** by a user-defined macro of the same name in their own database.

## Test

Adds `test/sql/read_only_load.test`: create a file DB, reopen it `readonly`
(which re-loads miint into a read-only catalog), then assert a table macro
(`miint_warnings()`) and a scalar macro (`parse_gff_attributes`) resolve and run.
**Red** before the fix (extension load throws), **green** after.

## Verification
- New regression test: red → green.
- Original manual repro (`duckdb -readonly …`) now works.
- Full SQL suite (`run_tests.sh`, incl. 43 macro-using test files) + HTTPS + shell tests pass.
- `make format-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)