### PR TITLE
docs(uchime): drop the stale WFA2 mention

### DIFF
--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -134,8 +134,7 @@ SOFTWARE.
 ## WFA2-lib
 
 Pairwise sequence alignment using the Wavefront Alignment Algorithm (WFA).
-Used by `align_pairwise_wfa2_score`, `align_pairwise_wfa2_cigar`, `align_pairwise_wfa2_full`,
-`uchime_ref`, and `uchime_denovo`.
+Used by `align_pairwise_wfa2_score`, `align_pairwise_wfa2_cigar`, and `align_pairwise_wfa2_full`.
 
 - Repository: https://github.com/smarco/WFA2-lib
 - Version: v2.3.5

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -2845,7 +2845,7 @@ SELECT flag, count(*) FROM detect_chimera_uchime('queries', db:='refs') GROUP BY
 
 **Algorithm:**
 1. For each query, partition into 4 chunks and search the reference DB using an 8-mer index for candidate parents (up to 16)
-2. Align query to each candidate using WFA2 global alignment
+2. Align query to each candidate using vsearch's SIMD-optimized Needleman-Wunsch global alignment
 3. Select the 2 best parents via smoothed identity (32bp sliding window)
 4. Build a 3-way star alignment and classify each column (match-A, match-B, no-vote, abstain)
 5. Sweep all breakpoints left-to-right, computing h-score at each position


### PR DESCRIPTION
Fixes #53.

Two spots still said UCHIME used WFA2, left over from when it was being reimplemented in-tree before we switched to vsearch. The actual aligner is vsearch's SIMD-NW.

- `docs/table-functions.md` algorithm step 2 now names vsearch's aligner.
- `THIRD_PARTY_LICENSES.md` WFA2-lib "Used by" list drops `uchime_ref` / `uchime_denovo` — they're already attributed under VSEARCH below.