### PR TITLE
fix(rype): return read_id in the id_column's storage type, not always VARCHAR

### DIFF
--- a/src/include/rype_classify.hpp
+++ b/src/include/rype_classify.hpp
@@ -27,7 +27,8 @@ public:
 		std::string id_column;
 		double threshold;
 		std::string negative_index_path;
-		bool has_sequence2 = false; // Cached from ValidateSequenceTable
+		bool has_sequence2 = false;                                // Cached from ValidateSequenceTable
+		LogicalType id_type = LogicalType(LogicalTypeId::INVALID); // Storage type of id_column; drives read_id output
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;

--- a/src/include/rype_common.hpp
+++ b/src/include/rype_common.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "rype.h"
+#include "id_column_utils.hpp"
 
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
@@ -76,12 +77,21 @@ inline size_t SampleAvgReadLength(Connection &conn, const std::string &table_quo
 	return fallback;
 }
 
-//! Look up a table or view by name and return its column names, lowercased.
-//! Throws BinderException if the entry does not exist or is not a table/view.
-//! `role` names the entry in the "does not exist" message (e.g. "Table or view",
-//! "chunk table"), so callers can produce role-specific diagnostics.
-inline vector<string> GetTableColumnNamesLower(ClientContext &context, const std::string &table_name,
-                                               const std::string &role = "Table or view") {
+//! Column names (lowercased) and their storage types for a table/view,
+//! index-aligned. The single backing query for both GetTableColumnNamesLower
+//! and the id-type capture in ValidateSequenceTable.
+struct LowercasedColumns {
+	vector<string> names;
+	vector<LogicalType> types;
+};
+
+//! Look up a table or view by name and return its column names (lowercased) and
+//! types, index-aligned. Throws BinderException if the entry does not exist or
+//! is not a table/view. `role` names the entry in the "does not exist" message
+//! (e.g. "Table or view", "chunk table"), so callers can produce role-specific
+//! diagnostics.
+inline LowercasedColumns GetTableColumnsLower(ClientContext &context, const std::string &table_name,
+                                              const std::string &role = "Table or view") {
 	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, table_name, QueryErrorContext());
 	auto entry = Catalog::GetEntry(context, INVALID_CATALOG, INVALID_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
 
@@ -89,45 +99,80 @@ inline vector<string> GetTableColumnNamesLower(ClientContext &context, const std
 		throw BinderException("%s '%s' does not exist", role, table_name);
 	}
 
-	vector<string> col_names;
+	LowercasedColumns cols;
 	if (entry->type == CatalogType::TABLE_ENTRY) {
 		auto &table = entry->Cast<TableCatalogEntry>();
 		auto &columns = table.GetColumns();
 		for (idx_t i = 0; i < columns.LogicalColumnCount(); i++) {
-			col_names.push_back(StringUtil::Lower(columns.GetColumn(LogicalIndex(i)).Name()));
+			auto &col = columns.GetColumn(LogicalIndex(i));
+			cols.names.push_back(StringUtil::Lower(col.Name()));
+			cols.types.push_back(col.Type());
 		}
 	} else if (entry->type == CatalogType::VIEW_ENTRY) {
 		auto &view = entry->Cast<ViewCatalogEntry>();
 		view.BindView(context);
 		auto col_info = view.GetColumnInfo();
-		for (const auto &name : col_info->names) {
-			col_names.push_back(StringUtil::Lower(name));
+		for (idx_t i = 0; i < col_info->names.size(); i++) {
+			cols.names.push_back(StringUtil::Lower(col_info->names[i]));
+			cols.types.push_back(col_info->types[i]);
 		}
 	} else {
 		throw BinderException("'%s' is not a table or view", table_name);
 	}
-	return col_names;
+	return cols;
 }
 
-//! Validate that a table/view exists and has the required columns for RYpe functions.
-//! Returns true if the optional "sequence2" column is present (used by rype_classify
-//! for paired-end reads). All RYpe functions require id_column and "sequence1".
-inline bool ValidateSequenceTable(ClientContext &context, const std::string &table_name, const std::string &id_column) {
-	auto col_names = GetTableColumnNamesLower(context, table_name);
+//! Look up a table or view by name and return its column names, lowercased.
+//! Throws BinderException if the entry does not exist or is not a table/view.
+//! `role` names the entry in the "does not exist" message (e.g. "Table or view",
+//! "chunk table"), so callers can produce role-specific diagnostics.
+inline vector<string> GetTableColumnNamesLower(ClientContext &context, const std::string &table_name,
+                                               const std::string &role = "Table or view") {
+	return GetTableColumnsLower(context, table_name, role).names;
+}
+
+//! Result of validating a RYpe sequence table: whether the optional "sequence2"
+//! column is present (paired-end, used by rype_classify/rype_log_ratio) and the
+//! storage type of the id column.
+struct RypeSequenceTableInfo {
+	bool has_sequence2 = false;
+	LogicalType id_type = LogicalType(LogicalTypeId::INVALID);
+};
+
+//! Validate that a table/view exists and has the required columns for RYpe
+//! functions. Reports whether the optional "sequence2" column is present and the
+//! id column's storage type. All RYpe functions require id_column and
+//! "sequence1". The id column must be VARCHAR, BIGINT, or UUID — RYpe carries
+//! ids as strings internally and emits them back in their SQL storage type, so
+//! only the codec-supported set round-trips losslessly; anything else is
+//! rejected loud at bind, matching align_minimap2 and the rest of the id-aware
+//! tree.
+inline RypeSequenceTableInfo ValidateSequenceTable(ClientContext &context, const std::string &table_name,
+                                                   const std::string &id_column) {
+	auto cols = GetTableColumnsLower(context, table_name);
+	auto &col_names = cols.names;
 
 	auto id_col_lower = StringUtil::Lower(id_column);
-	bool has_id = std::find(col_names.begin(), col_names.end(), id_col_lower) != col_names.end();
+	auto id_it = std::find(col_names.begin(), col_names.end(), id_col_lower);
 	bool has_seq1 = std::find(col_names.begin(), col_names.end(), "sequence1") != col_names.end();
 	bool has_seq2 = std::find(col_names.begin(), col_names.end(), "sequence2") != col_names.end();
 
-	if (!has_id) {
+	if (id_it == col_names.end()) {
 		throw BinderException("Table '%s' missing required column '%s'", table_name, id_column);
 	}
 	if (!has_seq1) {
 		throw BinderException("Table '%s' missing required column 'sequence1'", table_name);
 	}
 
-	return has_seq2;
+	RypeSequenceTableInfo info;
+	info.has_sequence2 = has_seq2;
+	info.id_type = cols.types[static_cast<size_t>(std::distance(col_names.begin(), id_it))];
+
+	if (!IsAllowedIdType(info.id_type)) {
+		throw BinderException("Column '%s' in table '%s' must be %s", id_column, table_name, AllowedIdTypeList());
+	}
+
+	return info;
 }
 
 //! Validate that a table/view exists and contains every column in
@@ -213,7 +258,12 @@ inline std::string MaterializeRypeInputTempTable(Connection &conn, const std::st
 	auto &id_materialized = id_result->Cast<MaterializedQueryResult>();
 	while (auto chunk = id_materialized.Fetch()) {
 		for (idx_t i = 0; i < chunk->size(); i++) {
-			out_read_ids.push_back(chunk->data[0].GetValue(i).ToString());
+			// Carry a NULL id as the empty string, not Value::ToString()'s literal
+			// "NULL". The egress codec (EmitIdCell) maps the empty carrier to SQL
+			// NULL for BIGINT/UUID — matching align_minimap2 — rather than throwing
+			// mid-stream on an unparseable "NULL"; VARCHAR emits the empty string.
+			auto id_val = chunk->data[0].GetValue(i);
+			out_read_ids.push_back(id_val.IsNull() ? std::string() : id_val.ToString());
 		}
 	}
 

--- a/src/include/rype_extract.hpp
+++ b/src/include/rype_extract.hpp
@@ -28,6 +28,7 @@ struct RypeExtractData : public TableFunctionData {
 	size_t k;
 	size_t w;
 	uint64_t salt;
+	LogicalType id_type = LogicalType(LogicalTypeId::INVALID); // Storage type of id_column; drives read_id output
 
 	std::vector<std::string> names;
 	std::vector<LogicalType> types;

--- a/src/include/rype_log_ratio.hpp
+++ b/src/include/rype_log_ratio.hpp
@@ -28,6 +28,7 @@ public:
 		std::string id_column;
 		double skip_threshold;
 		bool has_sequence2 = false;
+		LogicalType id_type = LogicalType(LogicalTypeId::INVALID); // Storage type of id_column; drives read_id output
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;

--- a/src/rype_classify.cpp
+++ b/src/rype_classify.cpp
@@ -100,9 +100,13 @@ unique_ptr<FunctionData> RypeClassifyTableFunction::Bind(ClientContext &context,
 	// missing paths, invalid formats, and corrupted indices. Early validation here
 	// would create TOCTOU race conditions and duplicate RYpe's validation logic.
 
-	// Validate sequence table exists and has required columns
-	// Cache whether sequence2 exists to avoid querying information_schema later
-	data->has_sequence2 = ValidateSequenceTable(context, data->sequence_table, data->id_column);
+	// Validate sequence table exists and has required columns. Cache whether
+	// sequence2 exists, and capture the id column's storage type so read_id
+	// mirrors it on output (BIGINT/UUID/VARCHAR) instead of always VARCHAR.
+	auto table_info = ValidateSequenceTable(context, data->sequence_table, data->id_column);
+	data->has_sequence2 = table_info.has_sequence2;
+	data->id_type = table_info.id_type;
+	data->types[0] = data->id_type;
 
 	// Set output schema
 	for (const auto &name : data->names) {
@@ -238,6 +242,7 @@ unique_ptr<LocalTableFunctionState> RypeClassifyTableFunction::InitLocal(Executi
 void RypeClassifyTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
 	auto &lstate = data_p.local_state->Cast<LocalState>();
+	auto &bind_data = data_p.bind_data->Cast<Data>();
 
 	// No mutex needed - MaxThreads() returns 1, enforcing single-threaded execution
 
@@ -301,8 +306,7 @@ void RypeClassifyTableFunction::Execute(ClientContext &context, TableFunctionInp
 			throw IOException("RYpe returned invalid query_id %lld (expected 0-%zu)", static_cast<long long>(query_id),
 			                  gstate.read_ids.size() - 1);
 		}
-		FlatVector::GetData<string_t>(output.data[0])[i] =
-		    StringVector::AddString(output.data[0], gstate.read_ids[query_id]);
+		EmitIdCell(output.data[0], i, gstate.read_ids[query_id], bind_data.id_type);
 
 		// Column 2: bucket_name (lookup from index using bucket_id)
 		uint32_t bucket_id = bucket_ids[array_idx + bucket_id_array.offset];

--- a/src/rype_extract.cpp
+++ b/src/rype_extract.cpp
@@ -71,7 +71,10 @@ static unique_ptr<RypeExtractData> BindExtraction(ClientContext &context, TableF
 		data->id_column = id_col_param->second.ToString();
 	}
 
-	ValidateSequenceTable(context, data->sequence_table, data->id_column);
+	// Capture the id column's storage type so read_id mirrors it on output
+	// (BIGINT/UUID/VARCHAR) instead of always VARCHAR. Extraction is single-end,
+	// so has_sequence2 is irrelevant here.
+	data->id_type = ValidateSequenceTable(context, data->sequence_table, data->id_column).id_type;
 
 	return data;
 }
@@ -135,7 +138,7 @@ BuildExtractionInputStream(ClientContext &context, const RypeExtractData &bind_d
 // Column 0 (id → read_id) requires manual transformation.
 // num_list_cols is the number of list columns starting at index 1.
 static void ExecuteExtraction(RypeExtractGlobalState &gstate, RypeExtractLocalState &lstate, DataChunk &output,
-                              idx_t num_list_cols) {
+                              idx_t num_list_cols, const LogicalType &id_type) {
 	if (gstate.done) {
 		output.SetCardinality(0);
 		return;
@@ -169,7 +172,7 @@ static void ExecuteExtraction(RypeExtractGlobalState &gstate, RypeExtractLocalSt
 	idx_t to_output = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
 	output.SetCardinality(to_output);
 
-	// Column 0: id (Int64) → read_id (VARCHAR) — manual transformation.
+	// Column 0: id (Int64) → read_id (mirrors id_column type) — manual transformation.
 	// Offset calculation follows rype_classify pattern: parent batch offset + child array offset.
 	auto &id_array = *batch.children[0];
 	if (!id_array.buffers[1]) {
@@ -185,8 +188,7 @@ static void ExecuteExtraction(RypeExtractGlobalState &gstate, RypeExtractLocalSt
 			throw IOException("RYpe returned invalid query_id %lld (expected 0-%zu)", static_cast<long long>(query_id),
 			                  gstate.read_ids.size() - 1);
 		}
-		FlatVector::GetData<string_t>(output.data[0])[i] =
-		    StringVector::AddString(output.data[0], gstate.read_ids[query_id]);
+		EmitIdCell(output.data[0], i, gstate.read_ids[query_id], id_type);
 	}
 
 	// Columns 1..N: List<UInt64> — use DuckDB's built-in Arrow-to-DuckDB conversion.
@@ -219,8 +221,7 @@ unique_ptr<FunctionData> RypeExtractMinimizerSetTableFunction::Bind(ClientContex
 	auto data = BindExtraction(context, input, "rype_extract_minimizer_set");
 
 	data->names = {"read_id", "fwd_set", "rc_set"};
-	data->types = {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::UBIGINT),
-	               LogicalType::LIST(LogicalType::UBIGINT)};
+	data->types = {data->id_type, LogicalType::LIST(LogicalType::UBIGINT), LogicalType::LIST(LogicalType::UBIGINT)};
 
 	for (const auto &name : data->names) {
 		names.emplace_back(name);
@@ -276,8 +277,9 @@ void RypeExtractMinimizerSetTableFunction::Execute(ClientContext &context, Table
                                                    DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<RypeExtractGlobalState>();
 	auto &lstate = data_p.local_state->Cast<RypeExtractLocalState>();
+	auto &bind_data = data_p.bind_data->Cast<RypeExtractData>();
 	// Output: read_id, fwd_set, rc_set → 2 list columns
-	ExecuteExtraction(gstate, lstate, output, 2);
+	ExecuteExtraction(gstate, lstate, output, 2, bind_data.id_type);
 }
 
 TableFunction RypeExtractMinimizerSetTableFunction::GetFunction() {
@@ -302,9 +304,8 @@ unique_ptr<FunctionData> RypeExtractStrandMinimizersTableFunction::Bind(ClientCo
 	auto data = BindExtraction(context, input, "rype_extract_strand_minimizers");
 
 	data->names = {"read_id", "fwd_hashes", "fwd_positions", "rc_hashes", "rc_positions"};
-	data->types = {LogicalType::VARCHAR, LogicalType::LIST(LogicalType::UBIGINT),
-	               LogicalType::LIST(LogicalType::UBIGINT), LogicalType::LIST(LogicalType::UBIGINT),
-	               LogicalType::LIST(LogicalType::UBIGINT)};
+	data->types = {data->id_type, LogicalType::LIST(LogicalType::UBIGINT), LogicalType::LIST(LogicalType::UBIGINT),
+	               LogicalType::LIST(LogicalType::UBIGINT), LogicalType::LIST(LogicalType::UBIGINT)};
 
 	for (const auto &name : data->names) {
 		names.emplace_back(name);
@@ -359,8 +360,9 @@ void RypeExtractStrandMinimizersTableFunction::Execute(ClientContext &context, T
                                                        DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<RypeExtractGlobalState>();
 	auto &lstate = data_p.local_state->Cast<RypeExtractLocalState>();
+	auto &bind_data = data_p.bind_data->Cast<RypeExtractData>();
 	// Output: read_id, fwd_hashes, fwd_positions, rc_hashes, rc_positions → 4 list columns
-	ExecuteExtraction(gstate, lstate, output, 4);
+	ExecuteExtraction(gstate, lstate, output, 4, bind_data.id_type);
 }
 
 TableFunction RypeExtractStrandMinimizersTableFunction::GetFunction() {

--- a/src/rype_log_ratio.cpp
+++ b/src/rype_log_ratio.cpp
@@ -95,8 +95,13 @@ unique_ptr<FunctionData> RypeLogRatioTableFunction::Bind(ClientContext &context,
 		}
 	}
 
-	// Validate sequence table exists and has required columns
-	data->has_sequence2 = ValidateSequenceTable(context, data->sequence_table, data->id_column);
+	// Validate sequence table exists and has required columns. Capture the id
+	// column's storage type so read_id mirrors it on output (BIGINT/UUID/VARCHAR)
+	// instead of always VARCHAR.
+	auto table_info = ValidateSequenceTable(context, data->sequence_table, data->id_column);
+	data->has_sequence2 = table_info.has_sequence2;
+	data->id_type = table_info.id_type;
+	data->types[0] = data->id_type;
 
 	// Set output schema
 	for (const auto &name : data->names) {
@@ -230,6 +235,7 @@ unique_ptr<LocalTableFunctionState> RypeLogRatioTableFunction::InitLocal(Executi
 void RypeLogRatioTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
 	auto &gstate = data_p.global_state->Cast<GlobalState>();
 	auto &lstate = data_p.local_state->Cast<LocalState>();
+	auto &bind_data = data_p.bind_data->Cast<Data>();
 
 	if (gstate.done) {
 		output.SetCardinality(0);
@@ -288,8 +294,7 @@ void RypeLogRatioTableFunction::Execute(ClientContext &context, TableFunctionInp
 			throw IOException("RYpe returned invalid query_id %lld (expected 0-%zu)", static_cast<long long>(query_id),
 			                  gstate.read_ids.size() - 1);
 		}
-		FlatVector::GetData<string_t>(output.data[0])[i] =
-		    StringVector::AddString(output.data[0], gstate.read_ids[query_id]);
+		EmitIdCell(output.data[0], i, gstate.read_ids[query_id], bind_data.id_type);
 	}
 
 	// --- Column 1 (log_ratio) and Column 2 (fast_path): zero-copy via Arrow conversion ---

--- a/test/sql/rype_classify_bigint.test
+++ b/test/sql/rype_classify_bigint.test
@@ -1,0 +1,131 @@
+# name: test/sql/rype_classify_bigint.test
+# description: rype_classify mirrors the id_column type (BIGINT/UUID) on read_id, matching align_minimap2.
+# group: [sql]
+
+#   Before the fix rype_classify always returned read_id as VARCHAR, even for a
+#   BIGINT id_column — inconsistent with align_minimap2 and the rest of the id-
+#   aware tree. read_id must now mirror the input column's storage type, and the
+#   adversarial int64 values (2^53+1, int64 max) prove the round-trip is exact,
+#   not a lossy float detour.
+
+require miint
+
+# --- BIGINT id_column: read_id comes back BIGINT and round-trips exactly ---
+statement ok
+CREATE TABLE seq_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_bigint VALUES
+    (9007199254740993, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (9223372036854775807, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+query T
+SELECT DISTINCT typeof(read_id)
+FROM rype_classify('data/rype/test.ryxdi', 'seq_bigint', threshold := 0.05);
+----
+BIGINT
+
+query I
+SELECT DISTINCT read_id
+FROM rype_classify('data/rype/test.ryxdi', 'seq_bigint', threshold := 0.05)
+ORDER BY read_id;
+----
+9007199254740993
+9223372036854775807
+
+# --- UUID id_column: read_id mirrors UUID and round-trips the full INT128 range ---
+statement ok
+CREATE TABLE seq_uuid (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_uuid VALUES
+    ('00000000-0000-0000-0000-000000000001', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('ffffffff-ffff-ffff-ffff-ffffffffffff', 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+query T
+SELECT DISTINCT typeof(read_id)
+FROM rype_classify('data/rype/test.ryxdi', 'seq_uuid', threshold := 0.05);
+----
+UUID
+
+query I
+SELECT DISTINCT read_id
+FROM rype_classify('data/rype/test.ryxdi', 'seq_uuid', threshold := 0.05)
+ORDER BY read_id;
+----
+00000000-0000-0000-0000-000000000001
+ffffffff-ffff-ffff-ffff-ffffffffffff
+
+# --- VARCHAR id_column: unchanged (read_id stays VARCHAR) ---
+statement ok
+CREATE TABLE seq_varchar AS SELECT CAST(read_id AS VARCHAR) AS read_id, sequence1 FROM seq_bigint;
+
+query T
+SELECT DISTINCT typeof(read_id)
+FROM rype_classify('data/rype/test.ryxdi', 'seq_varchar', threshold := 0.05);
+----
+VARCHAR
+
+# --- Disallowed id types are rejected at bind (matches align_minimap2) ---
+statement ok
+CREATE TABLE seq_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_hugeint VALUES (1, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+statement error
+SELECT * FROM rype_classify('data/rype/test.ryxdi', 'seq_hugeint', threshold := 0.05);
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- NULL ids emit SQL NULL instead of aborting the query. A NULL id is carried
+#     as the empty string on ingress, which the id codec resolves to SQL NULL for
+#     BIGINT/UUID — matching align_minimap2 rather than throwing mid-stream. ---
+statement ok
+CREATE TABLE seq_bigint_null (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_bigint_null VALUES
+    (NULL, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (42, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+query II
+SELECT
+    COUNT(*) FILTER (WHERE read_id IS NULL) > 0 AS has_null_read_id,
+    COUNT(*) FILTER (WHERE read_id = 42) > 0 AS has_id_42
+FROM rype_classify('data/rype/test.ryxdi', 'seq_bigint_null', threshold := 0.05);
+----
+true	true
+
+statement ok
+DROP TABLE seq_bigint_null;
+
+statement ok
+CREATE TABLE seq_uuid_null (read_id UUID, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_uuid_null VALUES
+    (NULL, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('00000000-0000-0000-0000-00000000002a', 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+query I
+SELECT COUNT(*) FILTER (WHERE read_id IS NULL) > 0 AS has_null_read_id
+FROM rype_classify('data/rype/test.ryxdi', 'seq_uuid_null', threshold := 0.05);
+----
+true
+
+statement ok
+DROP TABLE seq_uuid_null;
+
+# --- Cleanup ---
+statement ok
+DROP TABLE seq_bigint;
+
+statement ok
+DROP TABLE seq_uuid;
+
+statement ok
+DROP TABLE seq_varchar;
+
+statement ok
+DROP TABLE seq_hugeint;

--- a/test/sql/rype_extract_bigint.test
+++ b/test/sql/rype_extract_bigint.test
@@ -1,0 +1,93 @@
+# name: test/sql/rype_extract_bigint.test
+# description: rype_extract_* mirror the id_column type (BIGINT) on read_id, matching align_minimap2.
+# group: [sql]
+
+#   Companion to rype_classify_bigint.test — both extraction functions
+#   (rype_extract_minimizer_set, rype_extract_strand_minimizers) share the same
+#   type-blind id path and must return read_id in the input column's storage
+#   type. Adversarial int64 values prove the round-trip is exact.
+
+require miint
+
+statement ok
+CREATE TABLE seq_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_bigint VALUES
+    (9007199254740993, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (9223372036854775807, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+# --- rype_extract_minimizer_set ---
+query T
+SELECT DISTINCT typeof(read_id)
+FROM rype_extract_minimizer_set('seq_bigint', 32, 10);
+----
+BIGINT
+
+query I
+SELECT read_id
+FROM rype_extract_minimizer_set('seq_bigint', 32, 10)
+ORDER BY read_id;
+----
+9007199254740993
+9223372036854775807
+
+# --- rype_extract_strand_minimizers ---
+query T
+SELECT DISTINCT typeof(read_id)
+FROM rype_extract_strand_minimizers('seq_bigint', 32, 10);
+----
+BIGINT
+
+query I
+SELECT read_id
+FROM rype_extract_strand_minimizers('seq_bigint', 32, 10)
+ORDER BY read_id;
+----
+9007199254740993
+9223372036854775807
+
+# --- Disallowed id types are rejected at bind ---
+statement ok
+CREATE TABLE seq_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_hugeint VALUES (1, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+statement error
+SELECT * FROM rype_extract_minimizer_set('seq_hugeint', 32, 10);
+----
+must be VARCHAR, BIGINT, or UUID
+
+statement error
+SELECT * FROM rype_extract_strand_minimizers('seq_hugeint', 32, 10);
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- NULL ids emit SQL NULL instead of aborting the query (shared ingress maps a
+#     NULL id to the empty carrier, which the codec resolves to NULL). ---
+statement ok
+CREATE TABLE seq_bigint_null (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_bigint_null VALUES
+    (NULL, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    (7, 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA');
+
+query II
+SELECT
+    COUNT(*) FILTER (WHERE read_id IS NULL),
+    COUNT(*) FILTER (WHERE read_id = 7)
+FROM rype_extract_minimizer_set('seq_bigint_null', 32, 10);
+----
+1	1
+
+statement ok
+DROP TABLE seq_bigint_null;
+
+# --- Cleanup ---
+statement ok
+DROP TABLE seq_bigint;
+
+statement ok
+DROP TABLE seq_hugeint;

--- a/test/sql/rype_log_ratio_bigint.test
+++ b/test/sql/rype_log_ratio_bigint.test
@@ -1,0 +1,50 @@
+# name: test/sql/rype_log_ratio_bigint.test
+# description: rype_log_ratio mirrors the id_column type (BIGINT) on read_id, matching align_minimap2.
+# group: [sql]
+
+#   Companion to rype_classify_bigint.test — rype_log_ratio shares the same
+#   type-blind id path and must likewise return read_id in the input column's
+#   storage type. Adversarial int64 values prove the round-trip is exact.
+
+require miint
+
+statement ok
+CREATE TABLE seq_bigint (read_id BIGINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_bigint VALUES
+    (9007199254740993, 'GGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC'),
+    (9223372036854775807, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+query T
+SELECT DISTINCT typeof(read_id)
+FROM rype_log_ratio('data/rype/test_numerator.ryxdi', 'data/rype/test_denominator.ryxdi', 'seq_bigint');
+----
+BIGINT
+
+query I
+SELECT read_id
+FROM rype_log_ratio('data/rype/test_numerator.ryxdi', 'data/rype/test_denominator.ryxdi', 'seq_bigint')
+ORDER BY read_id;
+----
+9007199254740993
+9223372036854775807
+
+# --- Disallowed id types are rejected at bind ---
+statement ok
+CREATE TABLE seq_hugeint (read_id HUGEINT, sequence1 VARCHAR);
+
+statement ok
+INSERT INTO seq_hugeint VALUES (1, 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT');
+
+statement error
+SELECT * FROM rype_log_ratio('data/rype/test_numerator.ryxdi', 'data/rype/test_denominator.ryxdi', 'seq_hugeint');
+----
+must be VARCHAR, BIGINT, or UUID
+
+# --- Cleanup ---
+statement ok
+DROP TABLE seq_bigint;
+
+statement ok
+DROP TABLE seq_hugeint;


### PR DESCRIPTION
## Problem

`rype_classify`, `rype_log_ratio`, and `rype_extract_{minimizer_set,strand_minimizers}` accept a `BIGINT`/`UUID` `id_column` and round-trip it losslessly, but **always emit `read_id` as `VARCHAR`** — the lone holdout from `align_minimap2` and the rest of the id-aware tree, which mirror the input id type on output. A `BIGINT` id therefore comes back as a string (canonical decimal — exact, but the wrong SQL type).

## Fix

- Capture the id column's storage type in `ValidateSequenceTable` (validated against the shared `IsAllowedIdType` set: `VARCHAR`, `BIGINT`, or `UUID`) and **mirror it on the `read_id` output column**, emitting via the existing `EmitIdCell` codec. The in-memory carrier stays `vector<string>`; the codec round-trips it exactly (decimal for `BIGINT`, canonical 36-char for `UUID`), so there is no data-path change.
- Refactored the column lookup so `GetTableColumnNamesLower` and the new type capture share a single catalog query (`GetTableColumnsLower`).

### Behavior changes (both "fail loud", matching the rest of the tree)

1. **Tightened accepted id types.** A non-`{VARCHAR,BIGINT,UUID}` `id_column` (e.g. `INTEGER`, `HUGEINT`) is now **rejected at bind** (`Column '...' must be VARCHAR, BIGINT, or UUID`) instead of being silently coerced to `VARCHAR` — same contract as `align_minimap2`.
2. **NULL id handling.** The shared ingress stringified a NULL id via `Value::ToString()` to the literal `"NULL"`, which **aborted the whole query** on a `BIGINT`/`UUID` column (`EmitIdCell` parse failure). NULL ids are now carried as the empty string, which the codec resolves to **SQL NULL** — matching `align_minimap2` rather than throwing mid-stream.

## Tests (red → green)

New `test/sql/rype_{classify,log_ratio,extract}_bigint.test` cover:
- `read_id` returns `BIGINT`/`UUID` and round-trips adversarial int64 values (2^53+1, int64 max) and the full UUID range,
- `VARCHAR` unchanged,
- disallowed-type (`HUGEINT`) rejection at bind,
- NULL id → SQL NULL (no query abort).

All 8 RYpe SQL tests + `[id_codec]` C++ tests pass; `make format-check` passes.

## Known residual (out of scope)

A NULL id in a **`VARCHAR`** column now emits an empty string `''` rather than a true SQL `NULL` — the same limitation `align_minimap2` has, since the `vector<string>` carrier can't distinguish `''` from NULL without a parallel null-mask. The reported severity (BIGINT/UUID query abort) is fully resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)