### PR TITLE
fix(build): unbreak Windows MinGW and WASM after sylph merge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1828,6 +1828,22 @@ if(MIINT_ENABLE_VSEARCH AND MIINT_ENABLE_CURL AND UNIX AND NOT APPLE)
     target_link_options(${EXTENSION_NAME} INTERFACE "-Wl,--allow-multiple-definition")
     target_link_options(${LOADABLE_EXTENSION_NAME} PRIVATE "-Wl,--allow-multiple-definition")
 endif()
+
+# Windows MinGW: duckdb's LogicalType static members (VARCHAR, DOUBLE, BIGINT, ...)
+# are emitted into COMDAT sections in every translation unit that references them.
+# GNU ld on Linux folds these by default; rtools42's MinGW ld on Windows does not,
+# so the duckdb.dll link sees duplicate `duckdb::LogicalType::VARCHAR` symbols
+# between libmiint_extension.a's TUs and duckdb_common's TUs. Pre-sylph-merge this
+# was masked by --allow-multiple-definition being applied for the unrelated
+# vsearch+curl MD5/SHA1 collision; that flag is now gated on
+# `MIINT_ENABLE_VSEARCH AND MIINT_ENABLE_CURL`, both of which are OFF on Windows.
+# Re-add the flag for MinGW with the actual C++ COMDAT reason.
+if(WIN32 AND MINGW)
+    target_link_options(tests PRIVATE "-Wl,--allow-multiple-definition")
+    target_link_options(${EXTENSION_NAME} INTERFACE "-Wl,--allow-multiple-definition")
+    target_link_options(${LOADABLE_EXTENSION_NAME} PRIVATE "-Wl,--allow-multiple-definition")
+endif()
+
 if(HAVE_LIBZSTD)
     target_link_libraries(tests ${ZSTD_TARGET})
 endif()


### PR DESCRIPTION
Two failures that surfaced on the v1.5-variegata merge run after sylph landed. Both pre-existed in some form — they were masked by the build path the sylph merge replaced.

- **WASM**: cargo builds rype's cdylib (rype.wasm) even though we only link the umbrella's staticlib. wasm-ld wanted `main`. Pass `-sSIDE_MODULE=2` so it links as a side module.
- **Windows MinGW (cdylib)**: same shape — rtools42 doesn't ship libgcc_eh.a. Stub an empty archive in a -L search path.
- **Windows MinGW (LogicalType COMDAT)**: duckdb's LogicalType static members emit COMDAT defs in every TU that touches them; MinGW's ld doesn't fold them. Pre-sylph-merge this was masked by the vsearch+curl `--allow-multiple-definition` flag applying broadly; that's now gated and Windows lost coverage. Re-add the flag for MinGW with the actual reason.

Native build paths untouched. Verified WASM locally; MinGW is CI-only.

PR CI excludes wasm_eh and windows_amd64_mingw, so the green checks on the PR don't exercise this — full matrix runs on merge.