### PR TITLE
fix(read_fastx): size stream polls to the byte budget for large records

### DIFF
--- a/src/SequenceReader.cpp
+++ b/src/SequenceReader.cpp
@@ -203,6 +203,22 @@ static size_t record_bytes(const klibpp::KSeq &rec) {
 	return rec.name.size() + rec.comment.size() + rec.seq.size() + rec.qual.size();
 }
 
+// Size the next poll so a single read_stream call materializes at most ~max_bytes worth of
+// records, rather than a fixed POLL_CHUNK_SIZE that ignores record size. Without a byte budget
+// (SIZE_MAX) or before any record is observed, fall back to POLL_CHUNK_SIZE -- preserving the
+// short-read fast path. Never exceeds POLL_CHUNK_SIZE and never returns less than 1. Capped at
+// `remaining` by the caller's batch limit.
+static int dynamic_poll_n(size_t observed_record_bytes, size_t max_bytes, int remaining) {
+	int poll_n = POLL_CHUNK_SIZE;
+	if (observed_record_bytes > 0 && max_bytes != SIZE_MAX) {
+		const size_t by_budget = max_bytes / observed_record_bytes;
+		if (by_budget < static_cast<size_t>(POLL_CHUNK_SIZE)) {
+			poll_n = by_budget < 1 ? 1 : static_cast<int>(by_budget);
+		}
+	}
+	return remaining < poll_n ? remaining : poll_n;
+}
+
 // Append a KSeq into an SE batch, stripping sequence whitespace in place.
 static void append_se(SequenceRecordBatch &batch, klibpp::KSeq &rec) {
 	rec.seq.erase(std::remove_if(rec.seq.begin(), rec.seq.end(), [](unsigned char c) { return std::isspace(c); }),
@@ -239,6 +255,7 @@ SequenceRecordBatch SequenceReader::read_se(const int n, const size_t max_bytes)
 			}
 			append_se(batch, rec);
 			cumulative_bytes += rec_bytes;
+			observed_record_bytes_ = rec_bytes;
 			const bool done = (int)batch.size() >= n || cumulative_bytes >= max_bytes;
 			if (done) {
 				if (i + 1 < chunk.size()) {
@@ -268,8 +285,9 @@ SequenceRecordBatch SequenceReader::read_se(const int n, const size_t max_bytes)
 	// Poll the stream in chunks so the budget can short-circuit before the next I/O round.
 	while ((int)batch.size() < n && cumulative_bytes < max_bytes) {
 		const int remaining = n - (int)batch.size();
-		const int poll_n = remaining < POLL_CHUNK_SIZE ? remaining : POLL_CHUNK_SIZE;
+		const int poll_n = dynamic_poll_n(observed_record_bytes_, max_bytes, remaining);
 		auto more = read_stream(sequence1_reader_, poll_n);
+		max_poll_count_ = more.size() > max_poll_count_ ? more.size() : max_poll_count_;
 		if (more.empty()) {
 			break;
 		}
@@ -334,6 +352,7 @@ SequenceRecordBatch SequenceReader::read_pe(const int n, const size_t max_bytes)
 			}
 			append_pe(batch, rec1, rec2);
 			cumulative_bytes += pair_bytes;
+			observed_record_bytes_ = pair_bytes;
 			const bool done = (int)batch.size() >= n || cumulative_bytes >= max_bytes;
 			if (done) {
 				if (i + 1 < c1.size()) {
@@ -363,9 +382,10 @@ SequenceRecordBatch SequenceReader::read_pe(const int n, const size_t max_bytes)
 
 	while ((int)batch.size() < n && cumulative_bytes < max_bytes) {
 		const int remaining = n - (int)batch.size();
-		const int poll_n = remaining < POLL_CHUNK_SIZE ? remaining : POLL_CHUNK_SIZE;
+		const int poll_n = dynamic_poll_n(observed_record_bytes_, max_bytes, remaining);
 		auto more1 = read_stream(sequence1_reader_, poll_n);
 		auto more2 = read_stream(sequence2_reader_.value(), poll_n);
+		max_poll_count_ = more1.size() > max_poll_count_ ? more1.size() : max_poll_count_;
 
 		if (more1.empty() && more2.empty()) {
 			break;

--- a/src/include/SequenceReader.hpp
+++ b/src/include/SequenceReader.hpp
@@ -42,6 +42,13 @@ public:
 	// Defaults to SIZE_MAX, preserving the row-only behavior for existing callers.
 	SequenceRecordBatch read(const int n, const size_t max_bytes = SIZE_MAX);
 
+	// Test seam: the largest number of records materialized by any single underlying stream
+	// poll over this reader's lifetime. Lets tests assert that large records do not trigger
+	// oversized prefetches (see dynamic poll sizing in read_se/read_pe).
+	size_t MaxPollCount() const {
+		return max_poll_count_;
+	}
+
 private:
 	using SeqStreamIn = klibpp::SeqStreamIn;
 
@@ -63,6 +70,12 @@ private:
 	bool first_read_; // Track if we need to return buffered data
 	std::vector<klibpp::KSeq> buffered_read1_;
 	std::vector<klibpp::KSeq> buffered_read2_;
+
+	// Running estimate of bytes per record (per pair in PE), used to size each poll so a
+	// single read_stream call never materializes far more than the byte budget. 0 until the
+	// first record is accepted.
+	size_t observed_record_bytes_ = 0;
+	size_t max_poll_count_ = 0; // test seam; see MaxPollCount()
 
 	SequenceRecordBatch read_se(const int n, const size_t max_bytes);
 	SequenceRecordBatch read_pe(const int n, const size_t max_bytes);

--- a/test/cpp/test_SequenceReader.cpp
+++ b/test/cpp/test_SequenceReader.cpp
@@ -449,6 +449,81 @@ TEST_CASE("SequenceReader byte budget PE: budget counts both mates", "[SequenceR
 	REQUIRE((total == 5));
 }
 
+TEST_CASE("SequenceReader byte budget SE: large records do not over-prefetch", "[SequenceReader][byte_budget]") {
+	// Each record alone exceeds the budget, so the byte budget caps the batch at one record.
+	// The poll that feeds that batch must NOT eagerly materialize a fixed chunk of large
+	// records: with a 500 B budget and ~4 KB records, a single poll should pull one record,
+	// not POLL_CHUNK_SIZE of them. This is the memory bound the byte budget is meant to give.
+	TempFileFixture fixture;
+	auto path = "budget_large_prefetch.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 12; i++) {
+		records.push_back(fixture.simple_read("r" + std::to_string(i), std::string(2000, 'A'), std::string(2000, 'I')));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+
+	size_t total = 0;
+	for (int call = 0; call < 50; call++) {
+		auto batch = reader.read(100, 500); // budget << one record
+		if (batch.empty()) {
+			break;
+		}
+		REQUIRE((batch.size() == 1));
+		total += batch.size();
+	}
+	REQUIRE((total == 12));
+	// The dynamic poll must size to the budget: at most one ~4 KB record per poll.
+	REQUIRE((reader.MaxPollCount() == 1));
+}
+
+TEST_CASE("SequenceReader byte budget PE: large pairs do not over-prefetch", "[SequenceReader][byte_budget]") {
+	TempFileFixture fixture;
+	auto r1 = "budget_large_pe_r1.fq";
+	auto r2 = "budget_large_pe_r2.fq";
+	std::vector<std::string> recs1, recs2;
+	for (int i = 0; i < 8; i++) {
+		std::string id = "pair" + std::to_string(i);
+		recs1.push_back(fixture.simple_read(id, std::string(2000, 'A'), std::string(2000, 'I')));
+		recs2.push_back(fixture.simple_read(id, std::string(2000, 'C'), std::string(2000, 'H')));
+	}
+	fixture.write_temp_fastq(r1, recs1);
+	fixture.write_temp_fastq(r2, recs2);
+
+	miint::SequenceReader reader(r1, r2);
+
+	size_t total = 0;
+	for (int call = 0; call < 50; call++) {
+		auto batch = reader.read(100, 500); // budget << one pair (~8 KB)
+		if (batch.empty()) {
+			break;
+		}
+		REQUIRE((batch.size() == 1));
+		total += batch.size();
+	}
+	REQUIRE((total == 8));
+	REQUIRE((reader.MaxPollCount() == 1));
+}
+
+TEST_CASE("SequenceReader byte budget SE: small records still poll in chunks", "[SequenceReader][byte_budget]") {
+	// Guard against the dynamic poll collapsing to 1 for the common short-read case: with a
+	// generous budget and tiny records, the poll must still amortize (reach POLL_CHUNK_SIZE).
+	TempFileFixture fixture;
+	auto path = "budget_small_chunked.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 200; i++) {
+		records.push_back(fixture.simple_read("r" + std::to_string(i), "ACGT", "IIII"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+	auto batch = reader.read(100, 1024 * 1024); // generous budget, fills to n
+	REQUIRE((batch.size() == 100));
+	// Must still batch the poll, not degrade to one-record-at-a-time.
+	REQUIRE((reader.MaxPollCount() > 1));
+}
+
 TEST_CASE("SequenceReader byte budget default (SIZE_MAX) unchanged behavior", "[SequenceReader][byte_budget]") {
 	// Regression: callers that don't pass a budget see the same rows-only behavior.
 	TempFileFixture fixture;


### PR DESCRIPTION
## Problem

`read_fastx`'s peak memory on large records (genomes, long contigs) is dominated by an over-prefetch in the reader, not by anything downstream. `SequenceReader::read_se`/`read_pe` poll the stream in fixed chunks of `POLL_CHUNK_SIZE = 16` records via `read_stream(reader, 16)`, which **materializes all 16 records before the byte budget is consulted**. For records larger than `max_bytes / 16`, a single poll holds ~16× the budget resident per reader (one record in the batch, the other 15 stashed in `buffered_read{1,2}_`).

The byte budget added in 42cdf81 ("Bound read_fastx memory") bounded the *batch* but not the *poll*, so neither `max_batch_bytes` nor `max_memory` can cap this — the allocations are untracked raw `std::string`/vector heaps.

### Measured (T2T-CHM13, 25 records ≤ 248 MB; host = 30 GB RAM)

| Config | Before | After |
|---|---|---|
| Reader only (`sum(length)`), threads=1 | 2.47 GB | **0.58 GB** |
| Full COPY→parquet, threads=1 | 4.47 GB | 3.04 GB |
| Full COPY→parquet, threads=8 | 27.6 GB / **99 s** (swap thrash) | 23.6 GB / **27.6 s** |

Pre-fix, peak RSS scaled linearly at ~4.4 GB/thread and spilled to swap at `threads=8`.

## Fix

Size each poll to the byte budget instead of a fixed record count:

```
poll_n = clamp(max_bytes / observed_record_bytes, 1, POLL_CHUNK_SIZE)
```

`observed_record_bytes` is updated as records are accepted (per pair in PE, preserving mate lockstep). The `SIZE_MAX` (no-budget) path and the short-read fast path (`poll_n` stays at the cap) are unchanged by construction.

Surgical: contained to `SequenceReader.{hpp,cpp}` — one helper, one running-estimate member, two poll sites. No public API change, no callers touched.

## Why D1 (count-clamp) over an adaptive ramp

A count-based scheme can't avoid the over-allocation *inside* a single poll: `read_stream` materializes `poll_n` records before adapting, so a poll straddling a small→large size transition spikes regardless. The clamp keeps that worst case bounded by `POLL_CHUNK_SIZE` (today's behavior) while collapsing the common homogeneous-large case to `poll_n = 1`. Fully eliminating the transition spike would require a byte-aware poll that also restructures PE mate lockstep — out of scope here.

## Performance

A controlled pre/post A/B (binary swapped, `agg` mode isolating the reader, warmup + 3 reps, cache-hot) shows **no runtime change** on any path: genome `agg` t1 5.81 s↔5.81 s, short-read `agg` t1 1.2 s↔1.2 s, short-read `agg` t8 1.31 s↔1.3 s. Short reads keep `poll_n = 16` (path unchanged); large records are few by definition, so the extra poll calls don't register. The only runtime effect is positive and indirect: no more swap thrash under memory pressure.

## Tests

- Red→green `[byte_budget]` tests (SE + PE) asserting large records no longer over-prefetch, via a new `MaxPollCount()` test seam.
- Guard test that short reads still poll in chunks (no amortization regression).
- Full C++ suite: 1166 passed / 1 skipped / 0 failed. `read_fastx*`, `copy_fasta/fastq` SQL tests pass. `clang-format 11.0.1` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)