### PR TITLE
fix(build): sync local vcpkg checkout to the pinned baseline

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,26 @@
 export VCPKG_TOOLCHAIN_PATH=`pwd`/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+# Keep the local vcpkg clone in sync with the baseline pinned in vcpkg.json.
+# vcpkg here is a plain clone (not a submodule), so a bumped builtin-baseline
+# won't resolve unless this checkout's version database contains that commit.
+# CI pins the same SHA via lukka/run-vcpkg (vcpkgGitCommitId); this mirrors that
+# for local builds. We only move the checkout when the baseline isn't already
+# reachable from HEAD, so a newer vcpkg is never downgraded.
+if [ -d vcpkg/.git ]; then
+    BASELINE=$(grep builtin-baseline vcpkg.json 2>/dev/null | grep -oE '[0-9a-f]{40}' | head -1)
+    if [ -n "$BASELINE" ] && ! git -C vcpkg merge-base --is-ancestor "$BASELINE" HEAD 2>/dev/null; then
+        echo "vcpkg: syncing checkout to pinned baseline $BASELINE"
+        git -C vcpkg cat-file -e "${BASELINE}^{commit}" 2>/dev/null \
+            || git -C vcpkg fetch --quiet origin "$BASELINE" 2>/dev/null \
+            || git -C vcpkg fetch --quiet origin
+        if [ -n "$(git -C vcpkg status --porcelain)" ]; then
+            echo "ERROR: vcpkg working tree has local changes; refusing to move it to $BASELINE." >&2
+            echo "       Commit/stash inside vcpkg/ or check out the baseline manually, then rerun." >&2
+            exit 1
+        fi
+        git -C vcpkg checkout --quiet "$BASELINE" \
+            || { echo "ERROR: could not check out vcpkg baseline $BASELINE" >&2; exit 1; }
+    fi
+fi
+
 GEN=ninja make


### PR DESCRIPTION
## Problem

`bash build.sh` started failing during vcpkg dependency resolution:

```
error: no version database entry for openssl at 3.6.0#2.
...
CMake Error: CMAKE_CXX_COMPILER not set, after EnableLanguage
```

Root cause: `vcpkg.json` pins `builtin-baseline` to `fef715db` (set in commit `5096935`), but `vcpkg/` is a **plain clone, not a submodule**, so it never advances. When a local checkout predates the baseline, its on-disk version database (`versions/*/*.json`) lacks the port-versions the baseline references → vcpkg install fails → CMake never gets a compiler. Previously-working local builds break with no code change.

CI was never affected — all three build jobs pin the same SHA via `lukka/run-vcpkg` (`vcpkgGitCommitId: fef715db…`). This gap was **local-dev only**.

## Fix

`build.sh` now keeps the local vcpkg checkout in sync with the manifest baseline:

- Parses `builtin-baseline` from `vcpkg.json`.
- Only acts when that commit is **not reachable from the vcpkg checkout's HEAD** (fetches it if missing, then checks it out).
- **No-op** when HEAD already contains the baseline — never downgrades a newer vcpkg.
- **Aborts loudly** if the vcpkg tree has local changes, rather than clobbering them.

## Verification

- No-op path: with vcpkg already at the baseline, the guard does nothing.
- Self-heal path: simulated a stale checkout (`8ce02b3d9a`) → guard fetched/checked out the baseline → confirmed HEAD restored to `fef715db`.
- Full `bash build.sh` succeeds end-to-end after the fix (duckdb shell + miint extension + tests all built).
- `bash -n build.sh` passes.

## Note (not addressed here)

The baseline SHA is duplicated in 4 places — `vcpkg.json` ×1 and `MainDistributionPipeline.yml` ×3. A future bump must update all of them or local/CI diverge again. Could be hardened later with a CI consistency check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)