### PR TITLE
feat(align): save_bowtie2_index + opt-in progress on sharded aligners

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1251,7 +1251,8 @@ if(MIINT_ENABLE_GPL_BOUNDARY)
         src/phylogeny_fasttree.cpp
         src/align_bowtie2_daemon_common.cpp
         src/align_bowtie2.cpp
-        src/align_bowtie2_sharded.cpp)
+        src/align_bowtie2_sharded.cpp
+        src/save_bowtie2_index.cpp)
 endif()
 if(MIINT_ENABLE_UNIFRAC)
     list(APPEND EXTENSION_SOURCES
@@ -1601,6 +1602,7 @@ set(TEST_SOURCES
     src/Minimap2Aligner.cpp
     test/cpp/test_Minimap2Aligner.cpp
     test/cpp/test_AlignBowtie2Sharded.cpp
+    test/cpp/test_ShardProgress.cpp
     src/ncbi_parser.cpp
     src/zip_utils.cpp
     duckdb/third_party/miniz/miniz.cpp  # For ExtractFromZip tests

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -30,6 +30,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 - [`align_minimap2_sharded`](#align_minimap2_shardedquery_table-shard_directory-read_to_shard-options) - Sharded minimap2 alignment
 - [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) - Bowtie2 alignment
 - [`align_bowtie2_sharded`](#align_bowtie2_shardedquery_table-shard_directory-read_to_shard-options) - Sharded bowtie2 alignment
+- [`save_bowtie2_index`](#save_bowtie2_indexsubject_table-output_path-options) - Save bowtie2 index (for `align_bowtie2_sharded`; requires gpl-boundary)
 - [`align_mafft`](#align_maffttable_name) - MAFFT multiple sequence alignment (PartTree)
 - [`align_abpoa`](#align_abpoatable_name-options) - abPOA partial order multiple sequence alignment
 - [`consensus_abpoa`](#consensus_abpoatable_name-options) - abPOA consensus sequence generation
@@ -1965,6 +1966,48 @@ CREATE VIEW marker_genes AS
 SELECT * FROM save_minimap2_index('marker_genes', 'markers.mmi');
 ```
 
+## `save_bowtie2_index(subject_table, output_path, [options])`
+
+Build and save a bowtie2 index to disk, primarily for use as a shard with [`align_bowtie2_sharded`](#align_bowtie2_shardedquery_table-shard_directory-read_to_shard-options). This is the bowtie2 analogue of `save_minimap2_index`. The index is produced by the gpl-boundary daemon's bundled `bowtie2-build`, so this function **requires gpl-boundary** (install with `SELECT install_gpl_boundary();`).
+
+**Use case:** Build per-shard bowtie2 indexes once, then align many query sets against them with `align_bowtie2_sharded`. `align_bowtie2_sharded` expects each shard's index at `<shard_directory>/<shard_name>/index.*.bt2`, so build each shard with `output_path = '<shard_directory>/<shard_name>/index'`.
+
+**Parameters:**
+- `subject_table` (VARCHAR): Name of table or view containing subject/reference sequences. Must have `read_fastx`-compatible schema. Cannot contain paired-end data (sequence2 must be NULL or absent). The `read_id` column may be `VARCHAR` or `BIGINT`; `BIGINT` ids are stringified before being written into the index (recovered subject names are always `VARCHAR`).
+- `output_path` (VARCHAR): Basename **prefix** for the index. bowtie2-build writes multiple files (`<output_path>.1.bt2`, `.2.bt2`, `.3.bt2`, `.4.bt2`, `.rev.1.bt2`, `.rev.2.bt2`). The parent directory is created if it does not exist. Note this differs from `save_minimap2_index`, which writes a single `.mmi` file.
+- `threads` (INTEGER, default: 1): Number of threads `bowtie2-build` may use. Must be >= 1.
+
+**Output schema:**
+- `success` (BOOLEAN): Always true if function completes successfully
+- `index_path` (VARCHAR): The `output_path` prefix the index files were written under
+- `num_subjects` (BIGINT): Number of subject sequences indexed
+
+**Behavior:**
+- Loads all subject sequences from the table (rejects an empty table and rejects paired subjects)
+- Submits them to the gpl-boundary daemon's `bowtie2-build` tool, which writes the `.bt2` files at `output_path`
+- Returns a single row with success status and metadata
+- Unlike `align_bowtie2`/`align_bowtie2_sharded` (which need gpl-boundary >= 0.4.2 for the alignment-time `memory_mapped` control), index building works with any daemon that advertises `bowtie2-build`.
+
+**Examples:**
+```sql
+-- Build a single bowtie2 index from references fetched from NCBI
+CREATE TABLE refs AS
+    SELECT * FROM read_ncbi_fasta(['NC_000913.3', 'NC_002695.2', 'NC_011751.1']);
+SELECT * FROM save_bowtie2_index('refs', 'shards/ecoli/index');
+-- Returns: true | shards/ecoli/index | 3
+
+-- Build per-shard indexes for align_bowtie2_sharded (one subdir per shard)
+CREATE TABLE shard_a AS SELECT * FROM read_fastx('shard_a.fna');
+CREATE TABLE shard_b AS SELECT * FROM read_fastx('shard_b.fna');
+SELECT * FROM save_bowtie2_index('shard_a', 'shards/shard_a/index');
+SELECT * FROM save_bowtie2_index('shard_b', 'shards/shard_b/index');
+
+-- Then align against the shard directory
+SELECT * FROM align_bowtie2_sharded('queries',
+    shard_directory := 'shards',
+    read_to_shard := 'read_to_shard');
+```
+
 **Error handling:**
 - Error if subject_table does not exist
 - Error if subject_table contains paired-end data (sequence2 not NULL)
@@ -2002,6 +2045,7 @@ Align query sequences against multiple pre-built minimap2 index shards in parall
 - `preset` (VARCHAR, default: 'sr'): Minimap2 preset ('sr', 'map-ont', 'map-pb', etc.)
 - `max_secondary` (INTEGER, default: 5): Maximum secondary alignments per query. Set to 0 for primary only
 - `eqx` (BOOLEAN, default: true): Use =/X CIGAR operators instead of M
+- `progress` (BOOLEAN, default: false): Opt-in progress reporting. When true, emit clean, timestamped per-shard lines to **stderr** (`shard i/N 'name': index loaded, R reads` → `done - R reads, A alignments (T s)`). Pure side channel — results are byte-identical to the default, which emits nothing, so programmatic callers are unaffected unless they pass `progress := true`.
 
 **Output schema:**
 Returns the same 21-column schema as `align_minimap2` and `read_alignments`.
@@ -2268,6 +2312,7 @@ The sharded path emits only mapped reads (the daemon is invoked with `--no-unal`
 - `memory_mapped` (BOOLEAN, default: **false** in sharded mode): How each shard's bowtie2 FM-index is loaded by the daemon. `false` (the sharded default) reads the index with a sequential `fread`; `true` memory-maps it (bowtie2 `--mm`). Sharded mode defaults to `false` because on a cold network filesystem the sequential read is ~3.7× faster than the random page-faults of `--mm`. (The non-sharded [`align_bowtie2`](#align_bowtie2query_table-subject_table-options) keeps the daemon's `--mm`-on default, which lets warm-cache local runs share mmap'd index pages across processes.) Requires gpl-boundary ≥ 0.4.2 — older daemons are rejected at query start, since they would otherwise silently ignore this field.
 - `prefetch_ahead` (INTEGER, default: auto, range 0–4096): How many upcoming shards' index files to warm into the OS page cache (`POSIX_FADV_WILLNEED`) ahead of the shard-claim frontier, so a worker doesn't stall on a cold network-FS fault when it claims the next shard. The default (`auto`, when unset) warms one full wave ahead — `ceil(SET threads / max_threads_per_shard)` shards; `0` disables prefetch. A pure cache hint: alignment results are identical for any value.
 - `include_shard_name` (BOOLEAN, default: false): When true, append a `shard_name` column to the output
+- `progress` (BOOLEAN, default: false): Opt-in progress reporting. When true, emit clean, timestamped per-shard lines to **stderr** (`shard i/N 'name': index loaded` → `done - R reads, A alignments (T s)`). Pure side channel — results are byte-identical to the default, which emits nothing, so programmatic callers are unaffected unless they pass `progress := true`. (Distinct from `MIINT_BT2_TELEMETRY`, which emits machine-readable per-batch TSV.)
 - `quiet` (BOOLEAN, default: true): Runs Bowtie2 with `--quiet`. Keep the default — miint never surfaces Bowtie2's stderr statistics to SQL, so `quiet := false` has no user-visible effect and only adds overhead (per-batch summaries that miint drains and discards).
 - `threads` (INTEGER): Ignored in sharded mode. Use DuckDB's `SET threads=N` to control cross-shard parallelism and `max_threads_per_shard` for per-shard bowtie2 threading. A warning is printed at bind if `threads != 1` is passed directly to this function.
 

--- a/src/align_bowtie2.cpp
+++ b/src/align_bowtie2.cpp
@@ -18,9 +18,6 @@
 #include "gpl_boundary/process.hpp"
 #include "gpl_boundary/session.hpp"
 
-#include "nanoarrow/nanoarrow.h"
-#include "yyjson.hpp"
-
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -40,7 +37,6 @@ namespace duckdb {
 namespace {
 
 namespace gb = ::duckdb::miint::gpl_boundary;
-namespace yj = duckdb_yyjson;
 
 // Schema/output helpers, ConfigJsonBuilder, ValueAs* coercers, and the
 // shared bowtie2-align param mapper all live in
@@ -89,15 +85,6 @@ std::string BuildAlignConfigJson(const named_parameter_map_t &named_params, cons
 	return cfg.build();
 }
 
-std::string BuildBuildConfigJson(const std::string &index_basename, int64_t nthreads) {
-	bt2_daemon::ConfigJsonBuilder cfg;
-	cfg.append_str("index_path", index_basename);
-	if (nthreads > 1) {
-		cfg.append_int("nthreads", nthreads);
-	}
-	return cfg.build();
-}
-
 // -----------------------------------------------------------------------------
 // Temp-dir for bowtie2-build outputs. Respects $TMPDIR (default /tmp). One
 // dir per query; cleaned up in GlobalState destructor.
@@ -116,181 +103,6 @@ std::string MakeTempIndexDir() {
 		                  std::string(tmp), errno);
 	}
 	return std::string(buf.data());
-}
-
-// -----------------------------------------------------------------------------
-// Read subjects via separate connection. Reuses the existing miint contract:
-// subjects table has (read_id, sequence1); sequence2 if present must be
-// all-NULL. The daemon's bowtie2-build expects (name, sequence), so we
-// rename when materializing the Arrow batch.
-// -----------------------------------------------------------------------------
-
-struct LoadedSubjects {
-	std::vector<std::string> names;
-	std::vector<std::string> sequences;
-};
-
-LoadedSubjects LoadSubjects(ClientContext &context, const std::string &table_name) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection conn(db);
-	// Two-query approach: first probe column presence to detect optional
-	// sequence2 (which we need to validate is all-NULL — paired subjects are
-	// rejected per test/sql/align_bowtie2.test:191-200), then issue the
-	// actual SELECT. The schema validator in Bind already accepted read_id
-	// as VARCHAR or BIGINT; the implicit Value::GetValue<std::string>() cast
-	// below handles either type uniformly into the carrier vector.
-	const std::string columns_sql = "SELECT column_name FROM (DESCRIBE " +
-	                                KeywordHelper::WriteOptionallyQuoted(table_name) +
-	                                ") WHERE column_name IN ('sequence2')";
-	auto columns_res = conn.Query(columns_sql);
-	if (columns_res->HasError()) {
-		throw InvalidInputException("align_bowtie2: failed to introspect subject table '%s': %s", table_name,
-		                            columns_res->GetError());
-	}
-	const bool has_sequence2 = columns_res->RowCount() > 0;
-
-	std::string select_sql = "SELECT read_id, sequence1";
-	if (has_sequence2) {
-		select_sql += ", sequence2";
-	}
-	select_sql += " FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
-
-	auto result = conn.Query(select_sql);
-	if (result->HasError()) {
-		throw InvalidInputException("align_bowtie2: failed to read subject table '%s' "
-		                            "(must have columns read_id VARCHAR or BIGINT, sequence1 VARCHAR): %s",
-		                            table_name, result->GetError());
-	}
-
-	LoadedSubjects out;
-	auto &materialized = result->Cast<MaterializedQueryResult>();
-	out.names.reserve(materialized.RowCount());
-	out.sequences.reserve(materialized.RowCount());
-	while (auto chunk = materialized.Fetch()) {
-		for (idx_t i = 0; i < chunk->size(); ++i) {
-			auto name_val = chunk->GetValue(0, i);
-			auto seq_val = chunk->GetValue(1, i);
-			if (name_val.IsNull() || seq_val.IsNull()) {
-				throw InvalidInputException("align_bowtie2: NULL read_id or sequence1 in subject table '%s'",
-				                            table_name);
-			}
-			if (has_sequence2) {
-				auto s2_val = chunk->GetValue(2, i);
-				if (!s2_val.IsNull()) {
-					throw InvalidInputException("align_bowtie2: subject table '%s' has non-NULL sequence2 — "
-					                            "subjects must be single-end (sequence2 must be NULL)",
-					                            table_name);
-				}
-			}
-			out.names.push_back(name_val.GetValue<std::string>());
-			out.sequences.push_back(seq_val.GetValue<std::string>());
-		}
-	}
-	if (out.names.empty()) {
-		throw InvalidInputException("align_bowtie2: subject table '%s' is empty", table_name);
-	}
-	return out;
-}
-
-// -----------------------------------------------------------------------------
-// Arrow IPC encoders. Subjects ⇒ {name, sequence}; queries ⇒ {read_id,
-// sequence1, sequence2?, qual1?, qual2?}. Mirrors phylogeny_fasttree's
-// BuildInputIpcStream (nanoarrow's Init/StartAppending/AppendString/
-// FinishElement/FinishBuildingDefault + EncodeIpcStream).
-// -----------------------------------------------------------------------------
-
-std::vector<uint8_t> BuildSubjectsIpc(const LoadedSubjects &subjects) {
-	ArrowSchema schema {};
-	auto rc = ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_STRUCT);
-	if (rc != NANOARROW_OK) {
-		throw InternalException("align_bowtie2: ArrowSchemaInit failed");
-	}
-	rc = ArrowSchemaAllocateChildren(&schema, 2);
-	if (rc != NANOARROW_OK) {
-		schema.release(&schema);
-		throw InternalException("align_bowtie2: ArrowSchemaAllocateChildren failed");
-	}
-	ArrowSchemaInitFromType(schema.children[0], NANOARROW_TYPE_STRING);
-	ArrowSchemaSetName(schema.children[0], "name");
-	ArrowSchemaInitFromType(schema.children[1], NANOARROW_TYPE_STRING);
-	ArrowSchemaSetName(schema.children[1], "sequence");
-
-	ArrowArray array {};
-	ArrowError err {};
-	if (ArrowArrayInitFromSchema(&array, &schema, &err) != NANOARROW_OK) {
-		schema.release(&schema);
-		throw InternalException("align_bowtie2: ArrowArrayInit failed: %s", err.message);
-	}
-	if (ArrowArrayStartAppending(&array) != NANOARROW_OK) {
-		array.release(&array);
-		schema.release(&schema);
-		throw InternalException("align_bowtie2: ArrowArrayStartAppending failed");
-	}
-	for (size_t i = 0; i < subjects.names.size(); ++i) {
-		ArrowStringView nv {subjects.names[i].data(), static_cast<int64_t>(subjects.names[i].size())};
-		ArrowStringView sv {subjects.sequences[i].data(), static_cast<int64_t>(subjects.sequences[i].size())};
-		if (ArrowArrayAppendString(array.children[0], nv) != NANOARROW_OK ||
-		    ArrowArrayAppendString(array.children[1], sv) != NANOARROW_OK ||
-		    ArrowArrayFinishElement(&array) != NANOARROW_OK) {
-			array.release(&array);
-			schema.release(&schema);
-			throw InternalException("align_bowtie2: subjects append failed at row %d", static_cast<int>(i));
-		}
-	}
-	if (ArrowArrayFinishBuildingDefault(&array, &err) != NANOARROW_OK) {
-		array.release(&array);
-		schema.release(&schema);
-		throw InternalException("align_bowtie2: ArrowArrayFinishBuilding failed: %s", err.message);
-	}
-
-	std::vector<uint8_t> bytes;
-	try {
-		bytes = gb::EncodeIpcStream(&schema, &array, 1);
-	} catch (...) {
-		array.release(&array);
-		schema.release(&schema);
-		throw;
-	}
-	if (array.release) {
-		array.release(&array);
-	}
-	if (schema.release) {
-		schema.release(&schema);
-	}
-	return bytes;
-}
-
-// -----------------------------------------------------------------------------
-// Parse bowtie2-build's `result.index_files` array into a vector of paths.
-// Returns paths in registry order; we use the first one to derive the index
-// basename. Daemon contract: 6 absolute paths.
-// -----------------------------------------------------------------------------
-
-std::vector<std::string> ParseIndexFilesFromResultJson(const std::string &result_json) {
-	using YyjsonDocPtr = std::unique_ptr<yj::yyjson_doc, decltype(&yj::yyjson_doc_free)>;
-	YyjsonDocPtr doc(yj::yyjson_read(result_json.data(), result_json.size(), 0), &yj::yyjson_doc_free);
-	if (!doc) {
-		throw IOException("align_bowtie2: bowtie2-build result_json was not valid JSON: %s", result_json);
-	}
-	yj::yyjson_val *root = yj::yyjson_doc_get_root(doc.get());
-	if (!yj::yyjson_is_obj(root)) {
-		throw IOException("align_bowtie2: bowtie2-build result was not a JSON object: %s", result_json);
-	}
-	yj::yyjson_val *arr = yj::yyjson_obj_get(root, "index_files");
-	if (!arr || !yj::yyjson_is_arr(arr)) {
-		throw IOException("align_bowtie2: bowtie2-build result missing 'index_files' array: %s", result_json);
-	}
-	std::vector<std::string> out;
-	const size_t n = yj::yyjson_arr_size(arr);
-	out.reserve(n);
-	for (size_t i = 0; i < n; ++i) {
-		yj::yyjson_val *item = yj::yyjson_arr_get(arr, i);
-		if (!yj::yyjson_is_str(item)) {
-			throw IOException("align_bowtie2: bowtie2-build index_files contained non-string entry");
-		}
-		out.emplace_back(yj::yyjson_get_str(item));
-	}
-	return out;
 }
 
 // -----------------------------------------------------------------------------
@@ -507,9 +319,9 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 	// 1. Spawn the daemon + handshake. Fail loud if not present or stale.
 	gs->session = SpawnAndCheckSession();
 
-	// 2. Load subjects + materialize as Arrow IPC.
-	const auto subjects = LoadSubjects(context, bd.subject_table);
-	const auto subjects_ipc = BuildSubjectsIpc(subjects);
+	// 2. Load subjects + materialize as Arrow IPC (shared bowtie2-build glue).
+	const auto subjects = bt2_daemon::LoadSingleEndSubjects(context, bd.subject_table, "align_bowtie2");
+	const auto subjects_ipc = bt2_daemon::BuildSubjectsIpc(subjects, "align_bowtie2");
 
 	// 3. Build the bowtie2 index under a fresh temp dir.
 	gs->temp_dir = MakeTempIndexDir();
@@ -528,9 +340,9 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 			}
 		}
 	}
-	const std::string build_config = BuildBuildConfigJson(index_basename, threads);
+	const std::string build_config = bt2_daemon::BuildBowtie2BuildConfigJson(index_basename, threads);
 	auto build_result = gs->session->Submit("bowtie2-build", build_config, subjects_ipc.data(), subjects_ipc.size());
-	gs->index_files = ParseIndexFilesFromResultJson(build_result.result_json);
+	gs->index_files = bt2_daemon::ParseBowtie2BuildIndexFiles(build_result.result_json, "align_bowtie2");
 	if (gs->index_files.empty()) {
 		throw IOException("align_bowtie2: bowtie2-build returned zero index_files");
 	}

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -13,7 +13,14 @@
 #include "gpl_boundary/process.hpp"
 #include "nanoarrow/nanoarrow.h"
 
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+#include "yyjson.hpp"
+
 #include <cstring>
+#include <memory>
 #include <mutex>
 #include <tuple>
 #include <unistd.h>
@@ -22,6 +29,7 @@ namespace duckdb {
 namespace bt2_daemon {
 
 namespace gb = ::duckdb::miint::gpl_boundary;
+namespace yj = duckdb_yyjson;
 
 // =============================================================================
 // Config builder + param mapping (used by both align_bowtie2 callers)
@@ -823,6 +831,165 @@ void RequireGplBoundaryVersion(const std::string &binary_path, const char *calle
 			    caller, binary_path, found);
 		}
 	});
+}
+
+// =============================================================================
+// bowtie2-build glue (shared by align_bowtie2 + save_bowtie2_index)
+// =============================================================================
+
+LoadedSubjects LoadSingleEndSubjects(ClientContext &context, const std::string &table_name, const char *caller) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	// Probe for an optional sequence2 column first (paired subjects are
+	// rejected), then issue the actual SELECT. read_id may be VARCHAR or BIGINT;
+	// the implicit Value::GetValue<std::string>() cast below handles either.
+	const std::string columns_sql = "SELECT column_name FROM (DESCRIBE " +
+	                                KeywordHelper::WriteOptionallyQuoted(table_name) +
+	                                ") WHERE column_name IN ('sequence2')";
+	auto columns_res = conn.Query(columns_sql);
+	if (columns_res->HasError()) {
+		throw InvalidInputException("%s: failed to introspect subject table '%s': %s", caller, table_name,
+		                            columns_res->GetError());
+	}
+	const bool has_sequence2 = columns_res->RowCount() > 0;
+
+	std::string select_sql = "SELECT read_id, sequence1";
+	if (has_sequence2) {
+		select_sql += ", sequence2";
+	}
+	select_sql += " FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
+
+	auto result = conn.Query(select_sql);
+	if (result->HasError()) {
+		throw InvalidInputException("%s: failed to read subject table '%s' "
+		                            "(must have columns read_id VARCHAR or BIGINT, sequence1 VARCHAR): %s",
+		                            caller, table_name, result->GetError());
+	}
+
+	LoadedSubjects out;
+	auto &materialized = result->Cast<MaterializedQueryResult>();
+	out.names.reserve(materialized.RowCount());
+	out.sequences.reserve(materialized.RowCount());
+	while (auto chunk = materialized.Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); ++i) {
+			auto name_val = chunk->GetValue(0, i);
+			auto seq_val = chunk->GetValue(1, i);
+			if (name_val.IsNull() || seq_val.IsNull()) {
+				throw InvalidInputException("%s: NULL read_id or sequence1 in subject table '%s'", caller, table_name);
+			}
+			if (has_sequence2) {
+				auto s2_val = chunk->GetValue(2, i);
+				if (!s2_val.IsNull()) {
+					throw InvalidInputException("%s: subject table '%s' has non-NULL sequence2 — "
+					                            "subjects must be single-end (sequence2 must be NULL)",
+					                            caller, table_name);
+				}
+			}
+			out.names.push_back(name_val.GetValue<std::string>());
+			out.sequences.push_back(seq_val.GetValue<std::string>());
+		}
+	}
+	if (out.names.empty()) {
+		throw InvalidInputException("%s: subject table '%s' is empty", caller, table_name);
+	}
+	return out;
+}
+
+std::vector<uint8_t> BuildSubjectsIpc(const LoadedSubjects &subjects, const char *caller) {
+	ArrowSchema schema {};
+	auto rc = ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_STRUCT);
+	if (rc != NANOARROW_OK) {
+		throw InternalException("%s: ArrowSchemaInit failed", caller);
+	}
+	rc = ArrowSchemaAllocateChildren(&schema, 2);
+	if (rc != NANOARROW_OK) {
+		schema.release(&schema);
+		throw InternalException("%s: ArrowSchemaAllocateChildren failed", caller);
+	}
+	ArrowSchemaInitFromType(schema.children[0], NANOARROW_TYPE_STRING);
+	ArrowSchemaSetName(schema.children[0], "name");
+	ArrowSchemaInitFromType(schema.children[1], NANOARROW_TYPE_STRING);
+	ArrowSchemaSetName(schema.children[1], "sequence");
+
+	ArrowArray array {};
+	ArrowError err {};
+	if (ArrowArrayInitFromSchema(&array, &schema, &err) != NANOARROW_OK) {
+		schema.release(&schema);
+		throw InternalException("%s: ArrowArrayInit failed: %s", caller, err.message);
+	}
+	if (ArrowArrayStartAppending(&array) != NANOARROW_OK) {
+		array.release(&array);
+		schema.release(&schema);
+		throw InternalException("%s: ArrowArrayStartAppending failed", caller);
+	}
+	for (size_t i = 0; i < subjects.names.size(); ++i) {
+		ArrowStringView nv {subjects.names[i].data(), static_cast<int64_t>(subjects.names[i].size())};
+		ArrowStringView sv {subjects.sequences[i].data(), static_cast<int64_t>(subjects.sequences[i].size())};
+		if (ArrowArrayAppendString(array.children[0], nv) != NANOARROW_OK ||
+		    ArrowArrayAppendString(array.children[1], sv) != NANOARROW_OK ||
+		    ArrowArrayFinishElement(&array) != NANOARROW_OK) {
+			array.release(&array);
+			schema.release(&schema);
+			throw InternalException("%s: subjects append failed at row %d", caller, static_cast<int>(i));
+		}
+	}
+	if (ArrowArrayFinishBuildingDefault(&array, &err) != NANOARROW_OK) {
+		array.release(&array);
+		schema.release(&schema);
+		throw InternalException("%s: ArrowArrayFinishBuilding failed: %s", caller, err.message);
+	}
+
+	std::vector<uint8_t> bytes;
+	try {
+		bytes = gb::EncodeIpcStream(&schema, &array, 1);
+	} catch (...) {
+		array.release(&array);
+		schema.release(&schema);
+		throw;
+	}
+	if (array.release) {
+		array.release(&array);
+	}
+	if (schema.release) {
+		schema.release(&schema);
+	}
+	return bytes;
+}
+
+std::string BuildBowtie2BuildConfigJson(const std::string &index_basename, int64_t nthreads) {
+	ConfigJsonBuilder cfg;
+	cfg.append_str("index_path", index_basename);
+	if (nthreads > 1) {
+		cfg.append_int("nthreads", nthreads);
+	}
+	return cfg.build();
+}
+
+std::vector<std::string> ParseBowtie2BuildIndexFiles(const std::string &result_json, const char *caller) {
+	using YyjsonDocPtr = std::unique_ptr<yj::yyjson_doc, decltype(&yj::yyjson_doc_free)>;
+	YyjsonDocPtr doc(yj::yyjson_read(result_json.data(), result_json.size(), 0), &yj::yyjson_doc_free);
+	if (!doc) {
+		throw IOException("%s: bowtie2-build result_json was not valid JSON: %s", caller, result_json);
+	}
+	yj::yyjson_val *root = yj::yyjson_doc_get_root(doc.get());
+	if (!yj::yyjson_is_obj(root)) {
+		throw IOException("%s: bowtie2-build result was not a JSON object: %s", caller, result_json);
+	}
+	yj::yyjson_val *arr = yj::yyjson_obj_get(root, "index_files");
+	if (!arr || !yj::yyjson_is_arr(arr)) {
+		throw IOException("%s: bowtie2-build result missing 'index_files' array: %s", caller, result_json);
+	}
+	std::vector<std::string> out;
+	const size_t n = yj::yyjson_arr_size(arr);
+	out.reserve(n);
+	for (size_t i = 0; i < n; ++i) {
+		yj::yyjson_val *item = yj::yyjson_arr_get(arr, i);
+		if (!yj::yyjson_is_str(item)) {
+			throw IOException("%s: bowtie2-build index_files contained non-string entry", caller);
+		}
+		out.emplace_back(yj::yyjson_get_str(item));
+	}
+	return out;
 }
 
 } // namespace bt2_daemon

--- a/src/align_bowtie2_sharded.cpp
+++ b/src/align_bowtie2_sharded.cpp
@@ -3,6 +3,7 @@
 #include "align_common.hpp"
 #include "miint_log.hpp"
 #include "sequence_table_reader.hpp"
+#include "shard_progress.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
@@ -87,6 +88,7 @@ std::unordered_set<std::string> MakeKnownShardedParams() {
 	s.insert("include_shard_name");
 	s.insert("submit_batch_reads");
 	s.insert("prefetch_ahead");
+	s.insert("progress");
 	return s;
 }
 
@@ -217,6 +219,8 @@ struct AlignBowtie2ShardedBindData : public TableFunctionData {
 	// threading matters more than the number of concurrent shards.
 	idx_t max_threads_per_shard = 1;
 	bool include_shard_name = false;
+	// Opt-in per-shard progress to stderr (default false; see shard_progress.hpp).
+	bool progress = false;
 
 	// Lower-bound threshold on reads accumulated into one daemon Submit. Larger
 	// batches amortize bowtie2's per-batch FM-index reload and keep `bowtie2 -p N`
@@ -287,6 +291,10 @@ struct AlignBowtie2ShardedGlobalState : public GlobalTableFunctionState {
 	int telemetry_fd = -1;
 	bool telemetry_owns_fd = false;
 	TelClock::time_point telemetry_start;
+
+	// Opt-in per-shard progress (mirrors BindData::progress; set in InitGlobal,
+	// read-only from workers). When false, no progress lines are emitted.
+	bool progress = false;
 
 	idx_t MaxThreads() const override {
 		// DuckDB clamps to its own scheduler concurrency anyway, but
@@ -371,6 +379,12 @@ struct AlignBowtie2ShardedLocalState : public LocalTableFunctionState {
 	// `telemetry_batch_seq` orders this worker's batches in the TSV;
 	// `telemetry_open_stream_ms` carries the cursor-open cost from a shard claim
 	// forward onto that shard's first batch line (0 on subsequent batches).
+	// Progress-only per-shard accumulators (used when GlobalState::progress is
+	// true). Reset when a shard stream opens; read when it exhausts.
+	idx_t shard_reads = 0;
+	idx_t shard_alignments = 0;
+	TelClock::time_point shard_start;
+
 	idx_t telemetry_batch_seq = 0;
 	double telemetry_open_stream_ms = 0.0;
 
@@ -549,6 +563,13 @@ unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &in
 		    bt2_daemon::ValueAsBool("align_bowtie2_sharded", "include_shard_name", include_shard_param->second);
 	}
 
+	// Opt-in per-shard progress to stderr (default false): a programmatic caller
+	// that never passes progress:=true emits nothing.
+	auto progress_param = input.named_parameters.find("progress");
+	if (progress_param != input.named_parameters.end() && !progress_param->second.IsNull()) {
+		bd->progress = bt2_daemon::ValueAsBool("align_bowtie2_sharded", "progress", progress_param->second);
+	}
+
 	auto batch_param = input.named_parameters.find("submit_batch_reads");
 	if (batch_param != input.named_parameters.end() && !batch_param->second.IsNull()) {
 		const int64_t val = bt2_daemon::ValueAsInt("align_bowtie2_sharded", "submit_batch_reads", batch_param->second);
@@ -638,6 +659,7 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 	const idx_t derived = (db_threads + bd.max_threads_per_shard - 1) / bd.max_threads_per_shard;
 	gs->max_active_shards = std::max<idx_t>(1, std::min<idx_t>(derived, bd.shards.size()));
 	gs->db_threads = db_threads;
+	gs->progress = bd.progress;
 	gs->prefetch_ahead = bd.prefetch_ahead < 0 ? gs->max_active_shards : static_cast<idx_t>(bd.prefetch_ahead);
 	const bool prefetch_enabled = gs->prefetch_ahead > 0;
 
@@ -1030,10 +1052,23 @@ void Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output
 					rec.wall_ms = TelMsSince(gs.telemetry_start);
 					EmitBatchTelemetry(gs.telemetry_fd, rec);
 				}
+				if (gs.progress) {
+					local.shard_reads += static_cast<idx_t>(qb.read_ids.size());
+					for (const auto &w : local.current_batches) {
+						local.shard_alignments += static_cast<idx_t>(w.arrow_array.length);
+					}
+				}
 				continue; // loop back to drain decoded rows
 			}
 			// Shard exhausted — release for re-claim attempt. Drop this worker
 			// from the active count so a surviving worker can grow its `-p`.
+			if (gs.progress) {
+				const double elapsed_s = std::chrono::duration<double>(TelClock::now() - local.shard_start).count();
+				shard_progress::Emit("bowtie2", shard_progress::FormatShardDone(
+				                                    static_cast<uint64_t>(local.current_shard_idx) + 1,
+				                                    static_cast<uint64_t>(bd.shards.size()), local.current_shard_name,
+				                                    local.shard_reads, local.shard_alignments, elapsed_s));
+			}
 			local.input_stream.reset();
 			local.current_shard_idx = DConstants::INVALID_INDEX;
 			gs.active_workers.fetch_sub(1, std::memory_order_relaxed);
@@ -1091,6 +1126,19 @@ void Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output
 		if (tel_on) {
 			local.telemetry_open_stream_ms = TelMsSince(t_open0);
 		}
+		// Per-shard progress accounting: reset accumulators and stamp the start
+		// of this shard, then announce it. Read count is unknown at open (reads
+		// stream in batches), so the "started" line omits it; the "done" line
+		// below reports the totals.
+		local.shard_reads = 0;
+		local.shard_alignments = 0;
+		local.shard_start = TelClock::now();
+		if (gs.progress) {
+			shard_progress::Emit("bowtie2", shard_progress::FormatShardStart(
+			                                    static_cast<uint64_t>(local.current_shard_idx) + 1,
+			                                    static_cast<uint64_t>(bd.shards.size()), local.current_shard_name,
+			                                    /*n_reads=*/-1));
+		}
 	}
 }
 
@@ -1110,6 +1158,7 @@ TableFunction AlignBowtie2ShardedTableFunction::GetFunction() {
 	tf.named_parameters["include_shard_name"] = LogicalType::BOOLEAN;
 	tf.named_parameters["submit_batch_reads"] = LogicalType::INTEGER;
 	tf.named_parameters["prefetch_ahead"] = LogicalType::INTEGER;
+	tf.named_parameters["progress"] = LogicalType::BOOLEAN;
 	tf.order_preservation_type = OrderPreservationType::NO_ORDER;
 	return tf;
 }

--- a/src/align_minimap2_sharded.cpp
+++ b/src/align_minimap2_sharded.cpp
@@ -1,6 +1,7 @@
 #include "align_minimap2_sharded.hpp"
 #include "align_common.hpp"
 #include "shard_debug.hpp"
+#include "shard_progress.hpp"
 #include "duckdb/common/file_system.hpp"
 
 namespace duckdb {
@@ -118,6 +119,13 @@ unique_ptr<FunctionData> AlignMinimap2ShardedTableFunction::Bind(ClientContext &
 		data->debug = debug_param->second.GetValue<bool>();
 	}
 
+	// Parse progress parameter (opt-in, default false): when true, the function
+	// emits clean per-shard progress lines to stderr (see shard_progress.hpp).
+	auto progress_param = input.named_parameters.find("progress");
+	if (progress_param != input.named_parameters.end() && !progress_param->second.IsNull()) {
+		data->progress = progress_param->second.GetValue<bool>();
+	}
+
 	// Parse include_shard_name parameter
 	auto include_shard_param = input.named_parameters.find("include_shard_name");
 	if (include_shard_param != input.named_parameters.end() && !include_shard_param->second.IsNull()) {
@@ -157,6 +165,7 @@ unique_ptr<GlobalTableFunctionState> AlignMinimap2ShardedTableFunction::InitGlob
 	idx_t derived = (db_threads + data.max_threads_per_shard - 1) / data.max_threads_per_shard;
 	gstate->max_active_shards = std::max<idx_t>(1, std::min(derived, gstate->shard_count));
 	gstate->debug = data.debug;
+	gstate->progress = data.progress;
 	gstate->start_time = std::chrono::steady_clock::now();
 	idx_t total = 0;
 	for (const auto &shard : data.shards) {
@@ -338,11 +347,19 @@ std::shared_ptr<ActiveShard> AlignMinimap2ShardedTableFunction::ClaimWork(Client
 	}
 
 	// Phase 5: Publish under lock to prevent lost wake-ups with CV
+	active->total_reads = seq_count;
+	active->start_time = std::chrono::steady_clock::now();
 	{
 		std::lock_guard<std::mutex> guard(gstate.lock);
 		active->ready.store(true, std::memory_order_release);
 	}
 	gstate.cv.notify_all();
+	if (gstate.progress) {
+		shard_progress::Emit("minimap2",
+		                     shard_progress::FormatShardStart(static_cast<uint64_t>(shard_idx) + 1,
+		                                                      static_cast<uint64_t>(gstate.shard_count),
+		                                                      shard_info.name, static_cast<int64_t>(seq_count)));
+	}
 	return active;
 }
 
@@ -366,6 +383,24 @@ void AlignMinimap2ShardedTableFunction::ReleaseWork(GlobalState &gstate, LocalSt
 			shards.erase(std::remove(shards.begin(), shards.end(), active), shards.end());
 			SHARD_DBG_MEM(gstate, "ReleaseWork: REMOVED shard %zu (active_shards=%zu)",
 			              static_cast<size_t>(active->shard_idx), static_cast<size_t>(shards.size()));
+			if (gstate.progress) {
+				// The relaxed load sees every worker's relaxed alignments_emitted
+				// fetch_add: each fetch_add is sequenced-before that worker's
+				// acq_rel active_workers.fetch_sub, and this REMOVE runs only for
+				// the last worker (its fetch_sub read 1), whose acquire chains
+				// back through the prior decrements' releases — so all fetch_adds
+				// happen-before this load. (A miscount would only mis-state this
+				// diagnostic line; alignment results are unaffected.)
+				const double elapsed_s = std::chrono::duration_cast<std::chrono::duration<double>>(
+				                             std::chrono::steady_clock::now() - active->start_time)
+				                             .count();
+				shard_progress::Emit("minimap2",
+				                     shard_progress::FormatShardDone(
+				                         static_cast<uint64_t>(active->shard_idx) + 1,
+				                         static_cast<uint64_t>(gstate.shard_count), lstate.current_shard_name,
+				                         active->total_reads,
+				                         active->alignments_emitted.load(std::memory_order_relaxed), elapsed_s));
+			}
 		}
 		lstate.current_active_shard = nullptr;
 		// Notify under lock to prevent lost wake-ups with CV
@@ -475,6 +510,9 @@ void AlignMinimap2ShardedTableFunction::Execute(ClientContext &context, TableFun
 			        .count();
 			// Filter out unmapped reads
 			FilterMappedOnly(local_state.result_buffer);
+			if (global_state.progress) {
+				active->alignments_emitted.fetch_add(local_state.result_buffer.size(), std::memory_order_relaxed);
+			}
 			SHARD_DBG_MEM(global_state, "Execute: shard %zu ALIGN %zu reads -> %zu results in %ldms",
 			              static_cast<size_t>(active->shard_idx), static_cast<size_t>(query_batch.size()),
 			              static_cast<size_t>(local_state.result_buffer.size()), static_cast<long>(align_ms));
@@ -507,6 +545,7 @@ TableFunction AlignMinimap2ShardedTableFunction::GetFunction() {
 	tf.named_parameters["eqx"] = LogicalType::BOOLEAN;
 	tf.named_parameters["max_threads_per_shard"] = LogicalType::INTEGER;
 	tf.named_parameters["debug"] = LogicalType::BOOLEAN;
+	tf.named_parameters["progress"] = LogicalType::BOOLEAN;
 	tf.named_parameters["min_chain_coverage"] = LogicalType::FLOAT;
 	tf.named_parameters["include_shard_name"] = LogicalType::BOOLEAN;
 

--- a/src/include/align_bowtie2_daemon_common.hpp
+++ b/src/include/align_bowtie2_daemon_common.hpp
@@ -24,6 +24,9 @@ struct ArrowSchema;
 struct ArrowArray;
 
 namespace duckdb {
+
+class ClientContext;
+
 namespace bt2_daemon {
 
 // gpl-boundary bowtie2-align output schema_version we wire against
@@ -200,6 +203,35 @@ void RegisterBowtie2AlignNamedParameterTypes(TableFunction &tf);
 // ignore `memory_mapped` and reintroduce the cold-FS regression. `binary_path`
 // is the path returned by gpl_boundary::FindGplBoundary().
 void RequireGplBoundaryVersion(const std::string &binary_path, const char *caller);
+
+// =============================================================================
+// bowtie2-build glue shared by align_bowtie2 (temp-dir index) and
+// save_bowtie2_index (persisted index). Every `caller` argument is spliced into
+// the error message so users see the right function name.
+// =============================================================================
+
+// Subjects loaded from a single-end subject table, ready for bowtie2-build.
+struct LoadedSubjects {
+	std::vector<std::string> names;     // subject read_id, coerced to string
+	std::vector<std::string> sequences; // subject sequence1
+};
+
+// Read (read_id, sequence1) from `table_name` through a separate connection.
+// Rejects NULL read_id/sequence1, rejects a non-NULL sequence2 (subjects must be
+// single-end), and rejects an empty result. Throws InvalidInputException.
+LoadedSubjects LoadSingleEndSubjects(ClientContext &context, const std::string &table_name, const char *caller);
+
+// Encode subjects as an Arrow IPC stream of {name, sequence} consumable by the
+// daemon's bowtie2-build input schema. Throws InternalException on encoder failure.
+std::vector<uint8_t> BuildSubjectsIpc(const LoadedSubjects &subjects, const char *caller);
+
+// Build the bowtie2-build config_json: {"index_path": <basename>[, "nthreads": n]}.
+// nthreads is omitted when <= 1 (daemon default).
+std::string BuildBowtie2BuildConfigJson(const std::string &index_basename, int64_t nthreads);
+
+// Parse bowtie2-build's `result.index_files` JSON array into a vector of paths.
+// Throws IOException on malformed JSON or a missing array.
+std::vector<std::string> ParseBowtie2BuildIndexFiles(const std::string &result_json, const char *caller);
 
 } // namespace bt2_daemon
 } // namespace duckdb

--- a/src/include/align_minimap2_sharded.hpp
+++ b/src/include/align_minimap2_sharded.hpp
@@ -41,6 +41,10 @@ struct ActiveShard {
 	std::atomic<idx_t> active_workers {0};             // Threads currently on this shard
 	std::atomic<bool> exhausted {false};               // Set when no more batches to read
 	std::atomic<bool> ready {false};                   // Set when index is loaded and IDs materialized
+	// Progress-only (read/written only when GlobalState::progress is true).
+	std::atomic<idx_t> alignments_emitted {0};        // Mapped alignments produced for this shard
+	idx_t total_reads = 0;                            // Reads pre-fetched for this shard
+	std::chrono::steady_clock::time_point start_time; // Stamped when the shard becomes ready
 };
 
 class AlignMinimap2ShardedTableFunction {
@@ -54,6 +58,7 @@ public:
 		std::vector<ShardInfo> shards; // Sorted by read_count DESC (largest first)
 		idx_t max_threads_per_shard = 4;
 		bool debug = false;
+		bool progress = false;
 		bool include_shard_name = false;
 
 		// Subject-side id type. Sharded mode always loads prebuilt .mmi indexes
@@ -85,6 +90,7 @@ public:
 		idx_t max_threads_per_shard = 4;
 		idx_t max_active_shards = 1; // ceil(db_threads / max_threads_per_shard)
 		bool debug = false;
+		bool progress = false;
 		std::chrono::steady_clock::time_point start_time;
 		std::vector<std::shared_ptr<ActiveShard>> active_shards;
 		std::atomic<idx_t> total_associations {0};

--- a/src/include/save_bowtie2_index.hpp
+++ b/src/include/save_bowtie2_index.hpp
@@ -1,0 +1,58 @@
+#pragma once
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// save_bowtie2_index(subject_table, output_path, [threads]) builds a bowtie2
+// index from a single-end subject table via the gpl-boundary daemon's
+// bowtie2-build tool and persists it at `output_path` (a basename prefix:
+// writes <output_path>.1.bt2 … .rev.2.bt2). The bowtie2 analogue of
+// save_minimap2_index — except the index files are written by the daemon, so
+// this requires gpl-boundary (it advertises bowtie2-build). No >= 0.4.2 gate:
+// building never uses the align-time `memory_mapped` knob.
+class SaveBowtie2IndexTableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::string subject_table;
+		std::string output_path;
+		int64_t threads = 1;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data()
+		    : names({"success", "index_path", "num_subjects"}),
+		      types({LogicalType::BOOLEAN, LogicalType::VARCHAR, LogicalType::BIGINT}) {
+		}
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		bool done = false;
+		int64_t num_subjects = 0;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	struct LocalState : public LocalTableFunctionState {};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+	static unique_ptr<LocalTableFunctionState> InitLocal(ExecutionContext &context, TableFunctionInitInput &input,
+	                                                     GlobalTableFunctionState *global_state);
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/shard_progress.hpp
+++ b/src/include/shard_progress.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+// Opt-in, human-readable, timestamped per-shard progress for the sharded
+// aligners (align_minimap2_sharded / align_bowtie2_sharded). Gated by each
+// function's `progress` named parameter (default false): when off, nothing is
+// emitted and behavior is unchanged, so programmatic / library callers that
+// never pass `progress := true` are unaffected. Lines go to stderr (like the
+// `debug` facility in shard_debug.hpp) with a wall-clock timestamp.
+//
+// The `Format*` functions are PURE (no timing, no I/O) so they can be unit-
+// tested in the standalone Catch2 binary, which links no libduckdb. This header
+// is therefore intentionally duckdb-free: plain `uint64_t`/`int64_t`/`double`,
+// no `idx_t` / `Value` / duckdb headers. `Emit` (timestamp + stderr write) is
+// the only impure piece; it is exercised end-to-end by shaln's --verbose
+// stderr-capture test, not the C++ unit test.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <mutex>
+#include <string>
+
+namespace duckdb {
+namespace shard_progress {
+
+// Group a non-negative integer with comma thousands separators: 48210 -> "48,210".
+// Locale-independent (std::locale is avoided deliberately — it is not reliably
+// available and would make the output environment-dependent).
+inline std::string GroupThousands(uint64_t n) {
+	const std::string digits = std::to_string(n);
+	std::string out;
+	const size_t len = digits.size();
+	for (size_t i = 0; i < len; ++i) {
+		if (i > 0 && (len - i) % 3 == 0) {
+			out.push_back(',');
+		}
+		out.push_back(digits[i]);
+	}
+	return out;
+}
+
+// Body of a per-shard "started" line:
+//   "shard 2/5 'shard_b': index loaded"           (n_reads < 0 -> count unknown)
+//   "shard 2/5 'shard_b': index loaded, 50,000 reads"   (n_reads >= 0)
+// n_reads is < 0 when the shard's read count isn't known at load time (the
+// bowtie2 path streams reads; minimap2 pre-fetches them so it knows the count).
+inline std::string FormatShardStart(uint64_t ordinal, uint64_t shard_count, const std::string &shard_name,
+                                    int64_t n_reads) {
+	std::string s =
+	    "shard " + std::to_string(ordinal) + "/" + std::to_string(shard_count) + " '" + shard_name + "': index loaded";
+	if (n_reads >= 0) {
+		s += ", " + GroupThousands(static_cast<uint64_t>(n_reads)) + " reads";
+	}
+	return s;
+}
+
+// Body of a per-shard "done" line:
+//   "shard 2/5 'shard_b': done - 50,000 reads, 48,210 alignments (2.34s)"
+inline std::string FormatShardDone(uint64_t ordinal, uint64_t shard_count, const std::string &shard_name,
+                                   uint64_t n_reads, uint64_t n_alignments, double elapsed_s) {
+	char secs[32];
+	std::snprintf(secs, sizeof(secs), "%.2fs", elapsed_s);
+	return "shard " + std::to_string(ordinal) + "/" + std::to_string(shard_count) + " '" + shard_name + "': done - " +
+	       GroupThousands(n_reads) + " reads, " + GroupThousands(n_alignments) + " alignments (" + secs + ")";
+}
+
+// Emit one formatted body line to stderr, prefixed with a local wall-clock
+// timestamp (HH:MM:SS.t, tenths of a second) and an aligner `tag`
+// (e.g. "minimap2" / "bowtie2") for greppability. Thread-safe: a process-wide
+// mutex serializes the write so concurrent workers' lines never interleave.
+// Only call when the caller's `progress` flag is set.
+inline void Emit(const char *tag, const std::string &body) {
+	using clock = std::chrono::system_clock;
+	const auto now = clock::now();
+	const std::time_t t = clock::to_time_t(now);
+	const long long tenths = static_cast<long long>(
+	    std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count() % 1000 / 100);
+	std::tm tm_buf {};
+#if defined(_WIN32)
+	localtime_s(&tm_buf, &t);
+#else
+	localtime_r(&t, &tm_buf);
+#endif
+	char ts[16];
+	std::snprintf(ts, sizeof(ts), "%02d:%02d:%02d.%01lld", tm_buf.tm_hour, tm_buf.tm_min, tm_buf.tm_sec, tenths);
+
+	static std::mutex mtx;
+	std::lock_guard<std::mutex> guard(mtx);
+	std::fprintf(stderr, "%s [%s] %s\n", ts, tag, body.c_str());
+	std::fflush(stderr);
+}
+
+} // namespace shard_progress
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -23,6 +23,7 @@
 #include <align_minimap2.hpp>
 #include <align_minimap2_sharded.hpp>
 #include <save_minimap2_index.hpp>
+#include <save_bowtie2_index.hpp>
 #include <read_ncbi_fasta.hpp>
 #include <read_ncbi.hpp>
 #include <read_ncbi_annotation.hpp>
@@ -265,6 +266,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 #ifdef MIINT_HAS_GPL_BOUNDARY
 	AlignBowtie2TableFunction::Register(loader);
 	AlignBowtie2ShardedTableFunction::Register(loader);
+	SaveBowtie2IndexTableFunction::Register(loader);
 	RegisterBowtie2AvailableFunction(loader);
 #else
 	// Stub: bowtie2_available() always returns false when the gpl-boundary

--- a/src/save_bowtie2_index.cpp
+++ b/src/save_bowtie2_index.cpp
@@ -1,0 +1,157 @@
+#include "save_bowtie2_index.hpp"
+
+#include "align_bowtie2_daemon_common.hpp"
+#include "sequence_table_reader.hpp"
+
+#include "duckdb/common/exception.hpp"
+
+#include "gpl_boundary/process.hpp"
+#include "gpl_boundary/session.hpp"
+
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+namespace gb = ::duckdb::miint::gpl_boundary;
+
+// Spawn the daemon and require the bowtie2-build tool. Deliberately does NOT
+// call bt2_daemon::RequireGplBoundaryVersion: building an index never uses the
+// align-time `memory_mapped` knob (the reason align_bowtie2* gate on >= 0.4.2),
+// so index-building stays usable on any daemon that advertises bowtie2-build.
+std::unique_ptr<gb::Session> SpawnBuildSession() {
+	const std::string gpl_path = gb::FindGplBoundary();
+	if (gpl_path.empty()) {
+		throw IOException("save_bowtie2_index: gpl-boundary binary not found. To install:\n"
+		                  "  Easiest:  SELECT install_gpl_boundary();   "
+		                  "-- downloads a prebuilt binary into miint's cache dir\n"
+		                  "  Manual:   curl -fsSL "
+		                  "https://github.com/the-miint/GPL-boundary/releases/latest/download/install.sh | sh\n"
+		                  "If gpl-boundary is installed at a non-standard location, set "
+		                  "MIINT_GPL_BOUNDARY_PATH=<absolute path>.");
+	}
+	std::vector<std::string> argv = {gpl_path};
+	gb::ChildProcess child(argv);
+	auto session = std::make_unique<gb::Session>(std::move(child));
+	session->Initialize();
+	if (!session->has_tool("bowtie2-build")) {
+		throw IOException("save_bowtie2_index: gpl-boundary daemon does not advertise bowtie2-build. "
+		                  "Upgrade to v0.2.0 or later (`SELECT install_gpl_boundary()`).");
+	}
+	return session;
+}
+
+} // namespace
+
+unique_ptr<FunctionData> SaveBowtie2IndexTableFunction::Bind(ClientContext &context, TableFunctionBindInput &input,
+                                                             vector<LogicalType> &return_types,
+                                                             vector<std::string> &names) {
+	auto data = make_uniq<Data>();
+
+	if (input.inputs.size() < 2) {
+		throw BinderException("save_bowtie2_index requires subject_table and output_path parameters");
+	}
+	data->subject_table = input.inputs[0].ToString();
+	data->output_path = input.inputs[1].ToString();
+
+	// Validate the subject table exists and has the right column types (read_id
+	// VARCHAR/BIGINT, sequence1 VARCHAR). Throws BinderException on a missing
+	// table or wrong schema — the daemon wire schema is strings, so the returned
+	// schema isn't otherwise needed here.
+	ValidateSequenceTableSchema(context, data->subject_table, /*allow_bigint=*/true);
+
+	auto threads_param = input.named_parameters.find("threads");
+	if (threads_param != input.named_parameters.end() && !threads_param->second.IsNull()) {
+		data->threads = threads_param->second.GetValue<int64_t>();
+		if (data->threads < 1) {
+			throw InvalidInputException("save_bowtie2_index: threads must be >= 1 (got %lld)",
+			                            static_cast<long long>(data->threads));
+		}
+	}
+
+	for (const auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (const auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+	return std::move(data);
+}
+
+unique_ptr<GlobalTableFunctionState> SaveBowtie2IndexTableFunction::InitGlobal(ClientContext &context,
+                                                                               TableFunctionInitInput &input) {
+	auto &data = input.bind_data->Cast<Data>();
+	auto gstate = make_uniq<GlobalState>();
+
+	// 1. Spawn the daemon + require bowtie2-build (no >= 0.4.2 gate).
+	auto session = SpawnBuildSession();
+
+	// 2. Load subjects (rejects empty / paired) + encode as Arrow IPC.
+	const auto subjects = bt2_daemon::LoadSingleEndSubjects(context, data.subject_table, "save_bowtie2_index");
+	const auto subjects_ipc = bt2_daemon::BuildSubjectsIpc(subjects, "save_bowtie2_index");
+
+	// 3. Ensure the parent directory of the index basename exists, then build
+	//    the index directly at the user's path (kept, unlike align_bowtie2 which
+	//    builds into a temp dir and unlinks it).
+	std::filesystem::path index_path(data.output_path);
+	if (index_path.has_parent_path()) {
+		std::error_code ec;
+		std::filesystem::create_directories(index_path.parent_path(), ec);
+		if (ec) {
+			throw IOException("save_bowtie2_index: failed to create directory '%s': %s",
+			                  index_path.parent_path().string(), ec.message());
+		}
+	}
+
+	const std::string build_config = bt2_daemon::BuildBowtie2BuildConfigJson(data.output_path, data.threads);
+	auto build_result = session->Submit("bowtie2-build", build_config, subjects_ipc.data(), subjects_ipc.size());
+	const auto index_files = bt2_daemon::ParseBowtie2BuildIndexFiles(build_result.result_json, "save_bowtie2_index");
+	if (index_files.empty()) {
+		throw IOException("save_bowtie2_index: bowtie2-build returned zero index_files");
+	}
+
+	gstate->num_subjects = static_cast<int64_t>(subjects.names.size());
+
+	// The daemon has finished writing the .bt2 files; release it.
+	session->Shutdown();
+
+	return std::move(gstate);
+}
+
+unique_ptr<LocalTableFunctionState>
+SaveBowtie2IndexTableFunction::InitLocal(ExecutionContext &, TableFunctionInitInput &, GlobalTableFunctionState *) {
+	return make_uniq<LocalState>();
+}
+
+void SaveBowtie2IndexTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<Data>();
+	auto &gstate = data_p.global_state->Cast<GlobalState>();
+
+	if (gstate.done) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	output.data[0].SetValue(0, Value::BOOLEAN(true));               // success
+	output.data[1].SetValue(0, Value(bind_data.output_path));       // index_path
+	output.data[2].SetValue(0, Value::BIGINT(gstate.num_subjects)); // num_subjects
+	output.SetCardinality(1);
+	gstate.done = true;
+}
+
+TableFunction SaveBowtie2IndexTableFunction::GetFunction() {
+	auto tf = TableFunction("save_bowtie2_index", {LogicalType::VARCHAR, LogicalType::VARCHAR}, Execute, Bind,
+	                        InitGlobal, InitLocal);
+	tf.named_parameters["threads"] = LogicalType::INTEGER;
+	return tf;
+}
+
+void SaveBowtie2IndexTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/test/cpp/test_ShardProgress.cpp
+++ b/test/cpp/test_ShardProgress.cpp
@@ -1,0 +1,44 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "shard_progress.hpp"
+
+#include <string>
+
+using duckdb::shard_progress::FormatShardDone;
+using duckdb::shard_progress::FormatShardStart;
+using duckdb::shard_progress::GroupThousands;
+
+// These pin the EXACT user-facing format of the opt-in `progress` lines emitted
+// by align_minimap2_sharded / align_bowtie2_sharded. The shaln --verbose layer
+// (and users) read/grep these, so a format change must break a test rather than
+// ship silently. Emit() (timestamp + stderr write) is impure and is covered
+// end-to-end by shaln's --verbose stderr-capture test instead.
+
+TEST_CASE("GroupThousands inserts comma separators", "[shard_progress]") {
+	CHECK(GroupThousands(0) == "0");
+	CHECK(GroupThousands(7) == "7");
+	CHECK(GroupThousands(42) == "42");
+	CHECK(GroupThousands(999) == "999");
+	CHECK(GroupThousands(1000) == "1,000");
+	CHECK(GroupThousands(48210) == "48,210");
+	CHECK(GroupThousands(1000000) == "1,000,000");
+}
+
+TEST_CASE("FormatShardStart includes the read count when known", "[shard_progress]") {
+	CHECK(FormatShardStart(1, 2, "shard_a", 50000) == "shard 1/2 'shard_a': index loaded, 50,000 reads");
+}
+
+TEST_CASE("FormatShardStart omits the read count when unknown (streamed)", "[shard_progress]") {
+	// The bowtie2 path streams reads, so the per-shard count is unknown at load
+	// (n_reads < 0) and must be omitted from the "started" line.
+	CHECK(FormatShardStart(2, 5, "shard_b", -1) == "shard 2/5 'shard_b': index loaded");
+}
+
+TEST_CASE("FormatShardDone reports reads, alignments, and elapsed seconds", "[shard_progress]") {
+	CHECK(FormatShardDone(1, 2, "shard_a", 50000, 48210, 2.34) ==
+	      "shard 1/2 'shard_a': done - 50,000 reads, 48,210 alignments (2.34s)");
+}
+
+TEST_CASE("FormatShardDone rounds elapsed to two decimals", "[shard_progress]") {
+	CHECK(FormatShardDone(3, 3, "s", 0, 0, 1.0) == "shard 3/3 's': done - 0 reads, 0 alignments (1.00s)");
+}

--- a/test/sql/align_bowtie2_sharded.test
+++ b/test/sql/align_bowtie2_sharded.test
@@ -535,6 +535,37 @@ SELECT
 0
 
 # ==============================================================================
+# PROGRESS PARAM (opt-in, result-invariant)
+# ==============================================================================
+# `progress := true` enables timestamped per-shard progress lines on stderr.
+# It is a pure side channel: the result multiset MUST be byte-identical to the
+# default (which emits nothing — programmatic callers are unaffected). The
+# stderr lines themselves are asserted by shaln's --verbose stderr-capture test.
+
+statement ok
+SELECT count(*) FROM align_bowtie2_sharded('queries',
+    shard_directory := 'data/bowtie2_shards/', read_to_shard := 'read_to_shard', progress := true);
+
+# Two-direction EXCEPT ALL == 0 ⟺ progress:=true and the default yield equal multisets.
+query I
+SELECT
+  (SELECT COUNT(*) FROM (
+     SELECT read_id, reference, position, flags, cigar FROM align_bowtie2_sharded('queries',
+        shard_directory := 'data/bowtie2_shards/', read_to_shard := 'read_to_shard', progress := true)
+     EXCEPT ALL
+     SELECT read_id, reference, position, flags, cigar FROM align_bowtie2_sharded('queries',
+        shard_directory := 'data/bowtie2_shards/', read_to_shard := 'read_to_shard')))
+  +
+  (SELECT COUNT(*) FROM (
+     SELECT read_id, reference, position, flags, cigar FROM align_bowtie2_sharded('queries',
+        shard_directory := 'data/bowtie2_shards/', read_to_shard := 'read_to_shard')
+     EXCEPT ALL
+     SELECT read_id, reference, position, flags, cigar FROM align_bowtie2_sharded('queries',
+        shard_directory := 'data/bowtie2_shards/', read_to_shard := 'read_to_shard', progress := true)));
+----
+0
+
+# ==============================================================================
 # CLEANUP
 # ==============================================================================
 

--- a/test/sql/align_minimap2_sharded.test
+++ b/test/sql/align_minimap2_sharded.test
@@ -335,6 +335,37 @@ query1	ref1
 query2	ref2
 
 # ==============================================================================
+# PROGRESS PARAM (opt-in, result-invariant)
+# ==============================================================================
+# `progress := true` enables timestamped per-shard progress lines on stderr.
+# It is a pure side channel: the result multiset MUST be byte-identical to the
+# default (which emits nothing — programmatic callers are unaffected). The
+# stderr lines themselves are asserted by shaln's --verbose stderr-capture test.
+
+statement ok
+SELECT count(*) FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard', progress := true);
+
+# Two-direction EXCEPT ALL == 0 ⟺ progress:=true and the default yield equal multisets.
+query I
+SELECT
+  (SELECT COUNT(*) FROM (
+     SELECT read_id, reference, position, flags, cigar FROM align_minimap2_sharded('queries',
+        shard_directory := 'data/shards/', read_to_shard := 'read_to_shard', progress := true)
+     EXCEPT ALL
+     SELECT read_id, reference, position, flags, cigar FROM align_minimap2_sharded('queries',
+        shard_directory := 'data/shards/', read_to_shard := 'read_to_shard')))
+  +
+  (SELECT COUNT(*) FROM (
+     SELECT read_id, reference, position, flags, cigar FROM align_minimap2_sharded('queries',
+        shard_directory := 'data/shards/', read_to_shard := 'read_to_shard')
+     EXCEPT ALL
+     SELECT read_id, reference, position, flags, cigar FROM align_minimap2_sharded('queries',
+        shard_directory := 'data/shards/', read_to_shard := 'read_to_shard', progress := true)));
+----
+0
+
+# ==============================================================================
 # CLEANUP
 # ==============================================================================
 

--- a/test/sql/save_bowtie2_index.test
+++ b/test/sql/save_bowtie2_index.test
@@ -1,0 +1,97 @@
+# name: test/sql/save_bowtie2_index.test
+# description: Test save_bowtie2_index — builds and persists a bowtie2 index from a subject table
+# group: [sql]
+
+require miint
+
+require-env GPL_BOUNDARY_AVAILABLE
+
+# Match the sharded-test convention: the sqllogictest framework is happiest with
+# single-threaded table-function execution.
+statement ok
+SET threads=1;
+
+# ==============================================================================
+# BASIC BUILD: save_bowtie2_index writes a usable bowtie2 index to disk.
+# Reuses the exact ref1/ref2 subject sequences from align_bowtie2.test so the
+# round-trip below has known-aligning query/reference pairs.
+# ==============================================================================
+
+statement ok
+CREATE TABLE subjects AS SELECT * FROM (VALUES
+    ('ref1', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC'),
+    ('ref2', 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCAAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAATTAA')
+) AS t(read_id, sequence1);
+
+# Build into a sharded-layout subdir <dir>/myshard/index.* (what align_bowtie2_sharded expects).
+query II
+SELECT success, num_subjects
+FROM save_bowtie2_index('subjects', '__TEST_DIR__/shards/myshard/index');
+----
+true	2
+
+# The four bowtie2 index files required by align_bowtie2_sharded must exist
+# (bowtie2-build also writes .3/.4, so assert at least the required set).
+query I
+SELECT COUNT(*) >= 4 FROM glob('__TEST_DIR__/shards/myshard/index.*.bt2');
+----
+true
+
+# ==============================================================================
+# ROUND-TRIP (Rule 7 — verify the intent): the freshly built index is consumable
+# by align_bowtie2_sharded and produces the expected alignments.
+# ==============================================================================
+
+statement ok
+CREATE TABLE queries AS SELECT * FROM (VALUES
+    ('query1', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT'),
+    ('query2', 'TGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCATGCA')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE read_to_shard AS SELECT * FROM (VALUES
+    ('query1', 'myshard'),
+    ('query2', 'myshard')
+) AS t(read_id, shard_name);
+
+query II
+SELECT read_id, reference
+FROM align_bowtie2_sharded('queries',
+    shard_directory := '__TEST_DIR__/shards',
+    read_to_shard := 'read_to_shard',
+    max_secondary := 0)
+WHERE flags & 4 = 0
+ORDER BY read_id;
+----
+query1	ref1
+query2	ref2
+
+# ==============================================================================
+# ERROR HANDLING (fail loud)
+# ==============================================================================
+
+# Missing subject table
+statement error
+SELECT * FROM save_bowtie2_index('nonexistent_subjects', '__TEST_DIR__/shards/none/index');
+----
+does not exist
+
+# Empty subject table
+statement ok
+CREATE TABLE empty_subjects(read_id VARCHAR, sequence1 VARCHAR);
+
+statement error
+SELECT * FROM save_bowtie2_index('empty_subjects', '__TEST_DIR__/shards/empty/index');
+----
+is empty
+
+# Paired subjects rejected — subjects must be single-end (sequence2 must be NULL)
+statement ok
+CREATE TABLE paired_subjects AS SELECT * FROM (VALUES
+    ('ref1', 'ACGTACGTACGTACGTACGTACGTACGT', 'ACGTACGTACGTACGTACGTACGTACGT')
+) AS t(read_id, sequence1, sequence2);
+
+statement error
+SELECT * FROM save_bowtie2_index('paired_subjects', '__TEST_DIR__/shards/paired/index');
+----
+single-end


### PR DESCRIPTION
## Summary

Two surgical additions to the alignment stack, developed TDD with self code-review:

### `save_bowtie2_index(subject_table, output_path, [threads])`
Builds and persists a bowtie2 index via the gpl-boundary daemon's `bowtie2-build`
(the bowtie2 counterpart to `save_minimap2_index`). `output_path` is a basename
prefix; writes `<prefix>.1.bt2 … .rev.2.bt2` and auto-creates the parent dir. No
`>=0.4.2` daemon gate — building never uses `memory_mapped`, only `has_tool('bowtie2-build')`.

To keep things DRY, the shared daemon glue (`LoadSingleEndSubjects`, `BuildSubjectsIpc`,
`BuildBowtie2BuildConfigJson`, `ParseBowtie2BuildIndexFiles`) is extracted out of
`align_bowtie2.cpp` into `align_bowtie2_daemon_common.{cpp,hpp}`; `align_bowtie2.cpp`
now consumes it too (hence the large `-198 / +167` shuffle).

### Opt-in `progress` param on the sharded aligners
A `progress` BOOLEAN (default **false**) on `align_minimap2_sharded` and
`align_bowtie2_sharded` emits timestamped, throttled per-shard lifecycle lines to
**stderr** (`index loaded, N reads` → `done — M alignments (Ts)`). **Default behavior
is unchanged** — a programmatic caller that never passes `progress := true` emits
nothing. Pure, unit-testable formatters live in `src/include/shard_progress.hpp`.

## Tests
- `test/sql/save_bowtie2_index.test` — build into a shard layout, assert the 4 required
  `.bt2` files, and a round-trip through `align_bowtie2_sharded` (Rule 7 intent), plus
  error cases. Guarded by `require-env GPL_BOUNDARY_AVAILABLE`.
- `test/cpp/test_ShardProgress.cpp` — Catch2 units for the pure formatters.
- Result-invariance appended to both sharded `.test` files (`progress := true` yields the
  identical result multiset as the default).

## Docs
`docs/table-functions.md` documents `save_bowtie2_index` and the `progress` param.

> Base is `v1.5-variegata` (the branch this was cut from), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)