### PR TITLE
feat(read_fastx,align): native interleaved FASTQ + minimap2 map-time options

### DIFF
--- a/data/fastq/interleaved.fa
+++ b/data/fastq/interleaved.fa
@@ -1,0 +1,8 @@
+>ip1/1
+AAAA
+>ip1/2
+TTTT
+>ip2/1
+GGGG
+>ip2/2
+CCCC

--- a/data/fastq/interleaved.fq
+++ b/data/fastq/interleaved.fq
@@ -1,0 +1,16 @@
+@ip1/1
+AAAA
++
+IIII
+@ip1/2
+TTTT
++
+HHHH
+@ip2/1
+GGGG
++
+JJJJ
+@ip2/2
+CCCC
++
+KKKK

--- a/data/fastq/interleaved_odd.fq
+++ b/data/fastq/interleaved_odd.fq
@@ -1,0 +1,12 @@
+@ip1/1
+AAAA
++
+IIII
+@ip1/2
+TTTT
++
+HHHH
+@ip2/1
+GGGG
++
+JJJJ

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -5,7 +5,7 @@ Table functions allow querying bioinformatics files as SQL tables.
 ## Table of Contents
 
 - [`read_alignments`](#read_alignmentsfilename-reference_lengthstable_name-include_filepathfalse-include_seq_qualfalse) - SAM/BAM alignment files
-- [`read_fastx`](#read_fastxfilename-sequence2filename-include_filepathfalse-qual_offset33-max_batch_bytes512mib) - FASTA/FASTQ sequence files
+- [`read_fastx`](#read_fastxfilename-sequence2filename-interleavedfalse-include_filepathfalse-qual_offset33-max_batch_bytes512mib) - FASTA/FASTQ sequence files
 - [`read_sequences_sff`](#read_sequences_sfffilename-include_filepathfalse-trimtrue) - SFF (454/Roche) sequence files
 - [`read_mzml`](#read_mzmlfilename-include_filepathfalse) - mzML mass spectrometry files
 - [`read_mzxml`](#read_mzxmlfilename-include_filepathfalse) - mzXML mass spectrometry files
@@ -215,7 +215,7 @@ FROM alignment_slice('chr1_alns', 1000, 2000);
 - Multi-region slicing (different regions per reference) is not yet supported; use separate queries per region
 - `alignment_seq_identity` with the `'cigar'` method works on sliced output because it reads identity directly from `=`/`X` CIGAR ops without needing tags. Other methods (`gap_compressed`, `blast`, `gap_excluded`) require NM or MD tags which are NULLed after trimming.
 
-## `read_fastx(filename, [sequence2=filename], [include_filepath=false], [qual_offset=33], [max_batch_bytes='512MiB'])`
+## `read_fastx(filename, [sequence2=filename], [interleaved=false], [include_filepath=false], [qual_offset=33], [max_batch_bytes='512MiB'])`
 Read FASTA/FASTQ sequence files.
 
 **Parameters:**
@@ -224,6 +224,7 @@ Read FASTA/FASTQ sequence files.
   - **Arrays**: VARCHAR[] elements are treated as literal paths (no glob expansion)
 - `sequence2` (VARCHAR or VARCHAR[], optional): Path to R2 file(s) for paired-end reads. Must have same number of files as `filename`
   - **Paired-end with globs**: When `filename` is a glob pattern, `sequence2` must also be a glob pattern. Both are expanded and sorted independently, then paired by position. The expanded file counts must match.
+- `interleaved` (BOOLEAN, optional, default false): Treat each input as an interleaved paired-end stream — consecutive records pair up (record 2k-1 → `sequence1`/`qual1`, record 2k → `sequence2`/`qual2`), emitting one row per pair. Mutually exclusive with `sequence2`. The R1 record's `read_id`/`comment` are used for the pair (any trailing `/1` is stripped). An odd number of records is an error (the final record has no mate). Works with single-stream stdin.
 - `include_filepath` (BOOLEAN, optional, default false): Add filepath column to output
 - `qual_offset` (INTEGER, optional, default 33): Quality score offset (33 for Phred+33, 64 for Phred+64)
 - `max_batch_bytes` (VARCHAR, optional, default `'512MiB'`): Soft cap on the uncompressed sequence+quality bytes buffered per output chunk, given as a formatted byte size (e.g. `'256MiB'`, `'2GB'`). The reader stops adding records to a chunk once their combined bytes reach this budget, which bounds memory when individual records are very large (e.g. assembled genomes at multiple MB each). Short-read data is unaffected — a chunk fills to the standard vector size long before the cap. Must be greater than 0.
@@ -259,6 +260,9 @@ SELECT * FROM read_fastx('reads.fastq.gz');
 
 -- Read paired-end FASTQ files
 SELECT * FROM read_fastx('R1.fastq', sequence2='R2.fastq');
+
+-- Read interleaved paired-end (R1,R2,R1,R2,... in one file or stdin)
+SELECT * FROM read_fastx('interleaved.fastq', interleaved=true);
 
 -- Read multiple single-end files
 SELECT * FROM read_fastx(['sample1.fastq', 'sample2.fastq', 'sample3.fastq']);
@@ -2046,6 +2050,24 @@ Align query sequences against multiple pre-built minimap2 index shards in parall
 - `max_secondary` (INTEGER, default: 5): Maximum secondary alignments per query. Set to 0 for primary only
 - `eqx` (BOOLEAN, default: true): Use =/X CIGAR operators instead of M
 - `progress` (BOOLEAN, default: false): Opt-in progress reporting. When true, emit clean, timestamped per-shard lines to **stderr** (`shard i/N 'name': index loaded, R reads` → `done - R reads, A alignments (T s)`). Pure side channel — results are byte-identical to the default, which emits nothing, so programmatic callers are unaffected unless they pass `progress := true`.
+
+**Map-time scoring / chaining parameters (optional):**
+These tune the minimap2 mapping options (`mm_mapopt_t`) applied *after* the preset, so they change alignment/chaining against the **prebuilt** `.mmi` without rebuilding it. Each is optional; when omitted, the preset default is used (so omitting them all is unchanged behavior). The minimap2 `-k`/`-w` (k-mer/window) options are **not** here — they are baked into the index at `save_minimap2_index` time. Negative values are rejected.
+- `match_score` (INTEGER, ≥ 1, minimap2 `-A`): matching score
+- `mismatch_penalty` (INTEGER, ≥ 0, `-B`): mismatch penalty
+- `gap_open` (INTEGER, ≥ 0, `-O`): gap-open penalty
+- `gap_extend` (INTEGER, ≥ 0, `-E`): gap-extension penalty
+- `gap_open2` (INTEGER, ≥ 0, `-O2`): long-gap open penalty (two-piece affine)
+- `gap_extend2` (INTEGER, ≥ 0, `-E2`): long-gap extension penalty
+- `bandwidth` (INTEGER, ≥ 1, `-r`): chaining/alignment bandwidth
+- `zdrop` (INTEGER, ≥ 0, `-z`): Z-drop score for alignment extension
+- `zdrop_inv` (INTEGER, ≥ 0): Z-drop for inversion detection (`-z`'s second value)
+- `min_chain_score` (INTEGER, ≥ 1, `-m`): minimum chaining score to keep a chain
+- `min_count` (INTEGER, ≥ 1, `-n`): minimum number of minimizers on a chain
+- `max_gap` (INTEGER, ≥ 1, `-g`): maximum gap between chained minimizers
+- `min_dp_max` (INTEGER, ≥ 0, `-s`): minimum peak DP alignment score to keep a hit. The preset sets this (e.g. `sr` → 40); like minimap2's CLI it is **not** auto-recomputed when you change `match_score`/`min_chain_score`, so if you lower the match score, set `min_dp_max` too or the preset default may filter out otherwise-valid hits.
+- `pri_ratio` (FLOAT, 0.0–1.0, `-p`): minimum secondary-to-primary score ratio
+- `mask_level` (FLOAT, 0.0–1.0, `-M`): maximum fraction of query overlap to mask a redundant hit
 
 **Output schema:**
 Returns the same 21-column schema as `align_minimap2` and `read_alignments`.

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -1759,6 +1759,24 @@ Align query sequences to subject sequences using minimap2. This function enables
 - `w` (INTEGER, optional): Minimizer window size (overrides preset default if specified). **Warning:** Ignored when using `index_path` (window size is baked into the pre-built index)
 - `eqx` (BOOLEAN, default: true): Use =/X CIGAR operators instead of M
 
+**Map-time scoring / chaining parameters (optional):**
+These tune the minimap2 mapping options (`mm_mapopt_t`) applied *after* the preset — they affect alignment/chaining whether the index is built from `subject_table` or loaded from `index_path` (they are map-time, not index-time, unlike `k`/`w`). Each is optional; omitting it uses the preset default, so omitting them all is unchanged behavior. Negative values are rejected. (Identical set and semantics as `align_minimap2_sharded`.)
+- `match_score` (INTEGER, ≥ 1, minimap2 `-A`): matching score
+- `mismatch_penalty` (INTEGER, ≥ 0, `-B`): mismatch penalty
+- `gap_open` (INTEGER, ≥ 0, `-O`): gap-open penalty
+- `gap_extend` (INTEGER, ≥ 0, `-E`): gap-extension penalty
+- `gap_open2` (INTEGER, ≥ 0, `-O2`): long-gap open penalty (two-piece affine)
+- `gap_extend2` (INTEGER, ≥ 0, `-E2`): long-gap extension penalty
+- `bandwidth` (INTEGER, ≥ 1, `-r`): chaining/alignment bandwidth
+- `zdrop` (INTEGER, ≥ 0, `-z`): Z-drop score for alignment extension
+- `zdrop_inv` (INTEGER, ≥ 0): Z-drop for inversion detection (`-z`'s second value)
+- `min_chain_score` (INTEGER, ≥ 1, `-m`): minimum chaining score to keep a chain
+- `min_count` (INTEGER, ≥ 1, `-n`): minimum number of minimizers on a chain
+- `max_gap` (INTEGER, ≥ 1, `-g`): maximum gap between chained minimizers
+- `min_dp_max` (INTEGER, ≥ 0, `-s`): minimum peak DP alignment score to keep a hit. The preset sets this (e.g. `sr` → 40) and it is **not** auto-recomputed when you change `match_score`/`min_chain_score`, so if you lower the match score, set `min_dp_max` too or the preset default may filter out otherwise-valid hits.
+- `pri_ratio` (FLOAT, 0.0–1.0, `-p`): minimum secondary-to-primary score ratio
+- `mask_level` (FLOAT, 0.0–1.0, `-M`): maximum fraction of query overlap to mask a redundant hit
+
 **Output schema:**
 Returns the same schema as `read_alignments` (21 columns):
 - `read_id` (VARCHAR, BIGINT, or UUID — mirrors `query_table.read_id`): Query sequence identifier

--- a/src/Minimap2Aligner.cpp
+++ b/src/Minimap2Aligner.cpp
@@ -110,6 +110,61 @@ void Minimap2Aligner::InitOptions(const Minimap2Config &config, mm_idxopt_t &iop
 
 	// Coverage pre-filter threshold
 	mopt.min_chain_coverage = config.min_chain_coverage;
+
+	// Map-time scoring/chaining overrides. Applied after mm_set_opt(preset) so a caller
+	// can tune alignment against a prebuilt index. mm_mapopt_update() (run after the index
+	// loads) only adjusts occurrence thresholds, not these fields, so the overrides persist.
+	// -1 / -1.0f means "unset" (keep the preset default); ParseMinimap2ConfigParams has
+	// already rejected negative user values, so >= 0 reliably distinguishes a set override.
+	if (config.match_score >= 0) {
+		mopt.a = config.match_score;
+	}
+	if (config.mismatch_penalty >= 0) {
+		mopt.b = config.mismatch_penalty;
+	}
+	if (config.gap_open >= 0) {
+		mopt.q = config.gap_open;
+	}
+	if (config.gap_extend >= 0) {
+		mopt.e = config.gap_extend;
+	}
+	if (config.gap_open2 >= 0) {
+		mopt.q2 = config.gap_open2;
+	}
+	if (config.gap_extend2 >= 0) {
+		mopt.e2 = config.gap_extend2;
+	}
+	if (config.bandwidth >= 0) {
+		mopt.bw = config.bandwidth;
+	}
+	if (config.zdrop >= 0) {
+		mopt.zdrop = config.zdrop;
+	}
+	if (config.zdrop_inv >= 0) {
+		mopt.zdrop_inv = config.zdrop_inv;
+	}
+	if (config.min_chain_score >= 0) {
+		mopt.min_chain_score = config.min_chain_score;
+	}
+	if (config.min_count >= 0) {
+		mopt.min_cnt = config.min_count;
+	}
+	if (config.max_gap >= 0) {
+		mopt.max_gap = config.max_gap;
+	}
+	// min_dp_max is the minimal peak DP score to keep a hit (minimap2 -s). The preset sets it
+	// (sr -> 40); like minimap2's CLI we do NOT auto-recompute it from match_score/min_chain_score,
+	// so a caller that drops the match score should set min_dp_max too if the default would filter
+	// their hits.
+	if (config.min_dp_max >= 0) {
+		mopt.min_dp_max = config.min_dp_max;
+	}
+	if (config.pri_ratio >= 0.0f) {
+		mopt.pri_ratio = config.pri_ratio;
+	}
+	if (config.mask_level >= 0.0f) {
+		mopt.mask_level = config.mask_level;
+	}
 }
 
 // Static helper: load index from .mmi file

--- a/src/SequenceReader.cpp
+++ b/src/SequenceReader.cpp
@@ -398,8 +398,94 @@ SequenceRecordBatch SequenceReader::read_pe(const int n, const size_t max_bytes)
 	return batch;
 }
 
+// Read a single stream as interleaved paired-end: consecutive records collapse into one
+// paired row (record 2k-1 -> R1, record 2k -> R2). Mirrors read_pe's budget/tail-buffer
+// machinery but draws both mates from the one stream, so it carries any odd trailing record
+// across polls (in buffered_read1_) until its mate arrives. R1's id wins (append_pe). The
+// mate-id parity check is intentionally skipped: interleaved files do not always carry /1 /2.
+SequenceRecordBatch SequenceReader::read_interleaved(const int n, const size_t max_bytes) {
+	SequenceRecordBatch batch(true);
+	batch.reserve(n);
+
+	size_t cumulative_bytes = 0;
+
+	// Records pulled from the stream but not yet formed into pairs. Seeded from
+	// buffered_read1_ (the construction-time peek, or a stashed tail from a prior call)
+	// and refilled by polling. Any unconsumed remainder is stashed back into
+	// buffered_read1_ for the next call.
+	std::vector<klibpp::KSeq> pending = std::move(buffered_read1_);
+	buffered_read1_.clear();
+	first_read_ = false;
+
+	auto stash = [&](size_t i) {
+		buffered_read1_.clear();
+		buffered_read1_.reserve(pending.size() - i);
+		for (size_t j = i; j < pending.size(); j++) {
+			buffered_read1_.push_back(std::move(pending[j]));
+		}
+	};
+
+	while (true) {
+		// Form as many pairs as possible from the currently pending records.
+		size_t i = 0;
+		while (i + 1 < pending.size()) {
+			auto &rec1 = pending[i];
+			auto &rec2 = pending[i + 1];
+			const size_t pair_bytes = record_bytes(rec1) + record_bytes(rec2);
+			// Starvation guard: always accept at least one pair, even if it exceeds the budget.
+			if (!batch.empty() && cumulative_bytes + pair_bytes > max_bytes) {
+				stash(i);
+				return batch;
+			}
+			append_pe(batch, rec1, rec2);
+			cumulative_bytes += pair_bytes;
+			observed_record_bytes_ = pair_bytes;
+			i += 2;
+			if ((int)batch.size() >= n || cumulative_bytes >= max_bytes) {
+				stash(i);
+				return batch;
+			}
+		}
+
+		// 0 or 1 leftover record remains unpaired; keep it and poll for its mate / more.
+		std::vector<klibpp::KSeq> leftover;
+		if (i < pending.size()) {
+			leftover.push_back(std::move(pending[i]));
+		}
+
+		// Each pair consumes two records; size the poll to the rows still wanted (>= one pair).
+		const int remaining_pairs = n - (int)batch.size();
+		const int remaining_records = (remaining_pairs > 0 ? remaining_pairs : 1) * 2;
+		const int poll_n = dynamic_poll_n(observed_record_bytes_, max_bytes, remaining_records);
+		auto more = read_stream(sequence1_reader_, poll_n);
+		max_poll_count_ = more.size() > max_poll_count_ ? more.size() : max_poll_count_;
+
+		if (more.empty()) {
+			// EOF. A lone leftover record has no mate -> odd-count error.
+			if (!leftover.empty()) {
+				throw std::runtime_error(
+				    "read_fastx: interleaved input has an odd number of records (unpaired mate for '" +
+				    leftover[0].name + "')");
+			}
+			return batch;
+		}
+
+		// pending = leftover ++ more
+		pending.clear();
+		pending.reserve(leftover.size() + more.size());
+		for (auto &r : leftover) {
+			pending.push_back(std::move(r));
+		}
+		for (auto &r : more) {
+			pending.push_back(std::move(r));
+		}
+	}
+}
+
 SequenceRecordBatch SequenceReader::read(const int n, const size_t max_bytes) {
-	if (paired_) {
+	if (interleaved_) {
+		return read_interleaved(n, max_bytes);
+	} else if (paired_) {
 		return read_pe(n, max_bytes);
 	} else {
 		return read_se(n, max_bytes);

--- a/src/align_minimap2.cpp
+++ b/src/align_minimap2.cpp
@@ -308,6 +308,25 @@ TableFunction AlignMinimap2TableFunction::GetFunction() {
 	tf.named_parameters["debug"] = LogicalType::BOOLEAN;
 	tf.named_parameters["min_chain_coverage"] = LogicalType::FLOAT;
 
+	// Map-time scoring/chaining knobs (set on mm_mapopt_t after the preset). Same shared
+	// Minimap2Config path as align_minimap2_sharded; parsed + validated by
+	// ParseMinimap2ConfigParams. k/w above stay index-build options.
+	tf.named_parameters["match_score"] = LogicalType::INTEGER;
+	tf.named_parameters["mismatch_penalty"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_open"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_extend"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_open2"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_extend2"] = LogicalType::INTEGER;
+	tf.named_parameters["bandwidth"] = LogicalType::INTEGER;
+	tf.named_parameters["zdrop"] = LogicalType::INTEGER;
+	tf.named_parameters["zdrop_inv"] = LogicalType::INTEGER;
+	tf.named_parameters["min_chain_score"] = LogicalType::INTEGER;
+	tf.named_parameters["min_count"] = LogicalType::INTEGER;
+	tf.named_parameters["max_gap"] = LogicalType::INTEGER;
+	tf.named_parameters["min_dp_max"] = LogicalType::INTEGER;
+	tf.named_parameters["pri_ratio"] = LogicalType::FLOAT;
+	tf.named_parameters["mask_level"] = LogicalType::FLOAT;
+
 	// Alignment output order is non-deterministic (depends on thread scheduling),
 	// so NO_ORDER lets DuckDB parallelize CTAS pipelines instead of serializing
 	// them via preserve_insertion_order.

--- a/src/align_minimap2_sharded.cpp
+++ b/src/align_minimap2_sharded.cpp
@@ -549,6 +549,25 @@ TableFunction AlignMinimap2ShardedTableFunction::GetFunction() {
 	tf.named_parameters["min_chain_coverage"] = LogicalType::FLOAT;
 	tf.named_parameters["include_shard_name"] = LogicalType::BOOLEAN;
 
+	// Map-time scoring/chaining knobs (set on mm_mapopt_t after the preset; tune
+	// alignment against the prebuilt .mmi without rebuilding). Parsed + validated by
+	// ParseMinimap2ConfigParams. k/w stay index-time only (baked into the .mmi).
+	tf.named_parameters["match_score"] = LogicalType::INTEGER;
+	tf.named_parameters["mismatch_penalty"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_open"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_extend"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_open2"] = LogicalType::INTEGER;
+	tf.named_parameters["gap_extend2"] = LogicalType::INTEGER;
+	tf.named_parameters["bandwidth"] = LogicalType::INTEGER;
+	tf.named_parameters["zdrop"] = LogicalType::INTEGER;
+	tf.named_parameters["zdrop_inv"] = LogicalType::INTEGER;
+	tf.named_parameters["min_chain_score"] = LogicalType::INTEGER;
+	tf.named_parameters["min_count"] = LogicalType::INTEGER;
+	tf.named_parameters["max_gap"] = LogicalType::INTEGER;
+	tf.named_parameters["min_dp_max"] = LogicalType::INTEGER;
+	tf.named_parameters["pri_ratio"] = LogicalType::FLOAT;
+	tf.named_parameters["mask_level"] = LogicalType::FLOAT;
+
 	tf.table_scan_progress = Progress;
 
 	// Alignment output order is non-deterministic — NO_ORDER enables parallel CTAS.

--- a/src/include/Minimap2Aligner.hpp
+++ b/src/include/Minimap2Aligner.hpp
@@ -36,6 +36,26 @@ struct Minimap2Config {
 	int k = 0;                       // k-mer size (0 = use preset default)
 	int w = 0;                       // minimizer window (0 = use preset default)
 	float min_chain_coverage = 0.0f; // min best-chain span (qe-qs)/qlen to attempt DP (0.0 = disabled)
+
+	// Map-time scoring/chaining overrides (mm_mapopt_t). -1 / -1.0f = "unset, use the
+	// preset default". Applied in InitOptions after mm_set_opt(preset), so they tune
+	// alignment against a prebuilt index without rebuilding it. Validated in
+	// ParseMinimap2ConfigParams (negatives rejected so they never alias the sentinel).
+	int match_score = -1;      // -A  matching score (mm_mapopt_t::a)
+	int mismatch_penalty = -1; // -B  mismatch penalty (::b)
+	int gap_open = -1;         // -O  gap-open penalty (::q)
+	int gap_extend = -1;       // -E  gap-extension penalty (::e)
+	int gap_open2 = -1;        // -O2 long-gap open penalty (::q2)
+	int gap_extend2 = -1;      // -E2 long-gap extension penalty (::e2)
+	int bandwidth = -1;        // -r  chaining/alignment bandwidth (::bw)
+	int zdrop = -1;            // -z  Z-drop score (::zdrop)
+	int zdrop_inv = -1;        // -z second value, inversion Z-drop (::zdrop_inv)
+	int min_chain_score = -1;  // -m  min chaining score (::min_chain_score)
+	int min_count = -1;        // -n  min number of minimizers on a chain (::min_cnt)
+	int max_gap = -1;          // -g  max gap between chained minimizers (::max_gap)
+	int min_dp_max = -1;       // -s  min peak DP alignment score to keep a hit (::min_dp_max)
+	float pri_ratio = -1.0f;   // -p  min secondary-to-primary score ratio (::pri_ratio)
+	float mask_level = -1.0f;  // -M  max fraction of overlap to mask (::mask_level)
 };
 
 // Custom deleter for minimap2 index

--- a/src/include/SequenceReader.hpp
+++ b/src/include/SequenceReader.hpp
@@ -42,6 +42,14 @@ public:
 	// Defaults to SIZE_MAX, preserving the row-only behavior for existing callers.
 	SequenceRecordBatch read(const int n, const size_t max_bytes = SIZE_MAX);
 
+	// Treat the single stream as interleaved paired-end (record 2k-1 = R1, record 2k = R2),
+	// emitting one paired row per two consecutive records. Must be called before the first
+	// read() and only on a single-stream (non-paired) reader. read() then dispatches to
+	// read_interleaved() instead of read_se().
+	void set_interleaved(bool v) {
+		interleaved_ = v;
+	}
+
 	// Test seam: the largest number of records materialized by any single underlying stream
 	// poll over this reader's lifetime. Lets tests assert that large records do not trigger
 	// oversized prefetches (see dynamic poll sizing in read_se/read_pe).
@@ -67,7 +75,8 @@ private:
 	std::optional<StreamVar> sequence2_reader_;
 
 	bool paired_;
-	bool first_read_; // Track if we need to return buffered data
+	bool interleaved_ = false; // single stream read as interleaved paired-end
+	bool first_read_;          // Track if we need to return buffered data
 	std::vector<klibpp::KSeq> buffered_read1_;
 	std::vector<klibpp::KSeq> buffered_read2_;
 
@@ -79,5 +88,6 @@ private:
 
 	SequenceRecordBatch read_se(const int n, const size_t max_bytes);
 	SequenceRecordBatch read_pe(const int n, const size_t max_bytes);
+	SequenceRecordBatch read_interleaved(const int n, const size_t max_bytes);
 };
 }; // namespace miint

--- a/src/include/align_common.hpp
+++ b/src/include/align_common.hpp
@@ -108,6 +108,46 @@ inline void ParseMinimap2ConfigParams(const named_parameter_map_t &params, miint
 			throw InvalidInputException("min_chain_coverage must be between 0.0 and 1.0");
 		}
 	}
+
+	// Map-time scoring/chaining overrides. Each is optional; when present it must be
+	// in range (negatives are rejected so a user value can never alias the "unset"
+	// sentinel and be silently dropped). Stored into config; applied in InitOptions.
+	auto parse_int_min = [&params](const char *name, int &dst, int min_val) {
+		auto it = params.find(name);
+		if (it != params.end() && !it->second.IsNull()) {
+			int v = it->second.GetValue<int32_t>();
+			if (v < min_val) {
+				throw InvalidInputException("%s must be >= %d", name, min_val);
+			}
+			dst = v;
+		}
+	};
+	auto parse_ratio = [&params](const char *name, float &dst) {
+		auto it = params.find(name);
+		if (it != params.end() && !it->second.IsNull()) {
+			float v = it->second.GetValue<float>();
+			if (v < 0.0f || v > 1.0f) {
+				throw InvalidInputException("%s must be between 0.0 and 1.0", name);
+			}
+			dst = v;
+		}
+	};
+
+	parse_int_min("match_score", config.match_score, 1);
+	parse_int_min("mismatch_penalty", config.mismatch_penalty, 0);
+	parse_int_min("gap_open", config.gap_open, 0);
+	parse_int_min("gap_extend", config.gap_extend, 0);
+	parse_int_min("gap_open2", config.gap_open2, 0);
+	parse_int_min("gap_extend2", config.gap_extend2, 0);
+	parse_int_min("bandwidth", config.bandwidth, 1);
+	parse_int_min("zdrop", config.zdrop, 0);
+	parse_int_min("zdrop_inv", config.zdrop_inv, 0);
+	parse_int_min("min_chain_score", config.min_chain_score, 1);
+	parse_int_min("min_count", config.min_count, 1);
+	parse_int_min("max_gap", config.max_gap, 1);
+	parse_int_min("min_dp_max", config.min_dp_max, 0);
+	parse_ratio("pri_ratio", config.pri_ratio);
+	parse_ratio("mask_level", config.mask_level);
 }
 
 // Output SAMRecordBatch to DataChunk using the standard alignment schema.

--- a/src/include/read_fastx.hpp
+++ b/src/include/read_fastx.hpp
@@ -26,6 +26,7 @@ public:
 		std::optional<std::vector<std::string>> sequence2_paths;
 		bool include_filepath;
 		bool uses_stdin;
+		bool interleaved;
 		uint8_t qual_offset;
 		uint64_t max_batch_bytes;
 
@@ -33,9 +34,9 @@ public:
 		std::vector<LogicalType> types; // field types
 
 		Data(const std::vector<std::string> &r1_paths, const std::optional<std::vector<std::string>> &r2_paths,
-		     bool include_fp, bool stdin_used, uint8_t offset, uint64_t max_bytes)
+		     bool include_fp, bool stdin_used, bool interleaved_in, uint8_t offset, uint64_t max_bytes)
 		    : sequence1_paths(r1_paths), sequence2_paths(r2_paths), include_filepath(include_fp),
-		      uses_stdin(stdin_used), qual_offset(offset), max_batch_bytes(max_bytes),
+		      uses_stdin(stdin_used), interleaved(interleaved_in), qual_offset(offset), max_batch_bytes(max_bytes),
 		      names({"sequence_index", "read_id", "comment", "sequence1", "sequence2", "qual1", "qual2"}),
 		      types({LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::VARCHAR,
 		             LogicalType::VARCHAR, LogicalType::LIST(LogicalType::UTINYINT),
@@ -56,6 +57,7 @@ public:
 		std::vector<std::string> sequence2_filepaths;
 		size_t next_file_idx; // Next file available for claiming
 		bool uses_stdin;
+		bool interleaved;
 		std::vector<uint64_t>
 		    file_sequence_counters; // Per-file sequence counters (no atomic needed - file access is exclusive)
 		FileSystem &fs;
@@ -71,8 +73,9 @@ public:
 		};
 
 		GlobalState(FileSystem &fs, const std::vector<std::string> &sequence1_paths,
-		            const std::optional<std::vector<std::string>> &sequence2_paths, bool stdin_used)
-		    : next_file_idx(0), uses_stdin(stdin_used), fs(fs) {
+		            const std::optional<std::vector<std::string>> &sequence2_paths, bool stdin_used,
+		            bool interleaved_in)
+		    : next_file_idx(0), uses_stdin(stdin_used), interleaved(interleaved_in), fs(fs) {
 			sequence1_filepaths = sequence1_paths;
 			if (sequence2_paths.has_value()) {
 				sequence2_filepaths = sequence2_paths.value();
@@ -104,6 +107,12 @@ public:
 				                                                            sequence2_filepaths[file_idx]);
 			} else {
 				readers[file_idx] = std::make_unique<miint::SequenceReader>(sequence1_filepaths[file_idx]);
+			}
+			// Interleaved: read the single stream as paired-end (R1,R2,R1,R2,...). Bind has
+			// already rejected interleaved + sequence2, so this only applies to single-stream
+			// readers.
+			if (interleaved) {
+				readers[file_idx]->set_interleaved(true);
 			}
 		}
 	};

--- a/src/read_fastx.cpp
+++ b/src/read_fastx.cpp
@@ -140,6 +140,17 @@ unique_ptr<FunctionData> ReadFastxTableFunction::Bind(ClientContext &context, Ta
 		sequence2_paths = seq2_paths;
 	}
 
+	// Interleaved paired-end from a single stream (record 2k-1 = R1, 2k = R2). Mutually
+	// exclusive with the two-file sequence2 mode.
+	bool interleaved = false;
+	auto il_param = input.named_parameters.find("interleaved");
+	if (il_param != input.named_parameters.end() && !il_param->second.IsNull()) {
+		interleaved = il_param->second.GetValue<bool>();
+	}
+	if (interleaved && sequence2_paths.has_value()) {
+		throw InvalidInputException("read_fastx: interleaved cannot be combined with the sequence2 parameter");
+	}
+
 	bool include_filepath = false;
 	auto fp_param = input.named_parameters.find("include_filepath");
 	if (fp_param != input.named_parameters.end() && !fp_param->second.IsNull()) {
@@ -175,8 +186,8 @@ unique_ptr<FunctionData> ReadFastxTableFunction::Bind(ClientContext &context, Ta
 		max_batch_bytes = static_cast<uint64_t>(parsed);
 	}
 
-	auto data = duckdb::make_uniq<Data>(sequence1_paths, sequence2_paths, include_filepath, uses_stdin, qual_offset,
-	                                    max_batch_bytes);
+	auto data = duckdb::make_uniq<Data>(sequence1_paths, sequence2_paths, include_filepath, uses_stdin, interleaved,
+	                                    qual_offset, max_batch_bytes);
 	for (auto &name : data->names) {
 		names.emplace_back(name);
 	}
@@ -190,7 +201,8 @@ unique_ptr<GlobalTableFunctionState> ReadFastxTableFunction::InitGlobal(ClientCo
                                                                         TableFunctionInitInput &input) {
 	auto &data = input.bind_data->Cast<Data>();
 	auto &fs = FileSystem::GetFileSystem(context);
-	return duckdb::make_uniq<GlobalState>(fs, data.sequence1_paths, data.sequence2_paths, data.uses_stdin);
+	return duckdb::make_uniq<GlobalState>(fs, data.sequence1_paths, data.sequence2_paths, data.uses_stdin,
+	                                      data.interleaved);
 }
 
 unique_ptr<LocalTableFunctionState> ReadFastxTableFunction::InitLocal(ExecutionContext &context,
@@ -360,6 +372,7 @@ static unique_ptr<NodeStatistics> ReadFastxCardinality(ClientContext &context, c
 TableFunction ReadFastxTableFunction::GetFunction() {
 	auto tf = TableFunction("read_fastx", {LogicalType::ANY}, Execute, Bind, InitGlobal, InitLocal);
 	tf.named_parameters["sequence2"] = LogicalType::ANY;
+	tf.named_parameters["interleaved"] = LogicalType::BOOLEAN;
 	tf.named_parameters["include_filepath"] = LogicalType::BOOLEAN;
 	tf.named_parameters["qual_offset"] = LogicalType::BIGINT;
 	tf.named_parameters["max_batch_bytes"] = LogicalType::VARCHAR;

--- a/test/cpp/test_SequenceReader.cpp
+++ b/test/cpp/test_SequenceReader.cpp
@@ -538,3 +538,113 @@ TEST_CASE("SequenceReader byte budget default (SIZE_MAX) unchanged behavior", "[
 	auto batch = reader.read(100); // no budget argument -> default SIZE_MAX
 	REQUIRE((batch.size() == 50));
 }
+
+// Interleaved single stream: consecutive records pair up (2k-1 = R1, 2k = R2). R1's id
+// wins (the /1 is stripped); the A-sequence (R1) always lands in sequence1, the C-sequence
+// (R2) in sequence2.
+TEST_CASE("SequenceReader interleaved basic", "[SequenceReader][interleaved]") {
+	TempFileFixture fixture;
+	auto path = "il_basic.fq";
+	fixture.write_temp_fastq(
+	    path, {fixture.simple_read("p0/1", "AAAA", "IIII"), fixture.simple_read("p0/2", "CCCC", "HHHH"),
+	           fixture.simple_read("p1/1", "AAAA", "IIII"), fixture.simple_read("p1/2", "CCCC", "HHHH")});
+
+	miint::SequenceReader reader(path);
+	reader.set_interleaved(true);
+	auto batch = reader.read(100);
+
+	REQUIRE((batch.size() == 2));
+	REQUIRE((batch.is_paired));
+	REQUIRE((batch.read_ids[0] == "p0"));
+	REQUIRE((batch.read_ids[1] == "p1"));
+	REQUIRE((batch.sequences1[0] == "AAAA"));
+	REQUIRE((batch.sequences2[0] == "CCCC"));
+	REQUIRE((batch.quals1[0].as_string() == "IIII"));
+	REQUIRE((batch.quals2[0].as_string() == "HHHH"));
+}
+
+// The hard path: with 10 pairs (20 records) the reader polls in POLL_CHUNK_SIZE (16) bursts,
+// so a poll lands on an odd record boundary and a lone R1 must be carried over to pair with
+// the next poll's first record. A carry bug would swap an R1/R2 across the boundary.
+TEST_CASE("SequenceReader interleaved carry across poll boundary", "[SequenceReader][interleaved]") {
+	TempFileFixture fixture;
+	auto path = "il_carry.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 10; i++) {
+		records.push_back(fixture.simple_read("p" + std::to_string(i) + "/1", "AAAA", "IIII"));
+		records.push_back(fixture.simple_read("p" + std::to_string(i) + "/2", "CCCC", "HHHH"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+	reader.set_interleaved(true);
+	auto batch = reader.read(100);
+
+	REQUIRE((batch.size() == 10));
+	for (size_t k = 0; k < batch.size(); k++) {
+		REQUIRE((batch.read_ids[k] == "p" + std::to_string(k)));
+		REQUIRE((batch.sequences1[k] == "AAAA")); // R1 never swapped to sequence2
+		REQUIRE((batch.sequences2[k] == "CCCC"));
+	}
+}
+
+// Budget so tight only one pair fits per call: every pair must still surface, in order, with
+// R1/R2 correctly placed (the leftover-tail stash carries records between calls).
+TEST_CASE("SequenceReader interleaved byte budget across calls", "[SequenceReader][interleaved][byte_budget]") {
+	TempFileFixture fixture;
+	auto path = "il_budget.fq";
+	std::vector<std::string> records;
+	for (int i = 0; i < 6; i++) {
+		records.push_back(fixture.simple_read("p" + std::to_string(i) + "/1", "AAAA", "IIII"));
+		records.push_back(fixture.simple_read("p" + std::to_string(i) + "/2", "CCCC", "HHHH"));
+	}
+	fixture.write_temp_fastq(path, records);
+
+	miint::SequenceReader reader(path);
+	reader.set_interleaved(true);
+
+	std::vector<std::string> seen;
+	for (int call = 0; call < 50; call++) {
+		auto batch = reader.read(100, 40); // pair ~26 bytes; only one pair fits
+		if (batch.empty()) {
+			break;
+		}
+		REQUIRE((batch.size() == 1));
+		REQUIRE((batch.sequences1[0] == "AAAA"));
+		REQUIRE((batch.sequences2[0] == "CCCC"));
+		seen.push_back(batch.read_ids[0]);
+	}
+	std::vector<std::string> expected = {"p0", "p1", "p2", "p3", "p4", "p5"};
+	REQUIRE((seen == expected));
+}
+
+// An odd number of records means the final record has no mate -> loud error.
+TEST_CASE("SequenceReader interleaved odd record count throws", "[SequenceReader][interleaved][error]") {
+	TempFileFixture fixture;
+	auto path = "il_odd.fq";
+	fixture.write_temp_fastq(path,
+	                         {fixture.simple_read("p0/1", "AAAA", "IIII"), fixture.simple_read("p0/2", "CCCC", "HHHH"),
+	                          fixture.simple_read("p1/1", "AAAA", "IIII")});
+
+	miint::SequenceReader reader(path);
+	reader.set_interleaved(true);
+	REQUIRE_THROWS_WITH(reader.read(100), Catch::Matchers::ContainsSubstring("odd number of records"));
+}
+
+// Interleaved FASTA has no quality: both qual columns are empty, mates still paired.
+TEST_CASE("SequenceReader interleaved FASTA has no quality", "[SequenceReader][interleaved][FASTA]") {
+	TempFileFixture fixture;
+	auto path = "il_fasta.fa";
+	fixture.write_temp_fastq(path, {fixture.simple_fasta("p0/1", "AAAA"), fixture.simple_fasta("p0/2", "CCCC")});
+
+	miint::SequenceReader reader(path);
+	reader.set_interleaved(true);
+	auto batch = reader.read(100);
+
+	REQUIRE((batch.size() == 1));
+	REQUIRE((batch.is_paired));
+	REQUIRE((batch.sequences1[0] == "AAAA"));
+	REQUIRE((batch.sequences2[0] == "CCCC"));
+	REQUIRE((batch.quals1[0].as_string().empty()));
+	REQUIRE((batch.quals2[0].as_string().empty()));
+}

--- a/test/sql/align_minimap2.test
+++ b/test/sql/align_minimap2.test
@@ -334,3 +334,67 @@ DROP TABLE mt_subjects;
 
 statement ok
 DROP TABLE mt_queries;
+
+# ==============================================================================
+# MAP-TIME SCORING / CHAINING PARAMETERS
+# ==============================================================================
+# The same mm_mapopt_t knobs exposed on align_minimap2_sharded are available here
+# too (shared Minimap2Config / InitOptions path), applied after the preset. Defaults
+# = preset defaults, so omitting them is unchanged. k/w remain index-build options.
+
+statement ok
+CREATE TABLE score_subjects AS SELECT * FROM (VALUES
+    ('ref1', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCCTTAAGGCC')
+) AS t(read_id, sequence1);
+
+statement ok
+CREATE TABLE score_queries AS SELECT * FROM (VALUES
+    ('q1', 'ACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGTACGT')
+) AS t(read_id, sequence1);
+
+# Baseline: q1 aligns to ref1.
+query I
+SELECT COUNT(*) FROM align_minimap2('score_queries', subject_table := 'score_subjects', max_secondary := 0)
+WHERE NOT alignment_is_unmapped(flags);
+----
+1
+
+# min_chain_score set absurdly high drops the alignment -- proves the knob is
+# registered and wired on the non-sharded function too.
+query I
+SELECT COUNT(*) FROM align_minimap2('score_queries', subject_table := 'score_subjects',
+    max_secondary := 0, min_chain_score := 100000)
+WHERE NOT alignment_is_unmapped(flags);
+----
+0
+
+# min_dp_max (minimap2 -s) above any 52bp DP score drops the alignment.
+query I
+SELECT COUNT(*) FROM align_minimap2('score_queries', subject_table := 'score_subjects',
+    max_secondary := 0, min_dp_max := 100000)
+WHERE NOT alignment_is_unmapped(flags);
+----
+0
+
+# All new knobs accept valid values together and still align.
+query I
+SELECT COUNT(*) FROM align_minimap2('score_queries', subject_table := 'score_subjects',
+    max_secondary := 0, match_score := 2, mismatch_penalty := 4, gap_open := 4,
+    gap_extend := 2, gap_open2 := 24, gap_extend2 := 1, bandwidth := 500, zdrop := 400,
+    zdrop_inv := 200, min_count := 1, max_gap := 5000, min_dp_max := 1, pri_ratio := 0.8,
+    mask_level := 0.5)
+WHERE NOT alignment_is_unmapped(flags);
+----
+1
+
+# Validation is shared with the sharded path (negative penalty rejected).
+statement error
+SELECT * FROM align_minimap2('score_queries', subject_table := 'score_subjects', mismatch_penalty := -3);
+----
+mismatch_penalty must be >= 0
+
+statement ok
+DROP TABLE score_subjects;
+
+statement ok
+DROP TABLE score_queries;

--- a/test/sql/align_minimap2_sharded.test
+++ b/test/sql/align_minimap2_sharded.test
@@ -366,6 +366,123 @@ SELECT
 0
 
 # ==============================================================================
+# MINIMAP2 MAP-TIME SCORING / CHAINING PARAMETERS
+# ==============================================================================
+# These knobs set mm_mapopt_t fields after the preset, so callers can tune
+# alignment/chaining against a prebuilt .mmi without rebuilding it. Defaults =
+# preset defaults, so omitting them is unchanged (every test above passing is
+# that invariance assertion).
+
+# min_chain_score set absurdly high drops every alignment (a 52bp read's chain
+# score is in the tens, never 100000) -- proves the knob reaches the mapper and
+# changes the output.
+query I
+SELECT COUNT(*) FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    min_chain_score := 100000, max_secondary := 0)
+WHERE NOT alignment_is_unmapped(flags);
+----
+0
+
+# A permissive min_chain_score is wired but does not drop the well-aligned reads.
+query II
+SELECT read_id, reference FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    min_chain_score := 1, max_secondary := 0)
+WHERE NOT alignment_is_unmapped(flags) ORDER BY read_id;
+----
+query1	ref1
+query2	ref2
+
+# min_count (mm_mapopt_t::min_cnt) set above any 52bp read's minimizer count drops
+# all alignments -- proves min_count maps to a DISTINCT field from min_chain_score.
+query I
+SELECT COUNT(*) FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    min_count := 100, max_secondary := 0)
+WHERE NOT alignment_is_unmapped(flags);
+----
+0
+
+# min_dp_max (minimap2 -s) set above any 52bp read's DP score drops all alignments --
+# proves the alignment-score filter is exposed and wired to its own field.
+query I
+SELECT COUNT(*) FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    min_dp_max := 100000, max_secondary := 0)
+WHERE NOT alignment_is_unmapped(flags);
+----
+0
+
+# match_score (mm_mapopt_t::a) lowers the alignment (AS) score vs the default a=2 --
+# proves a scoring knob reaches the DP and is wired to its own field, not a no-op.
+query I
+SELECT
+  (SELECT tag_as FROM align_minimap2_sharded('queries',
+       shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+       match_score := 1, max_secondary := 0) WHERE read_id = 'query1' AND NOT alignment_is_unmapped(flags))
+  <
+  (SELECT tag_as FROM align_minimap2_sharded('queries',
+       shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+       max_secondary := 0) WHERE read_id = 'query1' AND NOT alignment_is_unmapped(flags));
+----
+true
+
+# All new scoring/chaining knobs accept valid values together and still align.
+query II
+SELECT read_id, reference FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    match_score := 2, mismatch_penalty := 4, gap_open := 4, gap_extend := 2,
+    gap_open2 := 24, gap_extend2 := 1, bandwidth := 500, zdrop := 400,
+    zdrop_inv := 200, min_count := 1, max_gap := 5000,
+    pri_ratio := 0.8, mask_level := 0.5, max_secondary := 0)
+WHERE NOT alignment_is_unmapped(flags) ORDER BY read_id;
+----
+query1	ref1
+query2	ref2
+
+# Validation: pri_ratio out of [0,1]
+statement error
+SELECT * FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    pri_ratio := 1.5);
+----
+pri_ratio must be between 0.0 and 1.0
+
+# Validation: mask_level out of [0,1]
+statement error
+SELECT * FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    mask_level := 2.0);
+----
+mask_level must be between 0.0 and 1.0
+
+# Validation: match_score must be >= 1
+statement error
+SELECT * FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    match_score := 0);
+----
+match_score must be >= 1
+
+# Validation: min_count must be >= 1
+statement error
+SELECT * FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    min_count := 0);
+----
+min_count must be >= 1
+
+# Validation: negative penalty rejected (a negative would otherwise collide with
+# the "unset" sentinel and be silently ignored).
+statement error
+SELECT * FROM align_minimap2_sharded('queries',
+    shard_directory := 'data/shards/', read_to_shard := 'read_to_shard',
+    mismatch_penalty := -3);
+----
+mismatch_penalty must be >= 0
+
+# ==============================================================================
 # CLEANUP
 # ==============================================================================
 

--- a/test/sql/read_fastx_interleaved.test
+++ b/test/sql/read_fastx_interleaved.test
@@ -1,0 +1,43 @@
+# name: test/sql/read_fastx_interleaved.test
+# description: Native de-interleave in read_fastx via the interleaved parameter
+# group: [sql]
+
+require miint
+
+# Interleaved FASTQ: consecutive records (R1,R2,R1,R2) collapse into paired rows.
+# R1's read_id wins (the trailing /1 is stripped); one sequence_index per pair.
+query IIIIIII
+SELECT sequence_index, read_id, comment, sequence1, sequence2, qual1, qual2
+FROM read_fastx('data/fastq/interleaved.fq', interleaved=true)
+ORDER BY sequence_index;
+----
+1	ip1	NULL	AAAA	TTTT	[40, 40, 40, 40]	[39, 39, 39, 39]
+2	ip2	NULL	GGGG	CCCC	[41, 41, 41, 41]	[42, 42, 42, 42]
+
+# One sequence_index per pair (2 pairs from 4 records), unique.
+query II
+SELECT COUNT(*), COUNT(DISTINCT sequence_index)
+FROM read_fastx('data/fastq/interleaved.fq', interleaved=true);
+----
+2	2
+
+# Interleaved FASTA has no quality: qual columns are NULL, mates still paired.
+query IIIII
+SELECT sequence_index, read_id, sequence1, sequence2, qual1
+FROM read_fastx('data/fastq/interleaved.fa', interleaved=true)
+ORDER BY sequence_index;
+----
+1	ip1	AAAA	TTTT	NULL
+2	ip2	GGGG	CCCC	NULL
+
+# Odd number of records -> loud error (the trailing record has no mate).
+statement error
+SELECT * FROM read_fastx('data/fastq/interleaved_odd.fq', interleaved=true);
+----
+odd number of records
+
+# interleaved is mutually exclusive with the two-file sequence2 mode.
+statement error
+SELECT * FROM read_fastx('data/fastq/small_a_r1.fq', sequence2='data/fastq/small_a_r2.fq', interleaved=true);
+----
+cannot be combined


### PR DESCRIPTION
## Summary

Two `duckdb-miint` changes the `shaln` sharded-alignment CLI needs (B5 feedback). **Stacked on `feat/save-bowtie2-index` (PR #133)** so this diff is only the new work; retarget to `v1.5-variegata` if #133 merges first.

### 1. `read_fastx(interleaved := true)` — native de-interleave
De-interleave a single FASTQ/FASTA stream into paired rows: record 2k-1 → `sequence1`/`qual1`, record 2k → `sequence2`/`qual2`, one `sequence_index` per pair. Replaces a fragile SQL `GROUP BY (sequence_index+1)//2` trick in shaln and yields a stable, unique per-pair `sequence_index`.

- New `SequenceReader::read_interleaved()` reuses `read_pe`'s `append_pe` + byte-budget + tail-carry machinery, drawing both mates from one stream (carries an odd trailing record across polls).
- R1's `read_id`/`comment` win (trailing `/1` stripped); mate-id parity check is intentionally lenient (interleaved files don't always carry `/1 /2`).
- Odd record count → loud error. Mutually exclusive with `sequence2`. Works over stdin.

### 2. minimap2 map-time options on **both** `align_minimap2` and `align_minimap2_sharded`
miint previously surfaced only `preset/max_secondary/eqx/k/w/min_chain_coverage`. This adds 15 map-time `mm_mapopt_t` knobs: `match_score, mismatch_penalty, gap_open, gap_extend, gap_open2, gap_extend2, bandwidth, zdrop, zdrop_inv, min_chain_score, min_count, max_gap, min_dp_max, pri_ratio, mask_level`. Registered + documented on **both** the sharded and non-sharded aligners (shared `Minimap2Config` path).

- Added to the shared `Minimap2Config` + `ParseMinimap2ConfigParams`; applied in `InitOptions` **after** `mm_set_opt(preset)`, so they tune alignment against a prebuilt `.mmi` (or a freshly built index) without rebuilding (`k`/`w` stay index-time only). Verified `mm_mapopt_update` preserves these fields.
- Sentinel `-1`/`-1.0f` = "unset, use preset default"; negatives rejected at parse so a user value can never alias the sentinel.
- `min_dp_max` (`-s`) included so a caller who lowers the match score can also adjust the DP-score filter — minimap2's CLI doesn't auto-recompute it from `-A`/`-m`, and neither do we (faithful behavior, documented).

## Testing
- **TDD red/green/refactor** throughout.
- `read_fastx_interleaved.test` (SQL) + 5 `[interleaved]` C++ `SequenceReader` cases (poll-boundary carry, byte-budget across calls, odd-count error, FASTA-no-qual).
- `align_minimap2_sharded.test` scoring block: 4 knobs proven to change output via distinct mechanisms (`min_chain_score`/`min_count`/`min_dp_max` → 0 alignments; `match_score` → lower AS), all-knobs-accept, 5 validation errors. `align_minimap2.test` gets a matching provable block. Flag predicates use `alignment_is_unmapped`, not bit math.
- Full minimap2 + read_fastx suites (incl. bigint/uuid variants) and C++ `[Minimap2Aligner]`/`[SequenceReader]` green; `make format-check` clean.
- Two self-reviews (high-effort) run; findings addressed (exposed `min_dp_max`; strengthened test coverage against field-mapping swaps; extended the knobs to the non-sharded aligner for API consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
