### PR TITLE
fix(rype): bound memory of index_create build and classify/extract/log_ratio input feeds

### DIFF
--- a/docs/rype.md
+++ b/docs/rype.md
@@ -28,6 +28,7 @@ Build a RYpe `.ryxdi` index directly from a DuckDB table of chunked reference se
 - `salt` (UBIGINT, optional, default 6148914691236517205): Hash salt. An index can only be classified against with matching `k`, `w`, and `salt`
 - `orient` (BOOLEAN, optional, default true): Orient sequences within each bucket for better overlap before extraction
 - `max_memory` (BIGINT, optional, default 0): Approximate memory budget in bytes for the build; 0 auto-detects available memory
+- `feed_window_features` (BIGINT, optional, default 0): Advanced. Number of features per internal feed window (see *Behavior*); 0 auto-sizes each window from a memory budget. Set a small value to force more, smaller windows. Rarely needed.
 
 **Output schema:** a single status row.
 - `output_path` (VARCHAR): The path of the index that was created (echoes the input)
@@ -35,9 +36,10 @@ Build a RYpe `.ryxdi` index directly from a DuckDB table of chunked reference se
 - `w` (INTEGER): The window size used
 - `status` (VARCHAR): `ok` on success
 
+**Input order:** the `chunk_table` may be in **any** physical order — chunks are sorted as part of the build. Within each feature, `chunk_index` must still be 0-based and gap-free; a missing or duplicate `chunk_index` (a genuinely malformed feature) fails the build with a clear RYpe error (e.g. `expected chunk_index N but got M`, or `first chunk_index must be 0`).
+
 **Behavior:**
-- A feature's chunks must be contiguous and form an ascending, 0-based, gap-free `chunk_index` sequence; the function reads them ordered by `(feature_idx, chunk_index)`.
-- The large sequence/chunk data is streamed (never fully materialized); the small bucket mapping is read into memory.
+- Memory is bounded regardless of corpus size. The build never sorts the whole corpus at once — a single `ORDER BY` over many 64 KB chunks would buffer everything and run out of memory, because DuckDB cannot spill large variable-length sort payloads. Instead the features are partitioned into windows (contiguous `feature_idx` ranges, auto-sized to a per-window memory budget, or set explicitly via `feed_window_features`), each window is read and sorted independently (multi-threaded, spillable), and the windows are spliced into one stream so chunks still reach RYpe fully ordered. The small bucket mapping is read into memory.
 - Inputs are validated at bind time: a missing table, a missing required column, `k` not in {16, 32, 64}, or `w < 1` all raise an error before any build work begins.
 - A duplicate `feature_idx` in `mapping_table` is rejected.
 - The index directory is written **non-atomically**: if the build fails partway, a partial, unusable directory may remain at `output_path` and should be discarded. Build to a temporary path and move it into place if atomicity is required.

--- a/src/include/rype_common.hpp
+++ b/src/include/rype_common.hpp
@@ -200,10 +200,12 @@ inline void ValidateTableHasColumns(ClientContext &context, const std::string &t
 // sequence_table corrupts the correspondence whenever the two scans see rows
 // in different orders (multi-threaded scans, views, parquet sources,
 // preserve_insertion_order=false). The helpers below materialize the source
-// once into a per-call TEMP table with an explicit id column, then read
-// read_ids and stream sequences from that same table ORDER BY id — the id
-// column is now a stable attribute of the data, not an emergent property of
-// independent scans.
+// once into a per-call TEMP table with an explicit id column. id, read_id, and
+// sequence now live together in one row, so the correspondence is intrinsic to
+// the data rather than an emergent property of independent scans. read_ids is
+// read ORDER BY id (so the vector is indexed by id); the sequence stream needs
+// no ordering — RYpe echoes each row's id back as the output query_id, so it is
+// fed unordered and lazily (SendQuery) to keep memory at O(batch).
 //
 // Usage pattern (in InitGlobal, on a per-GlobalState sub-Connection):
 //
@@ -272,8 +274,19 @@ inline std::string MaterializeRypeInputTempTable(Connection &conn, const std::st
 }
 
 //! Build the Arrow input stream RYpe will consume. Reads (id, sequence1, [sequence2])
-//! from the named TEMP table ordered by id. `include_pair_column` exposes a
-//! pair_sequence column (true for classify/log_ratio, false for extract).
+//! from the named TEMP table. `include_pair_column` exposes a pair_sequence column
+//! (true for classify/log_ratio, false for extract).
+//!
+//! Streamed via SendQuery (NOT Query) so RYpe consumes one batch at a time —
+//! O(batch_size) memory — instead of materializing the whole sequence corpus in
+//! RAM up front (which OOMs on large inputs, e.g. many genomes).
+//!
+//! No ORDER BY: RYpe echoes each row's `id` column back as the output query_id and
+//! never relies on input row order (see rype_classify/extract/log_ratio Execute,
+//! which all index read_ids[query_id]). id, read_id, and sequence already travel
+//! together in one temp-table row, so the read_ids[query_id] mapping is
+//! order-independent. Avoiding the sort also avoids a corpus-wide sort of large
+//! sequence BLOBs, which DuckDB cannot spill and which OOMs at scale.
 //!
 //! Caller transfers ownership of the returned wrapper to RYpe by calling
 //! .release() AFTER rype_*_arrow() succeeds; on failure, the unique_ptr's
@@ -284,8 +297,8 @@ BuildRypeArrowInput(Connection &conn, const std::string &tmp_table_name, bool in
 	std::string select_cols = include_pair_column
 	                              ? std::string("id, sequence1::BLOB AS sequence, sequence2::BLOB AS pair_sequence")
 	                              : std::string("id, sequence1::BLOB AS sequence");
-	std::string query = "SELECT " + select_cols + " FROM " + tmp_quoted + " ORDER BY id";
-	auto query_result = conn.Query(query);
+	std::string query = "SELECT " + select_cols + " FROM " + tmp_quoted;
+	auto query_result = conn.SendQuery(query);
 	if (query_result->HasError()) {
 		throw InvalidInputException("Failed to read from temp table: %s", query_result->GetError());
 	}

--- a/src/include/rype_index_create.hpp
+++ b/src/include/rype_index_create.hpp
@@ -22,6 +22,14 @@ namespace duckdb {
 // chunk_data VARCHAR) plus an optional feature->bucket mapping. Wraps the rype
 // FFI rype_index_build_from_arrow, feeding it two DuckDB query results as Arrow
 // streams. Returns a single status row.
+//
+// The chunk_table may be in ANY physical order. The feed is assembled from a
+// sequence of bounded, independently-sorted windows over feature_idx ranges (see
+// WindowedChunkStream in rype_index_create.cpp): a single `ORDER BY` over the
+// whole corpus would buffer every 64 KB chunk and OOM, because DuckDB cannot spill
+// large variable-length sort payloads. Per-window sorts stay small and spillable,
+// and the windows are spliced back-to-back so RYpe still sees each feature
+// contiguous and in ascending chunk_index order.
 class RypeIndexCreateTableFunction {
 public:
 	struct Data : public TableFunctionData {
@@ -33,13 +41,14 @@ public:
 		int32_t w;
 		uint64_t salt;
 		bool orient;
-		int64_t max_memory; // bytes; 0 = auto-detect
+		int64_t max_memory;           // bytes; 0 = auto-detect
+		int64_t feed_window_features; // features per feed window; 0 = auto-size from a byte budget
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;
 
 		Data()
-		    : k(64), w(50), salt(0x5555555555555555ULL), orient(true), max_memory(0),
+		    : k(64), w(50), salt(0x5555555555555555ULL), orient(true), max_memory(0), feed_window_features(0),
 		      names({"output_path", "k", "w", "status"}),
 		      types({LogicalType::VARCHAR, LogicalType::INTEGER, LogicalType::INTEGER, LogicalType::VARCHAR}) {
 		}

--- a/src/rype_index_create.cpp
+++ b/src/rype_index_create.cpp
@@ -4,7 +4,173 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 
+#include <algorithm>
+#include <utility>
+
 namespace duckdb {
+
+namespace {
+
+// A hand-rolled multiplexing ArrowArrayStream that splices several windowed query
+// results into one continuous stream for rype_index_build_from_arrow.
+//
+// Why windows: building from a single `SELECT ... ORDER BY feature_idx,
+// chunk_index` sorts the entire corpus of 64 KB chunk BLOBs in one blocking
+// operator, which DuckDB cannot spill — it OOMs on real data (many genomes,
+// measured: OOM at the memory limit). Pinning the scan to one thread to stream
+// pre-sorted data without a sort is not an option either: `threads` is global and
+// resizing it from InitGlobal (which runs on a scheduler worker thread) joins the
+// current worker — "Resource deadlock avoided".
+//
+// Instead we partition the features into windows (contiguous feature_idx ranges)
+// and run one `... WHERE feature_idx >= lo AND feature_idx <= hi ORDER BY
+// feature_idx, chunk_index` per window. Each window's sort is bounded (multi-
+// threaded, spillable); the windows are emitted back-to-back as one stream. RYpe's
+// ordering requirement — each feature contiguous, ascending, 0-based, gap-free —
+// holds: a feature lives wholly inside one window, windows ascend by feature_idx,
+// and the per-window ORDER BY groups each feature's chunks. The chunk_table may be
+// in ANY physical order. Only one window's StreamQueryResult is open at a time,
+// satisfying the one-active-stream-per-Connection rule.
+//
+// Ownership mirrors ResultArrowArrayStreamWrapper: rype_index_build_from_arrow
+// takes the stream and invokes release() synchronously during the build, which
+// deletes this object.
+struct WindowedChunkStream {
+	ArrowArrayStream stream;
+	Connection &conn;
+	std::string table_quoted;
+	std::vector<std::pair<int64_t, int64_t>> windows; // inclusive [lo, hi] feature_idx ranges, ascending
+	idx_t batch_size;
+	idx_t next_window = 0; // index of the next window to open
+	unique_ptr<ResultArrowArrayStreamWrapper> active;
+	std::string last_error;
+
+	WindowedChunkStream(Connection &conn_p, std::string table_quoted_p,
+	                    std::vector<std::pair<int64_t, int64_t>> windows_p, idx_t batch_size_p)
+	    : conn(conn_p), table_quoted(std::move(table_quoted_p)), windows(std::move(windows_p)),
+	      batch_size(batch_size_p) {
+		stream.private_data = this;
+		stream.get_schema = GetSchema;
+		stream.get_next = GetNext;
+		stream.release = Release;
+		stream.get_last_error = GetLastError;
+	}
+
+	bool OpenQuery(const std::string &sql) {
+		auto result = conn.SendQuery(sql);
+		if (result->HasError()) {
+			last_error = result->GetError();
+			return false;
+		}
+		active = make_uniq<ResultArrowArrayStreamWrapper>(std::move(result), batch_size);
+		return true;
+	}
+
+	std::string WindowSQL(int64_t lo, int64_t hi) const {
+		return "SELECT feature_idx::BIGINT AS feature_idx, chunk_index::INTEGER AS chunk_index, chunk_data FROM " +
+		       table_quoted + " WHERE feature_idx >= " + std::to_string(lo) +
+		       " AND feature_idx <= " + std::to_string(hi) + " ORDER BY feature_idx, chunk_index";
+	}
+
+	// Open windows[next_window] (advancing next_window). Caller guarantees the index
+	// is in range.
+	bool OpenNextWindow() {
+		auto &w = windows[next_window++];
+		return OpenQuery(WindowSQL(w.first, w.second));
+	}
+
+	// Zero-row probe used only when there are no windows (empty chunk_table) so that
+	// get_schema can still return a valid schema.
+	bool OpenSchemaProbe() {
+		return OpenQuery("SELECT feature_idx::BIGINT AS feature_idx, chunk_index::INTEGER AS chunk_index, "
+		                 "chunk_data FROM " +
+		                 table_quoted + " WHERE false");
+	}
+
+	static int GetSchema(ArrowArrayStream *stream, ArrowSchema *out) {
+		auto self = reinterpret_cast<WindowedChunkStream *>(stream->private_data);
+		if (!self->active) {
+			bool ok = self->windows.empty() ? self->OpenSchemaProbe() : self->OpenNextWindow();
+			if (!ok) {
+				return -1;
+			}
+		}
+		return self->active->stream.get_schema(&self->active->stream, out);
+	}
+
+	static int GetNext(ArrowArrayStream *stream, ArrowArray *out) {
+		auto self = reinterpret_cast<WindowedChunkStream *>(stream->private_data);
+		while (true) {
+			if (!self->active) {
+				if (self->next_window >= self->windows.size()) {
+					out->release = nullptr; // end of the multiplexed stream
+					return 0;
+				}
+				if (!self->OpenNextWindow()) {
+					return -1; // last_error set by OpenQuery
+				}
+			}
+			ArrowArray tmp;
+			tmp.release = nullptr;
+			if (self->active->stream.get_next(&self->active->stream, &tmp) != 0) {
+				self->last_error = self->active->stream.get_last_error(&self->active->stream);
+				return -1;
+			}
+			if (tmp.release != nullptr) {
+				*out = tmp; // a batch from the current window
+				return 0;
+			}
+			self->active.reset(); // window exhausted; advance to the next
+		}
+	}
+
+	static void Release(ArrowArrayStream *stream) {
+		if (!stream || !stream->release) {
+			return;
+		}
+		stream->release = nullptr;
+		delete reinterpret_cast<WindowedChunkStream *>(stream->private_data);
+	}
+
+	static const char *GetLastError(ArrowArrayStream *stream) {
+		auto self = reinterpret_cast<WindowedChunkStream *>(stream->private_data);
+		return self->last_error.c_str();
+	}
+};
+
+// Choose how many features go in each feed window. Targets ~256 MiB of chunk data
+// per window (the sort's working set inflates several-fold over the raw bytes, so a
+// modest data budget keeps the per-window sort comfortably bounded) by sampling the
+// average feature size over the first few features (feature_idx and chunk_data only
+// -> cheap). Returns at least 1 so a single oversized feature still makes progress.
+// `features` is the sorted distinct feature_idx list.
+idx_t AutoWindowFeatures(Connection &conn, const std::string &table_quoted, const std::vector<int64_t> &features) {
+	constexpr idx_t kSampleFeatures = 128;
+	constexpr int64_t kBudgetBytes = 256LL << 20; // ~256 MiB of chunk data per window
+	constexpr idx_t kFallback = 256;
+	if (features.empty()) {
+		return 1;
+	}
+	idx_t k = std::min(kSampleFeatures, static_cast<idx_t>(features.size()));
+	std::string sql = "SELECT AVG(b)::BIGINT FROM (SELECT SUM(LENGTH(chunk_data))::BIGINT AS b FROM " + table_quoted +
+	                  " WHERE feature_idx >= " + std::to_string(features.front()) +
+	                  " AND feature_idx <= " + std::to_string(features[k - 1]) + " GROUP BY feature_idx)";
+	auto result = conn.Query(sql);
+	if (result->HasError()) {
+		return kFallback;
+	}
+	auto value = result->GetValue(0, 0);
+	if (value.IsNull()) {
+		return kFallback;
+	}
+	int64_t avg_bytes = value.GetValue<int64_t>();
+	if (avg_bytes <= 0) {
+		return kFallback;
+	}
+	return static_cast<idx_t>(std::max<int64_t>(1, kBudgetBytes / avg_bytes));
+}
+
+} // namespace
 
 // ============================================================================
 // Bind
@@ -49,6 +215,18 @@ unique_ptr<FunctionData> RypeIndexCreateTableFunction::Bind(ClientContext &conte
 	auto mem_param = input.named_parameters.find("max_memory");
 	if (mem_param != input.named_parameters.end() && !mem_param->second.IsNull()) {
 		data->max_memory = mem_param->second.GetValue<int64_t>();
+	}
+
+	// Advanced: number of features per feed window (see WindowedChunkStream).
+	// 0 (default) = auto-size from a per-window memory budget. Mainly useful for
+	// tuning or for tests that need to force multiple windows over small inputs.
+	auto window_param = input.named_parameters.find("feed_window_features");
+	if (window_param != input.named_parameters.end() && !window_param->second.IsNull()) {
+		data->feed_window_features = window_param->second.GetValue<int64_t>();
+		if (data->feed_window_features < 0) {
+			throw BinderException("rype_index_create: feed_window_features must be >= 0 (got %lld)",
+			                      static_cast<long long>(data->feed_window_features));
+		}
 	}
 
 	// Validate at bind time (fail fast, before any build side effects). The chunk
@@ -129,28 +307,53 @@ unique_ptr<GlobalTableFunctionState> RypeIndexCreateTableFunction::InitGlobal(Cl
 	}
 	auto mapping_wrapper = make_uniq<ResultArrowArrayStreamWrapper>(std::move(mapping_result), STANDARD_VECTOR_SIZE);
 
-	// Chunk stream: feature_idx Int64, chunk_index Int32, chunk_data. A feature's
-	// chunks must be contiguous, ascending, 0-based; ORDER BY guarantees this.
-	// Streamed via SendQuery (lazy fetch) so the full sequence corpus is never
-	// materialized in memory at once.
-	std::string chunk_sql = "SELECT feature_idx::BIGINT AS feature_idx, chunk_index::INTEGER AS chunk_index, "
-	                        "chunk_data FROM " +
-	                        chunk_quoted + " ORDER BY feature_idx, chunk_index";
-	auto chunk_result = conn.SendQuery(chunk_sql);
-	if (chunk_result->HasError()) {
-		throw InvalidInputException("Failed to read chunk table '%s': %s", bind_data.chunk_table,
-		                            chunk_result->GetError());
+	// Chunk stream: feature_idx Int64, chunk_index Int32, chunk_data. RYpe requires
+	// each feature's chunks to arrive contiguously in ascending, 0-based, gap-free
+	// chunk_index order and reassembles them internally. We feed it as a sequence of
+	// bounded, independently-sorted windows over feature_idx ranges (see
+	// WindowedChunkStream): a single `ORDER BY` over the whole corpus OOMs because
+	// DuckDB cannot spill the 64 KB BLOB sort payload. The chunk_table may be in any
+	// physical order.
+
+	// Sorted distinct feature ids (feature_idx only -> cheap projection pushdown).
+	auto feat_result = conn.Query("SELECT DISTINCT feature_idx::BIGINT AS f FROM " + chunk_quoted + " ORDER BY f");
+	if (feat_result->HasError()) {
+		throw InvalidInputException("Failed to read feature ids from chunk table '%s': %s", bind_data.chunk_table,
+		                            feat_result->GetError());
 	}
-	auto chunk_wrapper = make_uniq<ResultArrowArrayStreamWrapper>(std::move(chunk_result), STANDARD_VECTOR_SIZE);
+	std::vector<int64_t> features;
+	features.reserve(feat_result->RowCount());
+	while (auto chunk = feat_result->Fetch()) {
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			auto v = chunk->data[0].GetValue(i);
+			if (!v.IsNull()) {
+				features.push_back(v.GetValue<int64_t>());
+			}
+		}
+	}
+
+	// Window size in #features: explicit override (feed_window_features), else auto
+	// from a per-window byte budget.
+	idx_t window_features = bind_data.feed_window_features > 0 ? static_cast<idx_t>(bind_data.feed_window_features)
+	                                                           : AutoWindowFeatures(conn, chunk_quoted, features);
+
+	// Partition the sorted distinct ids into inclusive [lo, hi] feature_idx windows.
+	std::vector<std::pair<int64_t, int64_t>> windows;
+	for (idx_t i = 0; i < features.size(); i += window_features) {
+		idx_t last = std::min(i + window_features, static_cast<idx_t>(features.size())) - 1;
+		windows.emplace_back(features[i], features[last]);
+	}
+
+	auto chunk_mux = make_uniq<WindowedChunkStream>(conn, chunk_quoted, std::move(windows), STANDARD_VECTOR_SIZE);
 
 	int rc =
-	    rype_index_build_from_arrow(bind_data.output_path.c_str(), &chunk_wrapper->stream, &mapping_wrapper->stream,
+	    rype_index_build_from_arrow(bind_data.output_path.c_str(), &chunk_mux->stream, &mapping_wrapper->stream,
 	                                static_cast<size_t>(bind_data.k), static_cast<size_t>(bind_data.w), bind_data.salt,
 	                                bind_data.orient ? 1 : 0, static_cast<size_t>(bind_data.max_memory));
 
 	// RYpe takes ownership of both (non-NULL) streams and invokes their release
 	// callbacks during the build — release the unique_ptrs to avoid a double-free.
-	(void)chunk_wrapper.release();
+	(void)chunk_mux.release();
 	(void)mapping_wrapper.release();
 
 	if (rc != 0) {
@@ -205,6 +408,7 @@ TableFunction RypeIndexCreateTableFunction::GetFunction() {
 	tf.named_parameters["salt"] = LogicalType::UBIGINT;
 	tf.named_parameters["orient"] = LogicalType::BOOLEAN;
 	tf.named_parameters["max_memory"] = LogicalType::BIGINT;
+	tf.named_parameters["feed_window_features"] = LogicalType::BIGINT;
 
 	return tf;
 }

--- a/test/sql/rype_index_create.test
+++ b/test/sql/rype_index_create.test
@@ -12,6 +12,9 @@
 
 require miint
 
+# Needed by the VIEW-over-parquet round-trip in the "Input order contract" section.
+require parquet
+
 # =============================================================================
 # Setup: a chunked sequence table with DISTINCT, non-repetitive chunks.
 #  - feature 1 (bucket_alpha): two DIFFERENT 64 bp chunks (chunk 0 then chunk 1)
@@ -205,6 +208,122 @@ appears multiple times
 
 statement ok
 DROP TABLE dup_mapping;
+
+# =============================================================================
+# Input order: the chunk_table may be in ANY physical order. The build sorts
+# chunks in bounded per-feature windows (WindowedChunkStream) instead of one
+# corpus-wide ORDER BY (which OOMs on large 64 KB-chunk corpora). So unordered
+# input still yields a correct index, while RYpe's per-feature contiguity check
+# still rejects genuinely malformed features (gap / null chunk_index).
+# =============================================================================
+
+# Build from a VIEW over a parquet file (the real-world access pattern) that is
+# written deliberately UNSORTED — proves the windowed feed sorts it correctly.
+statement ok
+COPY (SELECT * FROM chunks ORDER BY chunk_index DESC, feature_idx DESC)
+  TO '__TEST_DIR__/chunks_unsorted.parquet' (FORMAT parquet);
+
+statement ok
+CREATE VIEW chunks_view AS SELECT * FROM read_parquet('__TEST_DIR__/chunks_unsorted.parquet');
+
+query IIT
+SELECT k, w, status
+FROM rype_index_create('chunks_view', '__TEST_DIR__/built_view.ryxdi', mapping_table := 'mapping', k := 16, w := 8);
+----
+16	8	ok
+
+# Correct despite the unsorted parquet: the two-chunk feature self-matches
+# perfectly, which requires chunk 0 then chunk 1 to have been reassembled in order.
+query I
+SELECT score = 1.0 AS alpha_perfect
+FROM rype_classify('__TEST_DIR__/built_view.ryxdi', 'queries', threshold := 0.05)
+WHERE read_id = 'q_alpha_correct' AND bucket_name = 'bucket_alpha';
+----
+true
+
+statement ok
+DROP VIEW chunks_view;
+
+# Adversarially scrambled input: features interleaved AND chunk_index descending.
+# A pre-fix corpus-wide build with no sort would mis-pair these; the windowed sort
+# repairs both within-feature order and feature contiguity.
+statement ok
+CREATE TABLE scrambled AS SELECT * FROM (VALUES
+    (2::BIGINT, 0::INTEGER, 'GATTACAGGCATCAGTCAGTGGCCAATTGGCCAATTACGCGCGATATCGCGTATATGCATGCAT'),
+    (1::BIGINT, 1::INTEGER, 'AACCGGTTAGGCTACGATCGTACGATTCAGGCTAACGTACCGATTGCATGCATTACGGATCCGA'),
+    (1::BIGINT, 0::INTEGER, 'TTGCACGATCAGGTACCGATTACAGCATTGGCCAAGTCATGCATGGATCCGATCGTTAACGGAT')
+) AS t(feature_idx, chunk_index, chunk_data);
+
+query IIT
+SELECT k, w, status
+FROM rype_index_create('scrambled', '__TEST_DIR__/built_scrambled.ryxdi', mapping_table := 'mapping', k := 16, w := 8);
+----
+16	8	ok
+
+# Both features self-match perfectly (alpha is two-chunk → only possible if chunk 0
+# then 1 were reassembled in order despite the scrambled input).
+query I
+SELECT COUNT(*) AS perfect
+FROM rype_classify('__TEST_DIR__/built_scrambled.ryxdi', 'queries', threshold := 0.05)
+WHERE score = 1.0
+  AND ((read_id = 'q_alpha_correct' AND bucket_name = 'bucket_alpha')
+       OR (read_id = 'q_beta' AND bucket_name = 'bucket_beta'));
+----
+2
+
+# Same scrambled input with feed_window_features := 1 forces one window PER feature
+# (two windows), exercising the multiplexer's window-boundary advance. Still correct.
+query IIT
+SELECT k, w, status
+FROM rype_index_create('scrambled', '__TEST_DIR__/built_windows.ryxdi',
+                       mapping_table := 'mapping', k := 16, w := 8, feed_window_features := 1);
+----
+16	8	ok
+
+query I
+SELECT COUNT(*) AS perfect
+FROM rype_classify('__TEST_DIR__/built_windows.ryxdi', 'queries', threshold := 0.05)
+WHERE score = 1.0
+  AND ((read_id = 'q_alpha_correct' AND bucket_name = 'bucket_alpha')
+       OR (read_id = 'q_beta' AND bucket_name = 'bucket_beta'));
+----
+2
+
+statement ok
+DROP TABLE scrambled;
+
+# --- RYpe still rejects genuinely malformed features (regardless of order) ---
+
+# (a) Gap within a feature: chunk 0 then chunk 2 (chunk 1 missing). Sorting cannot
+# invent the missing chunk, so the build fails loudly.
+statement ok
+CREATE TABLE bad_gap AS SELECT * FROM (VALUES
+    (1::BIGINT, 0::INTEGER, 'TTGCACGATCAGGTACCGATTACAGCATTGGCCAAGTCATGCATGGATCCGATCGTTAACGGAT'),
+    (1::BIGINT, 2::INTEGER, 'AACCGGTTAGGCTACGATCGTACGATTCAGGCTAACGTACCGATTGCATGCATTACGGATCCGA')
+) AS t(feature_idx, chunk_index, chunk_data);
+
+statement error
+SELECT * FROM rype_index_create('bad_gap', '__TEST_DIR__/err_gap.ryxdi', k := 16, w := 8);
+----
+expected chunk_index 1 but got 2
+
+statement ok
+DROP TABLE bad_gap;
+
+# (b) NULL chunk_index: RYpe rejects null key/data columns with a distinct error.
+statement ok
+CREATE TABLE bad_null AS SELECT * FROM (VALUES
+    (1::BIGINT, 0::INTEGER, 'TTGCACGATCAGGTACCGATTACAGCATTGGCCAAGTCATGCATGGATCCGATCGTTAACGGAT'),
+    (1::BIGINT, NULL::INTEGER, 'AACCGGTTAGGCTACGATCGTACGATTCAGGCTAACGTACCGATTGCATGCATTACGGATCCGA')
+) AS t(feature_idx, chunk_index, chunk_data);
+
+statement error
+SELECT * FROM rype_index_create('bad_null', '__TEST_DIR__/err_null.ryxdi', k := 16, w := 8);
+----
+null 'chunk_index'
+
+statement ok
+DROP TABLE bad_null;
 
 statement ok
 DROP TABLE queries;


### PR DESCRIPTION
Two related memory fixes in the RYpe table functions. Both target the same root cause — DuckDB feeding the whole sequence corpus to RYpe in one in-memory operator instead of streaming it.

## 1. `rype_index_create` — windowed chunk feed (commit 1)

Building an index from a large 64 KB-chunked corpus **OOM'd at 18.6 GiB** on a 31 GB / 482K-chunk sample: the feed query's `ORDER BY feature_idx, chunk_index` sorted the entire corpus of 64 KB BLOBs in one blocking operator, and DuckDB cannot spill that large variable-length payload.

Fix: feed RYpe one continuous Arrow stream assembled from bounded, independently-sorted windows over `feature_idx` ranges (`WindowedChunkStream`, a hand-rolled multiplexing `ArrowArrayStream`). Multi-threaded scan (no global-scheduler resize), memory bounded by window size, robust to any input order. Windows auto-size to ~256 MiB of chunk data; overridable via the new advanced `feed_window_features` param.

*(An earlier single-threaded `SET threads=1` approach was abandoned: resizing the global thread pool from `InitGlobal`, which runs on a scheduler worker, flakily deadlocks — "Resource deadlock avoided".)*

**Verified:** 31 GB build, previously OOM at 18.6 GiB → now **7.54 GiB** peak, valid index.

## 2. `rype_classify` / `rype_extract_*` / `rype_log_ratio` — streamed input feed (commit 2)

`BuildRypeArrowInput` fed RYpe via `conn.Query` (a `MaterializedQueryResult`), pinning the entire `SELECT id, sequence1::BLOB, sequence2::BLOB FROM tmp ORDER BY id` result in RAM before RYpe pulled its first batch — defeating RYpe's streaming design and OOMing (~15 GB) on large inputs.

Fix: `conn.SendQuery` (a `StreamQueryResult`, consumed lazily — O(batch) memory) and drop the `ORDER BY id`. RYpe echoes each row's `id` column back as the output `query_id` and never relies on input row order (all three `Execute` paths index `read_ids[query_id]`; the Rust arrow readers carry the id via `batch_to_records`). `id`/`read_id`/`sequence` already travel together in one temp-table row, so the mapping is order-independent. Dropping the sort also removes a corpus-wide BLOB sort. `read_ids` is still read `ORDER BY id` (small; indexes the vector).

**Verified:** `rype_row_id_correspondence` (adversarial 50K-row view, `preserve_insertion_order=false`) and the full rype suite stay green; a classify of ~12 GB of sequences completes under a **1 GB** DuckDB `memory_limit` — the DuckDB-side input feed is now bounded (remaining footprint is RYpe's own per-workload processing, separate from this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
