### PR TITLE
Bump rype to shard-consolidation fix + make rust-glue rebuild on incremental builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -996,6 +996,15 @@ ExternalProject_Add(
         ${GLUE_CARGO_TARGET_FLAG}
     INSTALL_COMMAND ""
     BUILD_IN_SOURCE 0
+    # Run the cargo build on EVERY build, deferring change detection to cargo's own
+    # fingerprinting. ExternalProject does not track SOURCE_DIR (or path-dependency,
+    # e.g. ext/rype / ext/sylph) file contents, so without this an incremental build
+    # after a submodule bump or a local rype/sylph edit would silently relink the
+    # STALE libmiint_rust_glue.a — the dev gets a binary that doesn't match their
+    # source and has no way to notice. Cargo's no-op when nothing changed is ~1-3s.
+    # (Clean builds — CI's fresh ubuntu-latest runners, or `make clean` locally —
+    # were always correct; this only closes the incremental-build footgun.)
+    BUILD_ALWAYS 1
     BUILD_BYPRODUCTS ${GLUE_LIB_PATH}
 )
 


### PR DESCRIPTION
Bumps `ext/rype` to the merged shard-consolidation fix, and makes the Rust-glue build robust to submodule/source changes on incremental builds.

## 1. `chore(rype): bump ext/rype to b24aa45`

Pulls in **the-miint/RYpe#17**. The Arrow index-build path behind `rype_index_create` (`build_index_from_arrow`) previously streamed size-thresholded intermediate shards via `ShardAccumulator` but **never consolidated them** (unlike the CLI single-bucket build). Since `flush_shard` dedups only within each buffer, a minimizer carried by features in different flush windows was re-stored **once per shard** — exploding single-bucket indices.

**Measured on a real single-bucket human-reference build:**

| metric | value |
|---|---|
| stored entries | 32,031,116,502 |
| unique minimizers | 537,078,034 |
| **bloat** | **~60×** |
| shards | 100+ (~1 GB each) |

The fix consolidates intermediate shards (streaming k-way merge + global dedup) when there is >1, exactly like the CLI. End-to-end re-validation through the rebuilt extension on a 12,004-feature subset:

| | before | after |
|---|---|---|
| stored entries | 2,602,682,418 | **441,734,993** |
| **bloat** | **5.89×** | **1.00× (exact)** |
| index size | 12 GB | **1.8 GB** |
| `has_overlapping_shards` | true | **false** |

`stored == unique`, unique count unchanged → every duplicate removed, no minimizers lost.

## 2. `build: BUILD_ALWAYS on the rust-glue ExternalProject`

`ExternalProject_Add` does **not** track `SOURCE_DIR` / path-dependency (`ext/rype`, `ext/sylph`) file contents. So an **incremental** build (`build.sh`/`make` without `make clean`) after a submodule bump or a local rype/sylph edit silently relinked the **stale** `libmiint_rust_glue.a` — a dev gets a binary that doesn't match their source with no way to notice. (This bit me while validating the rype fix.)

CI is unaffected — `ubuntu-latest` runners build fresh, and the only cache is content-hashed ccache for C++ objects — and `make clean` always produced a correct build. This just closes the **local incremental footgun**.

`BUILD_ALWAYS 1` runs the cargo build every time and defers change-detection to cargo's own fingerprinting. Verified locally:

| build | rype recompiled | extension relinked |
|---|---|---|
| no source change | no | no (cheap ~no-op) |
| touched `ext/rype` source | yes | yes |

## Validation
- rype: `cargo test` (459 lib tests), `fmt`, `clippy` clean (in #17).
- miint: extension rebuilt and re-linked against the bumped submodule; `rype_index_create` smoke test produces `has_overlapping_shards=false`, `total_entries == total_minimizers`; `make format-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
