### PR TITLE
feat(ena): stream ena_upload_reads per-sample to bound memory

### DIFF
--- a/docs/ena.md
+++ b/docs/ena.md
@@ -138,11 +138,11 @@ RETURNING samea_accession;
 
 Run registration is two steps: (a) upload the FASTQ files to your Webin "drop box" and capture the per-file MD5s, then (b) `INSERT INTO ena.runs` referencing those filenames + MD5s.
 
-`ena_upload_reads` drives the upload from an in-DuckDB relation, encoding sequences and quality scores into FASTQ format on the fly, gzipping, computing MD5 in a single streaming pass, and shipping the bytes to ENA.
+`ena_upload_reads` drives the upload from an in-DuckDB relation, encoding sequences and quality scores into FASTQ format on the fly, gzipping, and computing each file's MD5 as it is written. It processes one sample at a time and streams that sample's reads chunk-by-chunk — it never loads the whole relation, or even a whole sample, into memory — so peak memory is bounded (roughly one chunk + one gzip window) regardless of dataset size. There is no input-size cap.
 
 ```sql
--- Required input columns: sample_ref, read_id, sequence1, qual1, sequence_index.
--- Optional: sequence2, qual2 (paired-end).
+-- Required input columns: sample_ref, read_id, sequence1, qual1.
+-- Optional: sequence2, qual2 (paired-end; supply both columns or neither).
 CREATE TABLE my_reads AS SELECT … ;
 
 CREATE TABLE upload_results AS
@@ -160,11 +160,13 @@ SELECT * FROM ena_upload_reads(
 -- └────────────┴─────────────────┴──────────┴────────────────────┴───────────────┴────────┘
 ```
 
-Layout is auto-detected from the input rows: presence of `sequence2` / `qual2` per sample-group decides single vs. paired. `layout := 'paired_interleaved'` overrides this to emit one interleaved file per sample. Mixed single/paired rows under the same `sample_ref` are rejected at scan time.
+Layout is auto-detected per sample by a cheap aggregate pre-pass: whether every / no / some rows under a `sample_ref` carry a non-null `sequence2` decides paired / single / (rejected) mixed. `layout := 'paired_interleaved'` overrides this to emit one interleaved file per sample. Mixed single/paired rows under the same `sample_ref` are rejected before any upload begins, as is a relation that carries only one of `sequence2` / `qual2` (which would silently drop a mate).
+
+Reads are written in the relation's scan order — they are **not** sorted by `sequence_index` (a payload sort cannot spill and would defeat the bounded-memory design). R1/R2 pairing is unaffected, since both mates come from the same input row. One consequence: a file's exact bytes (hence its MD5) are reproducible only insofar as the source relation's scan order is — the MD5 always matches the bytes actually uploaded, which is what ENA validates.
 
 `target_url` schemes:
 - `aspera://webin2.ebi.ac.uk/` — production Aspera transport, requires `ascp` on `PATH` (`MIINT_ENABLE_ASPERA` runtime check).
-- `ftp://` / `ftps://` / `http://` / `https://` — libcurl streaming-upload transport.
+- `ftp://` / `ftps://` / `http://` / `https://` — libcurl transport. Each file is encoded to a temp file, then uploaded.
 - `file:///some/dir/` — write to a local directory; no `secret` parameter required. Useful for testing the encode→gzip→md5 pipeline without round-tripping through ENA.
 
 ### 6. Register experiments and runs
@@ -357,5 +359,5 @@ DETACH ena;
 
 - `SELECT * FROM ena.<submission table>` is **not** supported (other than `submission_log`). The Webin V2 API doesn't expose registered objects through the same endpoint they were submitted to. The extension uses the [Reports API](https://www.ebi.ac.uk/ena/submit/report) for the alias→accession lookup that powers `refname` + `kind` lifecycle calls and `DELETE WHERE alias = '…'`, but doesn't surface a `SELECT *` view of the user's submission account through the catalog.
 - The `test` endpoint (`wwwdev.ebi.ac.uk`) is a sandbox: receipts come back with valid-looking accessions, but those accessions are not addressable through the public Browser. Use it for dry runs and CI; switch to `production` for real submissions.
-- File uploads require either `ascp` (Aspera) on `PATH` or libcurl-backed streaming. Aspera is faster for large files but requires the IBM Aspera client; HTTPS/FTP works without extra dependencies. The local `file://` transport is for testing the encode pipeline only — it does not push anything to ENA.
+- File uploads require either `ascp` (Aspera) on `PATH` or a libcurl-backed transport. Aspera is faster for large files but requires the IBM Aspera client; HTTPS/FTP works without extra dependencies. The local `file://` transport is for testing the encode pipeline only — it does not push anything to ENA.
 - WASM builds: ENA *reading* works in all WASM variants. ENA *submission* requires an upload transport — Aspera is unavailable on any WASM (no `fork`/`exec`) and libcurl is gated off on `wasm_threads` (vcpkg port lacks `-pthread`); only `wasm_eh` and `wasm_mvp` can submit, and only via curl-based HTTPS/FTP transports.

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -202,6 +202,15 @@ if curl -sSf --max-time 3 -o /dev/null \
     export ENA_AVAILABLE=1
 fi
 
+# ena_upload_reads streaming memory proof (opt-in, expensive). Uploads a
+# multi-GB lazy view to file:// under a tight memory_limit; the streaming
+# implementation completes in bounded memory whereas the old materialise-the-
+# whole-relation path would OOM. Off by default (slow, multi-GB encode); run
+# with `MIINT_ENA_BIG_STREAM_TEST=1 bash run_tests.sh` to include it.
+if [ "${MIINT_ENA_BIG_STREAM_TEST:-0}" = "1" ]; then
+    export MIINT_ENA_BIG_STREAM_TEST=1
+fi
+
 # ENA Webin V2 submission test endpoint. Live-integration tests for
 # INSERT INTO ena.{projects,samples,...} require a real Webin account
 # (free, registered at https://www.ebi.ac.uk/ena/submit/webin/). When the

--- a/src/ena_upload_helpers.cpp
+++ b/src/ena_upload_helpers.cpp
@@ -60,38 +60,13 @@ FastqLayoutMode ParseFastqLayoutMode(const std::string &name) {
 	                         "' — expected one of: auto, single, paired, paired_interleaved");
 }
 
-FastqLayoutMode ResolveLayout(const std::string &sample_ref, FastqLayoutMode requested,
-                              const std::vector<bool> &has_r2) {
-	if (has_r2.empty()) {
-		throw std::runtime_error("ResolveLayout: sample '" + sample_ref + "' has zero rows");
-	}
-
-	// Compute three per-mode "first offending row" indices. AUTO wants the
-	// first row inconsistent with row 0 (either flip direction). SINGLE wants
-	// the first row that *has* R2. PAIRED / PAIRED_INTERLEAVED want the first
-	// row that *lacks* R2. The earlier code reused one counter and reported
-	// the wrong row when the input started with R2 and later went single.
-	std::size_t r2_count = 0;
-	const std::size_t sentinel = has_r2.size();
-	std::size_t first_auto_mismatch = sentinel;
-	std::size_t first_with_r2 = sentinel;
-	std::size_t first_without_r2 = sentinel;
-	const bool first_has = has_r2[0];
-	for (std::size_t i = 0; i < has_r2.size(); i++) {
-		if (has_r2[i]) {
-			r2_count++;
-			if (first_with_r2 == sentinel) {
-				first_with_r2 = i;
-			}
-		} else if (first_without_r2 == sentinel) {
-			first_without_r2 = i;
-		}
-		if (has_r2[i] != first_has && first_auto_mismatch == sentinel) {
-			first_auto_mismatch = i;
-		}
-	}
-	const bool all_paired = r2_count == has_r2.size();
-	const bool all_single = r2_count == 0;
+FastqLayoutMode ResolveLayoutFromCounts(const std::string &sample_ref, FastqLayoutMode requested, bool all_paired,
+                                        bool any_paired) {
+	// A sample reaching here always has >= 1 row (it came from a GROUP BY), so
+	// the empty-set degenerate case (all_paired=true, any_paired=false) cannot
+	// occur. The decision is driven by (bool_and, bool_or) of "sequence2 IS NOT
+	// NULL" — so the errors name the sample but cannot point at an offending row.
+	const bool all_single = !any_paired;
 
 	switch (requested) {
 	case FastqLayoutMode::AUTO:
@@ -102,33 +77,29 @@ FastqLayoutMode ResolveLayout(const std::string &sample_ref, FastqLayoutMode req
 			return FastqLayoutMode::PAIRED;
 		}
 		throw std::runtime_error("Sample '" + sample_ref +
-		                         "' mixes single-end and paired-end rows (first mismatch at row " +
-		                         std::to_string(first_auto_mismatch) +
-		                         "). Specify layout explicitly or split the input into per-sample groups.");
+		                         "' mixes single-end and paired-end rows. Specify layout explicitly or "
+		                         "split the input into per-sample groups.");
 
 	case FastqLayoutMode::SINGLE:
 		if (all_single) {
 			return FastqLayoutMode::SINGLE;
 		}
-		throw std::runtime_error("Sample '" + sample_ref + "' has rows with non-null R2 but layout=single requested" +
-		                         " (first offending row " + std::to_string(first_with_r2) + ")");
+		throw std::runtime_error("Sample '" + sample_ref + "' has rows with non-null R2 but layout=single requested");
 
 	case FastqLayoutMode::PAIRED:
 		if (all_paired) {
 			return FastqLayoutMode::PAIRED;
 		}
-		throw std::runtime_error("Sample '" + sample_ref + "' has rows missing R2 but layout=paired requested" +
-		                         " (first offending row " + std::to_string(first_without_r2) + ")");
+		throw std::runtime_error("Sample '" + sample_ref + "' has rows missing R2 but layout=paired requested");
 
 	case FastqLayoutMode::PAIRED_INTERLEAVED:
 		if (all_paired) {
 			return FastqLayoutMode::PAIRED_INTERLEAVED;
 		}
 		throw std::runtime_error("Sample '" + sample_ref +
-		                         "' has rows missing R2 but layout=paired_interleaved requested" +
-		                         " (first offending row " + std::to_string(first_without_r2) + ")");
+		                         "' has rows missing R2 but layout=paired_interleaved requested");
 	}
-	throw std::logic_error("ResolveLayout: unhandled FastqLayoutMode");
+	throw std::logic_error("ResolveLayoutFromCounts: unhandled FastqLayoutMode");
 }
 
 std::vector<std::string> OutputFilenames(const std::string &sample_ref, FastqLayoutMode layout) {

--- a/src/ena_upload_reads.cpp
+++ b/src/ena_upload_reads.cpp
@@ -22,6 +22,7 @@
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/query_result.hpp"
+#include "duckdb/common/types/value.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
@@ -30,7 +31,6 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
-#include <map>
 #include <stdexcept>
 #include <string>
 #include <unistd.h> // unlink, rmdir; mkdtemp on POSIX only (Aspera path is compiled out on MinGW)
@@ -54,26 +54,15 @@ struct ENAUploadReadsBindData : public TableFunctionData {
 };
 
 // =====================================================================
-// Materialised input rows
+// Per-sample upload plan
 // =====================================================================
-struct UploadInputRows {
-	vector<string> sample_ref;
-	vector<string> read_id;
-	vector<string> sequence1;
-	vector<vector<uint8_t>> qual1;
-	vector<bool> has_seq2;
-	vector<string> sequence2;
-	vector<vector<uint8_t>> qual2;
-	vector<int64_t> sequence_index;
-	vector<bool> sequence_index_valid;
-	uint64_t total_seq_bytes = 0; // running total of sequence1 + sequence2 lengths
-};
-
-// One per (sample_ref) after grouping + layout resolution.
-struct SampleGroup {
+// One per distinct sample_ref, produced by the aggregate pre-pass. Carries only
+// the metadata needed to drive that sample's streaming data pass — no row
+// payload is held, which is what keeps peak memory bounded regardless of how
+// large the dataset (or any single sample) is.
+struct SamplePlan {
 	string sample_ref;
 	FastqLayoutMode resolved_layout;
-	vector<size_t> row_indices; // already sorted by sequence_index NULLS LAST
 };
 
 // One per output FASTQ file (single sample → 1 or 2 files).
@@ -87,8 +76,7 @@ struct EmittedFile {
 };
 
 struct ENAUploadReadsGlobalState : public GlobalTableFunctionState {
-	UploadInputRows input;
-	vector<SampleGroup> samples;
+	vector<SamplePlan> samples;
 	UploadTargetURL target;
 
 	// Authenticated-transport fields (left empty when transport=LOCAL_FILE).
@@ -109,7 +97,7 @@ struct ENAUploadReadsGlobalState : public GlobalTableFunctionState {
 };
 
 // =====================================================================
-// Input materialisation (separate connection, read-time)
+// Schema validation, sample planning, and row extraction (read-time)
 // =====================================================================
 
 // Find a column by case-insensitive name. Returns -1 when missing.
@@ -153,28 +141,18 @@ vector<uint8_t> ExtractQualList(Vector &list_vec, UnifiedVectorFormat &list_data
 	return out;
 }
 
-// Hard caps on the materialised input. We pull the entire relation into
-// memory once (one std::string per sequence + one std::vector per quality
-// list), which is fine for the typical "submit a few GB of FASTQ per batch"
-// workflow but will OOM on truly large inputs. These bounds turn the silent
-// OOM into an actionable error pointing the user at the right escape hatch
-// (split-by-sample, or re-call per chunk). Streaming would remove the cap;
-// it's deferred until a user actually trips this.
-constexpr idx_t MAX_INPUT_ROWS = 50'000'000;
-constexpr uint64_t MAX_INPUT_SEQUENCE_BYTES = 5ULL * 1024 * 1024 * 1024; // 5 GB
-
-void MaterialiseInput(ClientContext &context, const string &relation_name, UploadInputRows &out) {
-	auto &db = DatabaseInstance::GetDatabase(context);
-	Connection conn(db);
-	const string query = "SELECT * FROM " + KeywordHelper::WriteOptionallyQuoted(relation_name);
+// Validate the input relation's required columns + types against a zero-row
+// probe, so we never materialise data just to check the schema. Returns whether
+// the optional R2 columns (sequence2 + qual2) are present.
+bool ValidateSchemaDetectR2(Connection &conn, const string &relation_name) {
+	const string query = "SELECT * FROM " + KeywordHelper::WriteOptionallyQuoted(relation_name) + " LIMIT 0";
 	auto result = conn.Query(query);
 	if (result->HasError()) {
 		throw InvalidInputException("ena_upload_reads: failed to read relation '%s': %s", relation_name,
 		                            result->GetError());
 	}
-	auto &materialized = result->Cast<MaterializedQueryResult>();
-	auto &types = materialized.types;
-	auto &names = materialized.names;
+	auto &names = result->names;
+	auto &types = result->types;
 
 	const int sample_ref_idx = FindColumn(names, "sample_ref");
 	const int read_id_idx = FindColumn(names, "read_id");
@@ -182,7 +160,6 @@ void MaterialiseInput(ClientContext &context, const string &relation_name, Uploa
 	const int qual1_idx = FindColumn(names, "qual1");
 	const int sequence2_idx = FindColumn(names, "sequence2");
 	const int qual2_idx = FindColumn(names, "qual2");
-	const int sequence_index_idx = FindColumn(names, "sequence_index");
 
 	if (sample_ref_idx < 0) {
 		throw InvalidInputException("ena_upload_reads: input relation must include a 'sample_ref' column");
@@ -196,187 +173,85 @@ void MaterialiseInput(ClientContext &context, const string &relation_name, Uploa
 	if (qual1_idx < 0) {
 		throw InvalidInputException("ena_upload_reads: input relation must include a 'qual1' column");
 	}
-	const bool has_r2_columns = sequence2_idx >= 0 && qual2_idx >= 0;
-
 	RequireType("sample_ref", types[sample_ref_idx], LogicalTypeId::VARCHAR);
 	RequireType("read_id", types[read_id_idx], LogicalTypeId::VARCHAR);
 	RequireType("sequence1", types[sequence1_idx], LogicalTypeId::VARCHAR);
 	RequireListUtinyint("qual1", types[qual1_idx]);
+
+	// R2 is opt-in but all-or-nothing: a relation with only one of the two
+	// columns is a malformed schema, not a single-end relation. Treating it as
+	// single-end would silently drop the present mate, so reject it loudly.
+	const bool has_sequence2 = sequence2_idx >= 0;
+	const bool has_qual2 = qual2_idx >= 0;
+	if (has_sequence2 != has_qual2) {
+		throw InvalidInputException(
+		    "ena_upload_reads: input relation has '%s' but not '%s' — paired input requires both (or neither)",
+		    has_sequence2 ? "sequence2" : "qual2", has_sequence2 ? "qual2" : "sequence2");
+	}
+	const bool has_r2_columns = has_sequence2; // == has_qual2
 	if (has_r2_columns) {
 		RequireType("sequence2", types[sequence2_idx], LogicalTypeId::VARCHAR);
 		RequireListUtinyint("qual2", types[qual2_idx]);
 	}
+	return has_r2_columns;
+}
 
-	while (true) {
-		auto chunk = materialized.Fetch();
-		if (!chunk || chunk->size() == 0) {
-			break;
-		}
-		const idx_t n = chunk->size();
-
-		UnifiedVectorFormat sample_ref_data, read_id_data, sequence1_data, qual1_data;
-		chunk->data[sample_ref_idx].ToUnifiedFormat(n, sample_ref_data);
-		chunk->data[read_id_idx].ToUnifiedFormat(n, read_id_data);
-		chunk->data[sequence1_idx].ToUnifiedFormat(n, sequence1_data);
-		chunk->data[qual1_idx].ToUnifiedFormat(n, qual1_data);
-
-		auto sample_ref_strs = UnifiedVectorFormat::GetData<string_t>(sample_ref_data);
-		auto read_id_strs = UnifiedVectorFormat::GetData<string_t>(read_id_data);
-		auto sequence1_strs = UnifiedVectorFormat::GetData<string_t>(sequence1_data);
-
-		UnifiedVectorFormat sequence2_data, qual2_data;
-		const string_t *sequence2_strs = nullptr;
-		if (has_r2_columns) {
-			chunk->data[sequence2_idx].ToUnifiedFormat(n, sequence2_data);
-			chunk->data[qual2_idx].ToUnifiedFormat(n, qual2_data);
-			sequence2_strs = UnifiedVectorFormat::GetData<string_t>(sequence2_data);
-		}
-
-		UnifiedVectorFormat sequence_index_data;
-		if (sequence_index_idx >= 0) {
-			chunk->data[sequence_index_idx].ToUnifiedFormat(n, sequence_index_data);
-		}
-
-		for (idx_t row = 0; row < n; row++) {
-			const idx_t global_row = out.sample_ref.size();
-			if (global_row >= MAX_INPUT_ROWS) {
-				throw InvalidInputException(
-				    "ena_upload_reads: input relation exceeds %llu rows; split by sample_ref and call per-batch",
-				    MAX_INPUT_ROWS);
-			}
-			const auto sr_idx = sample_ref_data.sel->get_index(row);
-			if (!sample_ref_data.validity.RowIsValid(sr_idx)) {
-				throw InvalidInputException("ena_upload_reads: NULL sample_ref at row %llu", global_row);
-			}
-			const auto sample_ref = sample_ref_strs[sr_idx].GetString();
-			if (sample_ref.empty()) {
-				throw InvalidInputException("ena_upload_reads: empty sample_ref at row %llu", global_row);
-			}
-			if (sample_ref.find('/') != string::npos) {
-				throw InvalidInputException(
-				    "ena_upload_reads: sample_ref '%s' contains '/' which is not allowed in a filename", sample_ref);
-			}
-			// Reject path-traversal components — the sample_ref is concatenated
-			// directly into a destination path for `file://` writes, so
-			// `..` could escape the upload directory.
-			if (sample_ref == ".." || sample_ref == "." || sample_ref.find("..") != string::npos) {
-				throw InvalidInputException(
-				    "ena_upload_reads: sample_ref '%s' contains '..' (path-traversal not allowed)", sample_ref);
-			}
-
-			const auto rid_idx = read_id_data.sel->get_index(row);
-			if (!read_id_data.validity.RowIsValid(rid_idx)) {
-				throw InvalidInputException("ena_upload_reads: NULL read_id at row %llu", global_row);
-			}
-			const auto seq1_idx = sequence1_data.sel->get_index(row);
-			if (!sequence1_data.validity.RowIsValid(seq1_idx)) {
-				throw InvalidInputException("ena_upload_reads: NULL sequence1 at row %llu", global_row);
-			}
-			const auto q1_idx = qual1_data.sel->get_index(row);
-			if (!qual1_data.validity.RowIsValid(q1_idx)) {
-				throw InvalidInputException("ena_upload_reads: NULL qual1 at row %llu", global_row);
-			}
-
-			out.sample_ref.push_back(sample_ref);
-			out.read_id.push_back(read_id_strs[rid_idx].GetString());
-			out.sequence1.push_back(sequence1_strs[seq1_idx].GetString());
-			auto qual1 = ExtractQualList(chunk->data[qual1_idx], qual1_data, row);
-			if (qual1.size() != out.sequence1.back().size()) {
-				throw InvalidInputException(
-				    "ena_upload_reads: qual1 length (%llu) does not match sequence1 length (%llu) at row %llu",
-				    qual1.size(), out.sequence1.back().size(), global_row);
-			}
-			out.qual1.push_back(std::move(qual1));
-			out.total_seq_bytes += out.sequence1.back().size();
-
-			if (has_r2_columns) {
-				const auto s2 = sequence2_data.sel->get_index(row);
-				const auto q2 = qual2_data.sel->get_index(row);
-				const bool s2_valid = sequence2_data.validity.RowIsValid(s2);
-				const bool q2_valid = qual2_data.validity.RowIsValid(q2);
-				if (s2_valid != q2_valid) {
-					throw InvalidInputException(
-					    "ena_upload_reads: sequence2 and qual2 must both be NULL or both non-NULL at row %llu",
-					    global_row);
-				}
-				out.has_seq2.push_back(s2_valid);
-				if (s2_valid) {
-					out.sequence2.push_back(sequence2_strs[s2].GetString());
-					auto q2_vec = ExtractQualList(chunk->data[qual2_idx], qual2_data, row);
-					if (q2_vec.size() != out.sequence2.back().size()) {
-						throw InvalidInputException(
-						    "ena_upload_reads: qual2 length (%llu) does not match sequence2 length (%llu) at row %llu",
-						    q2_vec.size(), out.sequence2.back().size(), global_row);
-					}
-					out.qual2.push_back(std::move(q2_vec));
-					out.total_seq_bytes += out.sequence2.back().size();
-				} else {
-					out.sequence2.emplace_back();
-					out.qual2.emplace_back();
-				}
-			} else {
-				out.has_seq2.push_back(false);
-				out.sequence2.emplace_back();
-				out.qual2.emplace_back();
-			}
-
-			if (out.total_seq_bytes > MAX_INPUT_SEQUENCE_BYTES) {
-				throw InvalidInputException(
-				    "ena_upload_reads: input sequences exceed %llu bytes (cap is to keep the in-memory pipeline "
-				    "bounded; split by sample_ref and call per-batch)",
-				    MAX_INPUT_SEQUENCE_BYTES);
-			}
-
-			if (sequence_index_idx >= 0) {
-				const auto si = sequence_index_data.sel->get_index(row);
-				if (sequence_index_data.validity.RowIsValid(si)) {
-					out.sequence_index.push_back(UnifiedVectorFormat::GetData<int64_t>(sequence_index_data)[si]);
-					out.sequence_index_valid.push_back(true);
-				} else {
-					out.sequence_index.push_back(0);
-					out.sequence_index_valid.push_back(false);
-				}
-			} else {
-				out.sequence_index.push_back(0);
-				out.sequence_index_valid.push_back(false);
-			}
-		}
+// A sample_ref becomes a filename component (and, for file://, a path segment),
+// so reject anything that could break the name or escape the upload directory.
+void ValidateSampleRef(const string &sample_ref) {
+	if (sample_ref.empty()) {
+		throw InvalidInputException("ena_upload_reads: empty sample_ref");
+	}
+	if (sample_ref.find('/') != string::npos) {
+		throw InvalidInputException("ena_upload_reads: sample_ref '%s' contains '/' which is not allowed in a filename",
+		                            sample_ref);
+	}
+	if (sample_ref == "." || sample_ref.find("..") != string::npos) {
+		throw InvalidInputException("ena_upload_reads: sample_ref '%s' is '.' or contains '..' (path-traversal not "
+		                            "allowed)",
+		                            sample_ref);
 	}
 }
 
-// =====================================================================
-// Grouping + layout resolution
-// =====================================================================
-
-void GroupAndResolveLayout(const UploadInputRows &input, FastqLayoutMode requested, vector<SampleGroup> &out) {
-	std::map<string, vector<size_t>> by_sample;
-	for (size_t i = 0; i < input.sample_ref.size(); i++) {
-		by_sample[input.sample_ref[i]].push_back(i);
+// Cheap aggregate pre-pass: a single projected GROUP BY scan that learns each
+// sample's R2 pattern — `all_paired` (bool_and) and `any_paired` (bool_or) of
+// "sequence2 IS NOT NULL" — without ever touching the sequence payload. Resolves
+// every sample's layout up front, failing fast on a mixed sample or a
+// layout/mode conflict BEFORE any upload begins (so an invalid sample can't
+// leave earlier samples half-uploaded), and yields the list of samples to
+// stream. O(#samples) memory.
+void PlanSamples(Connection &conn, const string &relation_name, FastqLayoutMode requested, bool has_r2_columns,
+                 vector<SamplePlan> &out) {
+	const string quoted = KeywordHelper::WriteOptionallyQuoted(relation_name);
+	const string r2_expr = has_r2_columns ? "sequence2 IS NOT NULL" : "false";
+	const string query = "SELECT sample_ref, bool_and(" + r2_expr + ") AS all_paired, bool_or(" + r2_expr +
+	                     ") AS any_paired FROM " + quoted + " GROUP BY sample_ref";
+	auto result = conn.Query(query);
+	if (result->HasError()) {
+		throw InvalidInputException("ena_upload_reads: failed to scan relation '%s': %s", relation_name,
+		                            result->GetError());
 	}
-	for (auto &kv : by_sample) {
-		SampleGroup g;
-		g.sample_ref = kv.first;
-		g.row_indices = std::move(kv.second);
-		// Sort by sequence_index, NULLS LAST. Stable so equal/null rows keep
-		// original input order, which matches reader expectations.
-		std::stable_sort(g.row_indices.begin(), g.row_indices.end(), [&input](size_t a, size_t b) {
-			const bool av = input.sequence_index_valid[a];
-			const bool bv = input.sequence_index_valid[b];
-			if (av && bv) {
-				return input.sequence_index[a] < input.sequence_index[b];
+	while (auto chunk = result->Fetch()) {
+		const idx_t n = chunk->size();
+		for (idx_t row = 0; row < n; row++) {
+			auto sr_val = chunk->data[0].GetValue(row);
+			if (sr_val.IsNull()) {
+				throw InvalidInputException("ena_upload_reads: NULL sample_ref");
 			}
-			if (av) {
-				return true; // valid before null
+			const string sample_ref = sr_val.ToString();
+			ValidateSampleRef(sample_ref);
+			// bool_and / bool_or over a non-empty group are never NULL.
+			const bool all_paired = chunk->data[1].GetValue(row).GetValue<bool>();
+			const bool any_paired = chunk->data[2].GetValue(row).GetValue<bool>();
+			SamplePlan plan;
+			plan.sample_ref = sample_ref;
+			try {
+				plan.resolved_layout = ResolveLayoutFromCounts(sample_ref, requested, all_paired, any_paired);
+			} catch (const std::exception &e) {
+				throw InvalidInputException("ena_upload_reads: %s", e.what());
 			}
-			return false;
-		});
-		vector<bool> has_r2;
-		has_r2.reserve(g.row_indices.size());
-		for (auto idx : g.row_indices) {
-			has_r2.push_back(input.has_seq2[idx]);
+			out.push_back(std::move(plan));
 		}
-		g.resolved_layout = ResolveLayout(g.sample_ref, requested, has_r2);
-		out.push_back(std::move(g));
 	}
 }
 
@@ -384,14 +259,10 @@ void GroupAndResolveLayout(const UploadInputRows &input, FastqLayoutMode request
 // Encoder → gzip → MD5 stream
 // =====================================================================
 //
-// Shared core for the file-sink (push, eager file write) and the libcurl
-// streaming producer (pull, in-memory buffering). Both run identical zlib +
-// MD5 plumbing — only the destination of the gzipped output differs. The
-// destination is supplied via a `ChunkSink` callback so consumers can route
-// bytes wherever they need.
-//
-// MD5 is computed over the bytes handed to the sink, which is exactly what
-// the consumer ultimately writes / uploads — the digest matches.
+// Streaming zlib + MD5 plumbing. The gzipped output is handed to a `ChunkSink`
+// callback (here always a file write — every transport stages to a file). MD5 is
+// computed over the bytes handed to the sink, which is exactly what the consumer
+// ultimately writes / uploads, so the digest matches the on-disk file.
 
 class GzipMd5Stream {
 public:
@@ -543,302 +414,288 @@ private:
 };
 
 // =====================================================================
-// Streaming encode → gzip → MD5 producer for libcurl
+// Per-chunk FASTQ encoding
 // =====================================================================
 //
-// libcurl pulls bytes via CURLOPT_READFUNCTION; this producer satisfies that
-// contract by encoding records on demand. Wraps a GzipMd5Stream whose sink
-// appends gzipped chunks into `out_buf`; `Read` drains `out_buf` to libcurl
-// and produces more on demand.
-//
-// State machine:
-//   1) Encoding: fetch next row, encode FASTQ via the encoder, feed the
-//      record bytes to `stream.Write` — gzip output lands in `out_buf`.
-//   2) Finishing: when no more rows, call `stream.Finish()` (Z_FINISH)
-//      which drains the trailer into `out_buf` and yields the final
-//      md5 + bytes_emitted, which we cache for `Finish()`.
-//   3) EOF: Read returns 0 once `out_buf` is drained AND `stream.Finished()`.
-//
-// `Finish()` is valid only after Read has returned 0.
+// Encode the rows of one streamed DataChunk into the sample's gzip sink(s). The
+// data query selects a fixed column order — 0=read_id, 1=sequence1, 2=qual1,
+// (3=sequence2, 4=qual2) — so indices are positional. R1 always goes to sink0;
+// for split PAIRED, R2 goes to sink1; for PAIRED_INTERLEAVED, R2 follows R1 into
+// sink0 (one pass over the row → positional pairing by construction). The R2
+// columns are guaranteed present whenever the resolved layout needs them
+// (PlanSamples would have rejected the sample otherwise).
+void EncodeChunk(DataChunk &chunk, FastqLayoutMode layout, FastqEncoder &encoder, GzipMd5FileSink &sink0,
+                 GzipMd5FileSink *sink1, const string &sample_ref) {
+	const idx_t n = chunk.size();
 
-class StreamingGzipMd5Producer {
-public:
-	StreamingGzipMd5Producer(const UploadInputRows &input, const SampleGroup &group, FastqLayoutMode layout,
-	                         int which_file, uint8_t qual_offset)
-	    : input(input), group(group), layout(layout), which_file(which_file), encoder(qual_offset),
-	      stream([this](const uint8_t *p, std::size_t n) { out_buf.insert(out_buf.end(), p, p + n); }) {
+	UnifiedVectorFormat read_id_data, sequence1_data, qual1_data;
+	chunk.data[0].ToUnifiedFormat(n, read_id_data);
+	chunk.data[1].ToUnifiedFormat(n, sequence1_data);
+	chunk.data[2].ToUnifiedFormat(n, qual1_data);
+	auto read_id_strs = UnifiedVectorFormat::GetData<string_t>(read_id_data);
+	auto sequence1_strs = UnifiedVectorFormat::GetData<string_t>(sequence1_data);
+
+	const bool need_r2 = layout == FastqLayoutMode::PAIRED || layout == FastqLayoutMode::PAIRED_INTERLEAVED;
+	UnifiedVectorFormat sequence2_data, qual2_data;
+	const string_t *sequence2_strs = nullptr;
+	if (need_r2) {
+		chunk.data[3].ToUnifiedFormat(n, sequence2_data);
+		chunk.data[4].ToUnifiedFormat(n, qual2_data);
+		sequence2_strs = UnifiedVectorFormat::GetData<string_t>(sequence2_data);
 	}
 
-	StreamingGzipMd5Producer(const StreamingGzipMd5Producer &) = delete;
-	StreamingGzipMd5Producer &operator=(const StreamingGzipMd5Producer &) = delete;
-
-	std::size_t Read(char *buf, std::size_t max_bytes) {
-		while (true) {
-			if (out_buf_pos < out_buf.size()) {
-				const std::size_t avail = out_buf.size() - out_buf_pos;
-				const std::size_t to_copy = std::min(avail, max_bytes);
-				std::memcpy(buf, out_buf.data() + out_buf_pos, to_copy);
-				out_buf_pos += to_copy;
-				return to_copy;
-			}
-			out_buf.clear();
-			out_buf_pos = 0;
-			if (stream.Finished()) {
-				return 0;
-			}
-			ProduceMore();
-		}
-	}
-
-	std::pair<string, uint64_t> Finish() {
-		if (!stream.Finished()) {
-			throw IOException("ena_upload_reads: StreamingGzipMd5Producer::Finish before EOF");
-		}
-		return cached_result;
-	}
-
-private:
-	void ProduceMore() {
-		std::vector<uint8_t> record_buf;
-		auto record_sink = [&record_buf](const char *data, std::size_t size) {
-			record_buf.insert(record_buf.end(), reinterpret_cast<const uint8_t *>(data),
-			                  reinterpret_cast<const uint8_t *>(data) + size);
-		};
-		if (!EncodeOneRecord(record_sink)) {
-			cached_result = stream.Finish();
-			return;
-		}
-		stream.Write(record_buf.data(), record_buf.size());
-	}
-
-	bool EncodeOneRecord(const FastqEncoder::Sink &sink) {
-		if (row_cursor >= group.row_indices.size()) {
-			return false;
-		}
-		const auto rid = group.row_indices[row_cursor++];
-		const char *id = input.read_id[rid].data();
-		const std::size_t id_len = input.read_id[rid].size();
-
-		if (layout == FastqLayoutMode::SINGLE || (layout == FastqLayoutMode::PAIRED && which_file == 0)) {
-			const auto &seq = input.sequence1[rid];
-			const auto &q = input.qual1[rid];
-			encoder.Encode(sink, id, id_len, nullptr, 0, seq.data(), seq.size(), q.data(), q.size());
-		} else if (layout == FastqLayoutMode::PAIRED && which_file == 1) {
-			const auto &seq = input.sequence2[rid];
-			const auto &q = input.qual2[rid];
-			encoder.Encode(sink, id, id_len, nullptr, 0, seq.data(), seq.size(), q.data(), q.size());
-		} else if (layout == FastqLayoutMode::PAIRED_INTERLEAVED) {
-			const auto &s1 = input.sequence1[rid];
-			const auto &q1 = input.qual1[rid];
-			encoder.Encode(sink, id, id_len, nullptr, 0, s1.data(), s1.size(), q1.data(), q1.size());
-			const auto &s2 = input.sequence2[rid];
-			const auto &q2 = input.qual2[rid];
-			encoder.Encode(sink, id, id_len, nullptr, 0, s2.data(), s2.size(), q2.data(), q2.size());
-		} else {
-			// AUTO must be resolved by ResolveLayout before this class is
-			// instantiated. A future enum addition would land here too.
-			throw std::logic_error("StreamingGzipMd5Producer::EncodeOneRecord: unhandled layout");
-		}
-		return true;
-	}
-
-	const UploadInputRows &input;
-	const SampleGroup &group;
-	const FastqLayoutMode layout;
-	const int which_file;
-	FastqEncoder encoder;
-
-	// `out_buf` MUST be declared before `stream` so that the sink lambda
-	// stored inside `stream` is destroyed (with `stream`) before `out_buf` —
-	// otherwise the lambda's last access could touch a destroyed vector.
-	std::vector<std::uint8_t> out_buf;
-	std::size_t out_buf_pos = 0;
-	std::size_t row_cursor = 0;
-	std::pair<string, uint64_t> cached_result;
-	GzipMd5Stream stream;
-};
-
-// =====================================================================
-// Sample → file write
-// =====================================================================
-
-// Encode the rows of one sample into the supplied sink. `which_file` controls
-// which side of the layout we emit (0 = R1 / single / interleaved; 1 = R2
-// only, used by the split-paired layout's second pass).
-//
-// `qual_offset` is wired through the encoder constructor by the caller; this
-// helper only forwards reads, so the active offset is implicit in `encoder`.
-void EncodeSampleRows(const UploadInputRows &in, const SampleGroup &group, FastqLayoutMode layout, int which_file,
-                      FastqEncoder &encoder, GzipMd5FileSink &sink) {
-	auto sink_fn = [&sink](const char *data, std::size_t size) {
-		sink.Write(data, size);
+	auto write0 = [&sink0](const char *data, std::size_t size) {
+		sink0.Write(data, size);
+	};
+	// R2 destination: split PAIRED → sink1; PAIRED_INTERLEAVED → sink0 (R2 right
+	// after R1 in the same file). `r2_sink` is non-null exactly when `need_r2`, so
+	// `write_r2` is only ever invoked through a valid pointer.
+	GzipMd5FileSink *r2_sink = need_r2 ? (layout == FastqLayoutMode::PAIRED ? sink1 : &sink0) : nullptr;
+	auto write_r2 = [r2_sink](const char *data, std::size_t size) {
+		r2_sink->Write(data, size);
 	};
 
-	for (auto rid : group.row_indices) {
-		const char *id = in.read_id[rid].data();
-		const std::size_t id_len = in.read_id[rid].size();
-
-		if (layout == FastqLayoutMode::SINGLE || (layout == FastqLayoutMode::PAIRED && which_file == 0)) {
-			const auto &seq = in.sequence1[rid];
-			const auto &q = in.qual1[rid];
-			encoder.Encode(sink_fn, id, id_len, nullptr, 0, seq.data(), seq.size(), q.data(), q.size());
-		} else if (layout == FastqLayoutMode::PAIRED && which_file == 1) {
-			const auto &seq = in.sequence2[rid];
-			const auto &q = in.qual2[rid];
-			encoder.Encode(sink_fn, id, id_len, nullptr, 0, seq.data(), seq.size(), q.data(), q.size());
-		} else if (layout == FastqLayoutMode::PAIRED_INTERLEAVED) {
-			const auto &s1 = in.sequence1[rid];
-			const auto &q1 = in.qual1[rid];
-			encoder.Encode(sink_fn, id, id_len, nullptr, 0, s1.data(), s1.size(), q1.data(), q1.size());
-			const auto &s2 = in.sequence2[rid];
-			const auto &q2 = in.qual2[rid];
-			encoder.Encode(sink_fn, id, id_len, nullptr, 0, s2.data(), s2.size(), q2.data(), q2.size());
-		} else {
-			// AUTO must be resolved before this point; see ResolveLayout.
-			throw std::logic_error("EncodeSampleRows: unhandled FastqLayoutMode");
+	for (idx_t row = 0; row < n; row++) {
+		const auto rid_i = read_id_data.sel->get_index(row);
+		if (!read_id_data.validity.RowIsValid(rid_i)) {
+			throw InvalidInputException("ena_upload_reads: NULL read_id in sample '%s'", sample_ref);
 		}
+		const auto s1_i = sequence1_data.sel->get_index(row);
+		if (!sequence1_data.validity.RowIsValid(s1_i)) {
+			throw InvalidInputException("ena_upload_reads: NULL sequence1 in sample '%s'", sample_ref);
+		}
+		const auto q1_i = qual1_data.sel->get_index(row);
+		if (!qual1_data.validity.RowIsValid(q1_i)) {
+			throw InvalidInputException("ena_upload_reads: NULL qual1 in sample '%s'", sample_ref);
+		}
+
+		const char *id = read_id_strs[rid_i].GetData();
+		const std::size_t id_len = read_id_strs[rid_i].GetSize();
+		const char *s1 = sequence1_strs[s1_i].GetData();
+		const std::size_t s1_len = sequence1_strs[s1_i].GetSize();
+		auto q1 = ExtractQualList(chunk.data[2], qual1_data, row);
+		if (q1.size() != s1_len) {
+			throw InvalidInputException(
+			    "ena_upload_reads: qual1 length (%llu) does not match sequence1 length (%llu) in sample '%s'",
+			    (uint64_t)q1.size(), (uint64_t)s1_len, sample_ref);
+		}
+		encoder.Encode(write0, id, id_len, nullptr, 0, s1, s1_len, q1.data(), q1.size());
+
+		if (!need_r2) {
+			continue;
+		}
+		const auto s2_i = sequence2_data.sel->get_index(row);
+		const auto q2_i = qual2_data.sel->get_index(row);
+		if (!sequence2_data.validity.RowIsValid(s2_i) || !qual2_data.validity.RowIsValid(q2_i)) {
+			// PlanSamples resolved this sample as paired; a NULL R2 here means the
+			// relation returned different rows between the pre-pass and this scan
+			// (a non-deterministic view). Refuse rather than emit a broken pair.
+			throw InvalidInputException("ena_upload_reads: sample '%s' resolved as paired but a row has NULL R2 "
+			                            "(is the input relation non-deterministic across scans?)",
+			                            sample_ref);
+		}
+		const char *s2 = sequence2_strs[s2_i].GetData();
+		const std::size_t s2_len = sequence2_strs[s2_i].GetSize();
+		auto q2 = ExtractQualList(chunk.data[4], qual2_data, row);
+		if (q2.size() != s2_len) {
+			throw InvalidInputException(
+			    "ena_upload_reads: qual2 length (%llu) does not match sequence2 length (%llu) in sample '%s'",
+			    (uint64_t)q2.size(), (uint64_t)s2_len, sample_ref);
+		}
+		encoder.Encode(write_r2, id, id_len, nullptr, 0, s2, s2_len, q2.data(), q2.size());
 	}
 }
 
-void RunUpload(ClientContext &context, const ENAUploadReadsBindData &bind, ENAUploadReadsGlobalState &gs) {
-	auto &fs = FileSystem::GetFileSystem(context);
+#ifdef MIINT_HAS_CURL
+// Upload an already-staged local file to a curl URL (ftp/ftps/http/https). The
+// encode path stages every transport's output to a file (uniform); for curl we
+// then stream that file to the socket via a file-backed read callback.
+miint::CurlUploadResult UploadFileViaCurl(FileSystem &fs, const string &path, miint::CurlUploadOptions opts) {
+	auto handle = fs.OpenFile(path, FileFlags::FILE_FLAGS_READ);
+	opts.expected_size = static_cast<long long>(fs.GetFileSize(*handle));
+	auto producer = [&fs, &handle](char *buf, std::size_t max_bytes) -> std::size_t {
+		return static_cast<std::size_t>(fs.Read(*handle, buf, static_cast<int64_t>(max_bytes)));
+	};
+	return miint::RunCurlUpload(opts, producer);
+}
+#endif
 
-	if (gs.target.transport == UploadTransport::LOCAL_FILE) {
-		fs.CreateDirectoriesRecursive(gs.target.remote_dir);
+// Encode + stage + transport one sample's file(s). Every transport stages the
+// gzipped output to a file first — the destination for file://, a private temp
+// dir for aspera/curl — then ships it: ascp for Aspera, a file-backed upload for
+// curl, nothing more for file://. The sample's rows are streamed once (both
+// sinks stay open across the single pass for split-paired), so peak memory is
+// one DataChunk + one zlib window regardless of how large the sample is.
+void UploadOneSample(ClientContext &context, const ENAUploadReadsBindData &bind, ENAUploadReadsGlobalState &gs,
+                     Connection &conn, const string &data_query_prefix, const SamplePlan &plan) {
+	auto &fs = FileSystem::GetFileSystem(context);
+	const auto filenames = OutputFilenames(plan.sample_ref, plan.resolved_layout); // 1 (single/interleaved) or 2
+
+	// On platforms without Aspera support fail-fast *before* the mkdtemp staging
+	// code — mkdtemp is POSIX-only and MinGW's libc doesn't provide it, so this
+	// guard also keeps the file compilable on Windows.
+#if !(MIINT_ASPERA_SUPPORTED && defined(MIINT_STATIC_BUILD))
+	if (gs.target.transport == UploadTransport::ASPERA) {
+		throw IOException("ena_upload_reads: Aspera transport is not supported on this build/platform");
+	}
+#endif
+
+	const bool stage = gs.target.transport != UploadTransport::LOCAL_FILE;
+	string temp_dir;
+	vector<string> write_paths;
+	if (!stage) {
+		for (auto &fname : filenames) {
+			write_paths.push_back(gs.target.remote_dir + fname);
+		}
+	} else {
+		// Private temp dir so each staged file's basename matches its remote
+		// name; unlink + rmdir after transport.
+		string tmpl = miint::GetTempDir() + "/ena-upload-XXXXXX";
+		vector<char> buf(tmpl.begin(), tmpl.end());
+		buf.push_back('\0');
+		if (mkdtemp(buf.data()) == nullptr) {
+			throw IOException("ena_upload_reads: mkdtemp failed: %s", std::strerror(errno));
+		}
+		temp_dir.assign(buf.data());
+		for (auto &fname : filenames) {
+			write_paths.push_back(temp_dir + "/" + fname);
+		}
 	}
 
-	for (auto &group : gs.samples) {
-		auto filenames = OutputFilenames(group.sample_ref, group.resolved_layout);
-		for (size_t f = 0; f < filenames.size(); f++) {
-			const auto &fname = filenames[f];
-			const int which_file = (group.resolved_layout == FastqLayoutMode::PAIRED && f == 1) ? 1 : 0;
+	// Cleanup runs whether the block below succeeds or throws. For LOCAL_FILE
+	// temp_dir is empty, so the destination is left in place (matches COPY).
+	auto cleanup_temp = [&]() noexcept {
+		if (!temp_dir.empty()) {
+			for (auto &wp : write_paths) {
+				(void)unlink(wp.c_str());
+			}
+			(void)rmdir(temp_dir.c_str());
+		}
+	};
 
-			string md5_hex;
-			uint64_t bytes_written = 0;
+	try {
+		vector<unique_ptr<GzipMd5FileSink>> sinks;
+		sinks.reserve(write_paths.size());
+		for (auto &wp : write_paths) {
+			sinks.push_back(make_uniq<GzipMd5FileSink>(fs, wp));
+		}
+		GzipMd5FileSink *sink1 = sinks.size() > 1 ? sinks[1].get() : nullptr;
+
+		// Stream this sample's rows once and encode straight into the sink(s).
+		// SendQuery (not a prepared statement) is deliberate: it defaults to a
+		// streaming result, so Fetch pulls one DataChunk at a time and peak memory
+		// stays bounded. A prepared statement's result output_type defaults to
+		// FORCE_MATERIALIZED — it would buffer the entire sample in RAM, defeating
+		// the whole refactor. Draining to exhaustion closes the stream before the
+		// next sample's query. If EncodeChunk throws mid-stream the result is
+		// abandoned un-closed, but the exception aborts the statement: `conn` is
+		// torn down (its dtor runs cleanup) and never reused, so the dangling
+		// active query never matters here.
+		FastqEncoder encoder(bind.qual_offset);
+		auto result = conn.SendQuery(data_query_prefix + KeywordHelper::WriteQuoted(plan.sample_ref, '\''));
+		if (result->HasError()) {
+			throw InvalidInputException("ena_upload_reads: failed to read sample '%s': %s", plan.sample_ref,
+			                            result->GetError());
+		}
+		while (auto chunk = result->Fetch()) {
+			if (chunk->size() == 0) {
+				continue;
+			}
+			EncodeChunk(*chunk, plan.resolved_layout, encoder, *sinks[0], sink1, plan.sample_ref);
+		}
+
+		// Finish each file (flushes the gzip trailer, closes the handle, yields
+		// the md5 over exactly the on-disk bytes), then transport it.
+		for (size_t f = 0; f < filenames.size(); f++) {
+			auto finished = sinks[f]->Finish();
+			string md5_hex = std::move(finished.first);
+			const uint64_t bytes_written = finished.second;
 
 			if (gs.target.transport == UploadTransport::CURL) {
 #ifdef MIINT_HAS_CURL
-				// Streaming path — no temp file. libcurl pulls bytes from
-				// the producer until EOF; the producer encodes records on
-				// demand and computes MD5 over the gzipped output as it
-				// flows through.
-				StreamingGzipMd5Producer producer(gs.input, group, group.resolved_layout, which_file, bind.qual_offset);
 				miint::CurlUploadOptions opts;
-				opts.url = gs.target.url_for_curl + fname;
+				opts.url = gs.target.url_for_curl + filenames[f];
 				opts.user = gs.user;
 				opts.password = gs.password;
 				opts.create_dirs = true;
 				// `MIINT_CURL_VERBOSE=1` enables CURLOPT_VERBOSE wire trace on
-				// stderr — invaluable for diagnosing FTPS/HTTPS upload hangs
-				// against the live ENA endpoint.
+				// stderr — invaluable for diagnosing FTPS/HTTPS upload hangs.
 				if (const char *v = std::getenv("MIINT_CURL_VERBOSE"); v && std::string(v) == "1") {
 					opts.verbose = true;
 				}
-				auto curl_producer = [&producer](char *buf, std::size_t max_bytes) -> std::size_t {
-					return producer.Read(buf, max_bytes);
-				};
-				auto result = miint::RunCurlUpload(opts, curl_producer);
-				if (!result.error_message.empty()) {
+				auto curl_result = UploadFileViaCurl(fs, write_paths[f], opts);
+				if (!curl_result.error_message.empty()) {
 					throw IOException("ena_upload_reads: %s upload failed for sample '%s' file '%s': %s",
-					                  gs.target.scheme, group.sample_ref, fname, result.error_message);
+					                  gs.target.scheme, plan.sample_ref, filenames[f], curl_result.error_message);
 				}
-				auto finished = producer.Finish();
-				md5_hex = std::move(finished.first);
-				bytes_written = finished.second;
 #else
-				throw IOException("ena_upload_reads: %s:// transport requires libcurl, which is disabled in this build "
-				                  "(use aspera:// or file:// instead, or rebuild with -DMIINT_ENABLE_CURL=ON)",
+				throw IOException("ena_upload_reads: %s:// transport requires libcurl, which is disabled in this "
+				                  "build (use aspera:// or file:// instead, or rebuild with -DMIINT_ENABLE_CURL=ON)",
 				                  gs.target.scheme);
 #endif
-			} else {
-				// Encode → gzip → MD5 → file. For Aspera we then ascp the
-				// file. For LOCAL_FILE the destination IS the local path.
-				//
-				// On platforms without Aspera support (Windows/MinGW, Emscripten)
-				// fail-fast *before* the temp-dir staging code — mkdtemp is POSIX-only
-				// and MinGW's libc doesn't provide it, so guarding here also keeps
-				// the file compilable on Windows.
-#if !(MIINT_ASPERA_SUPPORTED && defined(MIINT_STATIC_BUILD))
-				if (gs.target.transport == UploadTransport::ASPERA) {
-					throw IOException("ena_upload_reads: Aspera transport is not supported on this build/platform");
-				}
-#endif
-				string write_path;
-				string temp_dir;
-				if (gs.target.transport == UploadTransport::LOCAL_FILE) {
-					write_path = gs.target.remote_dir + fname;
-				}
-#if MIINT_ASPERA_SUPPORTED && defined(MIINT_STATIC_BUILD)
-				else {
-					// Aspera: write to a private temp directory so the
-					// basename matches the desired remote name. mkdtemp
-					// gives us a unique path; we unlink + rmdir after
-					// ascp finishes.
-					string tmpl = miint::GetTempDir() + "/ena-upload-XXXXXX";
-					vector<char> buf(tmpl.begin(), tmpl.end());
-					buf.push_back('\0');
-					if (mkdtemp(buf.data()) == nullptr) {
-						throw IOException("ena_upload_reads: mkdtemp failed: %s", std::strerror(errno));
-					}
-					temp_dir.assign(buf.data());
-					write_path = temp_dir + "/" + fname;
-				}
-#endif
-
-				// Cleanup helper — runs whether the encode/gzip/transport
-				// block succeeds or throws. For LOCAL_FILE we leave the
-				// destination in place regardless (matches COPY behaviour).
-				auto cleanup_temp = [&]() noexcept {
-					if (!temp_dir.empty()) {
-						(void)unlink(write_path.c_str());
-						(void)rmdir(temp_dir.c_str());
-					}
-				};
-
-				try {
-					FastqEncoder encoder(bind.qual_offset);
-					GzipMd5FileSink sink(fs, write_path);
-					EncodeSampleRows(gs.input, group, group.resolved_layout, which_file, encoder, sink);
-					auto finished = sink.Finish();
-					md5_hex = std::move(finished.first);
-					bytes_written = finished.second;
-
-#if MIINT_ASPERA_SUPPORTED && defined(MIINT_STATIC_BUILD)
-					if (gs.target.transport == UploadTransport::ASPERA) {
-						AsperaSendOptions opts;
-						opts.ascp_path = gs.aspera_ascp_path;
-						opts.key_path = gs.aspera_key_path;
-						opts.user = gs.user;
-						opts.host = gs.target.host;
-						opts.port = 33001;
-						opts.local_path = write_path;
-						opts.remote_dir = gs.target.remote_dir;
-						opts.max_rate = gs.aspera_max_rate;
-						auto argv = BuildAscpSendArgv(opts);
-
-						auto result = miint::RunAsperaSend(argv, gs.password);
-						if (result.exit_code != 0) {
-							throw IOException("ena_upload_reads: ascp failed (exit %d) for sample '%s' file '%s': %s",
-							                  result.exit_code, group.sample_ref, fname, result.stderr_output);
-						}
-					}
-#endif
-				} catch (...) {
-					cleanup_temp();
-					throw;
-				}
-				cleanup_temp();
 			}
+#if MIINT_ASPERA_SUPPORTED && defined(MIINT_STATIC_BUILD)
+			else if (gs.target.transport == UploadTransport::ASPERA) {
+				AsperaSendOptions opts;
+				opts.ascp_path = gs.aspera_ascp_path;
+				opts.key_path = gs.aspera_key_path;
+				opts.user = gs.user;
+				opts.host = gs.target.host;
+				opts.port = 33001;
+				opts.local_path = write_paths[f];
+				opts.remote_dir = gs.target.remote_dir;
+				opts.max_rate = gs.aspera_max_rate;
+				auto argv = BuildAscpSendArgv(opts);
+				auto ascp_result = miint::RunAsperaSend(argv, gs.password);
+				if (ascp_result.exit_code != 0) {
+					throw IOException("ena_upload_reads: ascp failed (exit %d) for sample '%s' file '%s': %s",
+					                  ascp_result.exit_code, plan.sample_ref, filenames[f], ascp_result.stderr_output);
+				}
+			}
+#endif
+			// LOCAL_FILE: the destination IS write_paths[f]; nothing more to do.
 
 			EmittedFile e;
-			e.sample_ref = group.sample_ref;
-			e.filename = fname;
+			e.sample_ref = plan.sample_ref;
+			e.filename = filenames[f];
 			e.filetype = "fastq";
 			e.md5_hex = std::move(md5_hex);
 			e.bytes_written = bytes_written;
-			e.layout_name = FastqLayoutModeName(group.resolved_layout);
+			e.layout_name = FastqLayoutModeName(plan.resolved_layout);
 			gs.emitted.push_back(std::move(e));
 		}
+	} catch (...) {
+		cleanup_temp();
+		throw;
+	}
+	cleanup_temp();
+}
+
+// Plan the samples (cheap aggregate pre-pass), then stream each one to its
+// destination, one at a time. A single Connection is reused across samples; each
+// sample's streaming result is fully drained before the next query (DuckDB
+// allows only one active stream per connection).
+void RunStreamingUpload(ClientContext &context, const ENAUploadReadsBindData &bind, ENAUploadReadsGlobalState &gs) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+
+	const bool has_r2_columns = ValidateSchemaDetectR2(conn, bind.relation_name);
+	PlanSamples(conn, bind.relation_name, bind.layout_mode, has_r2_columns, gs.samples);
+
+	if (gs.target.transport == UploadTransport::LOCAL_FILE) {
+		auto &fs = FileSystem::GetFileSystem(context);
+		fs.CreateDirectoriesRecursive(gs.target.remote_dir);
+	}
+
+	// Per-sample data query, completed in UploadOneSample by appending a quoted
+	// sample_ref literal. WriteQuoted escapes the value, so a sample_ref with an
+	// embedded quote stays safe (the filename-level checks in ValidateSampleRef
+	// reject '/' and '..' but allow quotes).
+	const string data_query_prefix = "SELECT read_id, sequence1, qual1" +
+	                                 string(has_r2_columns ? ", sequence2, qual2" : "") + " FROM " +
+	                                 KeywordHelper::WriteOptionallyQuoted(bind.relation_name) + " WHERE sample_ref = ";
+	for (auto &plan : gs.samples) {
+		UploadOneSample(context, bind, gs, conn, data_query_prefix, plan);
 	}
 }
 
@@ -964,14 +821,12 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 #endif
 	}
 
-	MaterialiseInput(context, bind.relation_name, gs->input);
-	GroupAndResolveLayout(gs->input, bind.layout_mode, gs->samples);
-
-	// Run the entire upload eagerly during init. The execution side just
-	// drains the per-file rows from `emitted`. This keeps the error model
-	// simple (any failure aborts the statement) and matches the typical
-	// per-batch upload size — usually under a few GB of FASTQ.
-	RunUpload(context, bind, *gs);
+	// Plan the samples (cheap aggregate pre-pass, fail-fast layout resolution)
+	// and run the entire upload eagerly during init, streaming one sample at a
+	// time. The execution side just drains the per-file rows from `emitted`. This
+	// keeps the error model simple (any failure aborts the statement) and keeps
+	// peak memory bounded to one DataChunk + one zlib window regardless of size.
+	RunStreamingUpload(context, bind, *gs);
 	return std::move(gs);
 }
 

--- a/src/include/ena_upload_helpers.hpp
+++ b/src/include/ena_upload_helpers.hpp
@@ -20,10 +20,10 @@
 namespace duckdb {
 
 // User-requested or auto-detected per-sample FASTQ layout. AUTO is a
-// bind-time placeholder; ResolveLayout collapses it to SINGLE or PAIRED based
-// on the actual rows. PAIRED_INTERLEAVED is a user override (the only layout
-// the encoder side cannot infer from data alone) that emits one file with R1
-// and R2 records alternating.
+// bind-time placeholder; ResolveLayoutFromCounts collapses it to SINGLE or
+// PAIRED based on the sample's actual R2 presence. PAIRED_INTERLEAVED is a user
+// override (the only layout the encoder side cannot infer from data alone) that
+// emits one file with R1 and R2 records alternating.
 enum class FastqLayoutMode : uint8_t {
 	AUTO,
 	SINGLE,
@@ -39,13 +39,17 @@ const char *FastqLayoutModeName(FastqLayoutMode mode);
 // std::runtime_error with the offending value when the name isn't recognised.
 FastqLayoutMode ParseFastqLayoutMode(const std::string &name);
 
-// Resolve the per-sample layout from rows. `has_r2[i]` records whether row i
-// in the sample's grouped chunk supplied a non-null R2. Mixed rows (some with,
-// some without) raise std::runtime_error naming the sample_ref and the
-// 0-based index of the first inconsistent row. PAIRED_INTERLEAVED is honored
-// only when every row has a non-null R2; otherwise behaves like PAIRED.
-FastqLayoutMode ResolveLayout(const std::string &sample_ref, FastqLayoutMode requested,
-                              const std::vector<bool> &has_r2);
+// Resolve the per-sample layout from aggregate R2-presence counts. `all_paired`
+// is true when *every* row in the sample supplied a non-null R2 (SQL
+// `bool_and(sequence2 IS NOT NULL)`); `any_paired` is true when *at least one*
+// did (`bool_or(...)`). This is the entry point for the streaming upload path,
+// which learns each sample's R2 pattern from a cheap GROUP BY pre-pass instead
+// of buffering every row. Mixed samples (`any_paired && !all_paired`) and
+// layout/mode conflicts raise std::runtime_error naming the sample_ref.
+// PAIRED_INTERLEAVED is honored only when every row has a non-null R2; otherwise
+// (like PAIRED) it errors. Callers must pass a sample with >= 1 row.
+FastqLayoutMode ResolveLayoutFromCounts(const std::string &sample_ref, FastqLayoutMode requested, bool all_paired,
+                                        bool any_paired);
 
 // Output FASTQ filenames for one sample given its resolved layout.
 //   SINGLE             → ["{sample_ref}.fastq.gz"]

--- a/test/cpp/test_ena_upload_reads.cpp
+++ b/test/cpp/test_ena_upload_reads.cpp
@@ -32,78 +32,59 @@ using duckdb::FastqLayoutModeName;
 using duckdb::OutputFilenames;
 using duckdb::ParseFastqLayoutMode;
 using duckdb::ParseUploadTargetURL;
-using duckdb::ResolveLayout;
+using duckdb::ResolveLayoutFromCounts;
 using duckdb::UploadTargetURL;
 using duckdb::UploadTransport;
 
-// ---- Layout detection ----------------------------------------------------
+// ---- Layout detection from aggregate counts (streaming pre-pass) ----------
+// (all_paired, any_paired) is the (bool_and, bool_or) of "sequence2 IS NOT NULL"
+// over a sample. all-single = (false,false); all-paired = (true,true);
+// mixed = (false,true). (true,false) is impossible for a non-empty sample.
 
-TEST_CASE("ResolveLayout: AUTO collapses to SINGLE when no row has R2", "[ena_upload_reads]") {
-	std::vector<bool> has_r2 = {false, false, false};
-	REQUIRE(ResolveLayout("sampleA", FastqLayoutMode::AUTO, has_r2) == FastqLayoutMode::SINGLE);
+TEST_CASE("ResolveLayoutFromCounts: AUTO collapses to SINGLE when no row has R2", "[ena_upload_reads]") {
+	REQUIRE(ResolveLayoutFromCounts("sampleA", FastqLayoutMode::AUTO, /*all_paired=*/false, /*any_paired=*/false) ==
+	        FastqLayoutMode::SINGLE);
 }
 
-TEST_CASE("ResolveLayout: AUTO collapses to PAIRED when every row has R2", "[ena_upload_reads]") {
-	std::vector<bool> has_r2 = {true, true, true};
-	REQUIRE(ResolveLayout("sampleA", FastqLayoutMode::AUTO, has_r2) == FastqLayoutMode::PAIRED);
+TEST_CASE("ResolveLayoutFromCounts: AUTO collapses to PAIRED when every row has R2", "[ena_upload_reads]") {
+	REQUIRE(ResolveLayoutFromCounts("sampleA", FastqLayoutMode::AUTO, /*all_paired=*/true, /*any_paired=*/true) ==
+	        FastqLayoutMode::PAIRED);
 }
 
-TEST_CASE("ResolveLayout: mixed rows raise a clear error naming sample and row", "[ena_upload_reads]") {
-	std::vector<bool> has_r2 = {true, true, false, true};
-	REQUIRE_THROWS_WITH(ResolveLayout("sampleA", FastqLayoutMode::AUTO, has_r2),
-	                    Catch::Matchers::ContainsSubstring("sampleA") && Catch::Matchers::ContainsSubstring("row 2"));
-
-	std::vector<bool> has_r2_other = {false, false, true};
-	REQUIRE_THROWS_WITH(ResolveLayout("anotherSample", FastqLayoutMode::AUTO, has_r2_other),
-	                    Catch::Matchers::ContainsSubstring("anotherSample") &&
-	                        Catch::Matchers::ContainsSubstring("row 2"));
+TEST_CASE("ResolveLayoutFromCounts: AUTO mixed single/paired raises naming the sample", "[ena_upload_reads]") {
+	REQUIRE_THROWS_WITH(
+	    ResolveLayoutFromCounts("sampleA", FastqLayoutMode::AUTO, /*all_paired=*/false, /*any_paired=*/true),
+	    Catch::Matchers::ContainsSubstring("sampleA") && Catch::Matchers::ContainsSubstring("mixes"));
 }
 
-TEST_CASE("ResolveLayout: explicit SINGLE rejects rows that supplied R2", "[ena_upload_reads]") {
-	std::vector<bool> has_r2 = {false, true, false};
-	REQUIRE_THROWS_WITH(ResolveLayout("sampleA", FastqLayoutMode::SINGLE, has_r2),
-	                    Catch::Matchers::ContainsSubstring("layout=single") &&
-	                        Catch::Matchers::ContainsSubstring("sampleA") &&
-	                        Catch::Matchers::ContainsSubstring("row 1"));
+TEST_CASE("ResolveLayoutFromCounts: explicit SINGLE rejects a sample with any R2", "[ena_upload_reads]") {
+	// mixed
+	REQUIRE_THROWS_WITH(
+	    ResolveLayoutFromCounts("sampleA", FastqLayoutMode::SINGLE, /*all_paired=*/false, /*any_paired=*/true),
+	    Catch::Matchers::ContainsSubstring("layout=single") && Catch::Matchers::ContainsSubstring("sampleA"));
+	// fully paired
+	REQUIRE_THROWS_WITH(
+	    ResolveLayoutFromCounts("sampleA", FastqLayoutMode::SINGLE, /*all_paired=*/true, /*any_paired=*/true),
+	    Catch::Matchers::ContainsSubstring("layout=single"));
 }
 
-TEST_CASE("ResolveLayout: SINGLE error reports first row with R2, even when row 0 has R2", "[ena_upload_reads]") {
-	// Regression: an earlier implementation reused the AUTO "first mismatch
-	// vs row 0" counter and reported the wrong row when the first row was
-	// the offender.
-	std::vector<bool> has_r2 = {true, false, true};
-	REQUIRE_THROWS_WITH(ResolveLayout("sampleA", FastqLayoutMode::SINGLE, has_r2),
-	                    Catch::Matchers::ContainsSubstring("layout=single") &&
-	                        Catch::Matchers::ContainsSubstring("row 0"));
+TEST_CASE("ResolveLayoutFromCounts: explicit PAIRED rejects a sample missing any R2", "[ena_upload_reads]") {
+	// fully single
+	REQUIRE_THROWS_WITH(
+	    ResolveLayoutFromCounts("sampleA", FastqLayoutMode::PAIRED, /*all_paired=*/false, /*any_paired=*/false),
+	    Catch::Matchers::ContainsSubstring("layout=paired") && Catch::Matchers::ContainsSubstring("sampleA"));
+	// mixed
+	REQUIRE_THROWS_WITH(
+	    ResolveLayoutFromCounts("sampleA", FastqLayoutMode::PAIRED, /*all_paired=*/false, /*any_paired=*/true),
+	    Catch::Matchers::ContainsSubstring("layout=paired"));
 }
 
-TEST_CASE("ResolveLayout: PAIRED error reports first row missing R2, even when row 0 has R2", "[ena_upload_reads]") {
-	std::vector<bool> has_r2 = {true, true, false, true};
-	REQUIRE_THROWS_WITH(ResolveLayout("sampleA", FastqLayoutMode::PAIRED, has_r2),
-	                    Catch::Matchers::ContainsSubstring("layout=paired") &&
-	                        Catch::Matchers::ContainsSubstring("row 2"));
-}
-
-TEST_CASE("ResolveLayout: explicit PAIRED rejects rows missing R2", "[ena_upload_reads]") {
-	std::vector<bool> has_r2 = {true, true, false};
-	REQUIRE_THROWS_WITH(ResolveLayout("sampleA", FastqLayoutMode::PAIRED, has_r2),
-	                    Catch::Matchers::ContainsSubstring("layout=paired") &&
-	                        Catch::Matchers::ContainsSubstring("sampleA"));
-}
-
-TEST_CASE("ResolveLayout: PAIRED_INTERLEAVED requires every row to have R2", "[ena_upload_reads]") {
-	std::vector<bool> all_paired = {true, true};
-	REQUIRE(ResolveLayout("sampleA", FastqLayoutMode::PAIRED_INTERLEAVED, all_paired) ==
-	        FastqLayoutMode::PAIRED_INTERLEAVED);
-
-	std::vector<bool> mixed = {true, false};
-	REQUIRE_THROWS_WITH(ResolveLayout("sampleA", FastqLayoutMode::PAIRED_INTERLEAVED, mixed),
+TEST_CASE("ResolveLayoutFromCounts: PAIRED_INTERLEAVED requires every row to have R2", "[ena_upload_reads]") {
+	REQUIRE(ResolveLayoutFromCounts("sampleA", FastqLayoutMode::PAIRED_INTERLEAVED, /*all_paired=*/true,
+	                                /*any_paired=*/true) == FastqLayoutMode::PAIRED_INTERLEAVED);
+	REQUIRE_THROWS_WITH(ResolveLayoutFromCounts("sampleA", FastqLayoutMode::PAIRED_INTERLEAVED, /*all_paired=*/false,
+	                                            /*any_paired=*/true),
 	                    Catch::Matchers::ContainsSubstring("paired_interleaved"));
-}
-
-TEST_CASE("ResolveLayout: empty rows is treated as a programming error", "[ena_upload_reads]") {
-	std::vector<bool> empty;
-	REQUIRE_THROWS(ResolveLayout("sampleA", FastqLayoutMode::AUTO, empty));
 }
 
 // ---- Filenames ------------------------------------------------------------

--- a/test/sql/ena_upload_reads_bigmem.test
+++ b/test/sql/ena_upload_reads_bigmem.test
@@ -1,0 +1,56 @@
+# name: test/sql/ena_upload_reads_bigmem.test
+# description: ena_upload_reads streaming memory proof — a single sample far larger than memory_limit uploads losslessly
+# group: [sql]
+
+#
+# Opt-in / expensive (encodes millions of reads), so it is gated behind
+# MIINT_ENA_BIG_STREAM_TEST (exported by run_tests.sh when set). It proves the
+# per-sample streaming path handles a single sample whose materialised size far
+# exceeds the configured memory_limit.
+#
+# The pre-streaming implementation read the whole relation into RAM (and a
+# prepared statement's result FORCE-materialises), so this would OOM. The
+# SendQuery streaming path Fetches one DataChunk at a time: peak RSS was measured
+# (manually, /usr/bin/time -v) at ~48 MB for 200k reads and ~49 MB for 2M reads —
+# flat in N. This test is the in-suite functional smoke that a multi-GB single
+# sample uploads losslessly without error; it does not itself assert RSS.
+
+require miint
+
+require-env MIINT_ENA_BIG_STREAM_TEST
+
+# Bound DuckDB's tracked memory well below the dataset's materialised footprint
+# (~1.4 GB for 3M x 200 bp reads + equal-length quality lists). A streaming scan
+# stays comfortably under this; a regression that materialised the scan (e.g. an
+# ORDER BY on the payload, or a prepared statement) would blow past it.
+statement ok
+SET memory_limit = '512MB';
+
+# Lazy single-sample view: nothing is built until scanned, and each scan streams.
+statement ok
+CREATE VIEW big_reads AS
+  SELECT 'bigsample' AS sample_ref,
+         'r' || i AS read_id,
+         repeat('ACGT', 50) AS sequence1,                       -- 200 bp
+         list_resize([40]::UTINYINT[], 200, 40::UTINYINT) AS qual1,
+         CAST(NULL AS VARCHAR) AS sequence2,
+         CAST(NULL AS UTINYINT[]) AS qual2,
+         i AS sequence_index
+  FROM range(0, 3000000) t(i);
+
+statement ok
+CREATE TABLE big_result AS
+  SELECT * FROM ena_upload_reads(relation := 'big_reads',
+                                 target_url := 'file://__TEST_DIR__/bigmem/');
+
+# One single-end file, non-empty.
+query II
+SELECT layout, bytes_written > 0 FROM big_result;
+----
+single	true
+
+# Losslessness at scale: every read survived the encode→gzip→decode round-trip.
+query I
+SELECT count(*) FROM read_fastx('__TEST_DIR__/bigmem/bigsample.fastq.gz');
+----
+3000000

--- a/test/sql/ena_upload_reads_stream.test
+++ b/test/sql/ena_upload_reads_stream.test
@@ -1,0 +1,224 @@
+# name: test/sql/ena_upload_reads_stream.test
+# description: ena_upload_reads — order-independent round-trip + multi-chunk characterization (file://)
+# group: [sql]
+
+#
+# These tests lock the *observable* behaviour of ena_upload_reads ahead of the
+# per-sample streaming refactor: every input read must survive the
+# encode→gzip→upload→decode round-trip exactly, regardless of the order in which
+# reads are emitted. We compare the decoded .fastq.gz against the input as a
+# MULTISET (symmetric difference via EXCEPT ALL both directions == 0), so the
+# assertions stay green whether the implementation emits in sequence_index order
+# (today) or in scan order (after the refactor).
+
+require miint
+
+# ---------------------------------------------------------------------------
+# Single-end + paired-split losslessness on the canned fixtures.
+# ---------------------------------------------------------------------------
+statement ok
+CREATE TABLE in_single AS
+  SELECT 'sampleA' AS sample_ref, read_id, sequence1, qual1,
+         CAST(NULL AS VARCHAR) AS sequence2, CAST(NULL AS UTINYINT[]) AS qual2, sequence_index
+  FROM read_fastx('data/fastq/small_a.fq');
+
+statement ok
+CREATE TABLE in_paired AS
+  SELECT 'sampleB' AS sample_ref, read_id, sequence1, qual1, sequence2, qual2, sequence_index
+  FROM read_fastx('data/fastq/small_a_r1.fq', sequence2='data/fastq/small_a_r2.fq');
+
+statement ok
+CREATE TABLE rt_input AS
+  SELECT * FROM in_single UNION ALL BY NAME SELECT * FROM in_paired;
+
+statement ok
+CREATE TABLE rt_result AS
+  SELECT * FROM ena_upload_reads(relation := 'rt_input',
+                                 target_url := 'file://__TEST_DIR__/rt/');
+
+# sampleA single-end → 1 file; sampleB paired → 2 files.
+query I
+SELECT count(*) FROM rt_result;
+----
+3
+
+# Single-end round-trip: decoded == input as a multiset of (read_id, sequence1, qual1).
+query I
+WITH decoded AS (SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/rt/sampleA.fastq.gz'))
+SELECT count(*) FROM (
+  (SELECT * FROM decoded EXCEPT ALL SELECT read_id, sequence1, qual1 FROM in_single)
+  UNION ALL
+  (SELECT read_id, sequence1, qual1 FROM in_single EXCEPT ALL SELECT * FROM decoded));
+----
+0
+
+# Paired R1 file round-trips against (read_id, sequence1, qual1).
+query I
+WITH d1 AS (SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/rt/sampleB_1.fastq.gz'))
+SELECT count(*) FROM (
+  (SELECT * FROM d1 EXCEPT ALL SELECT read_id, sequence1, qual1 FROM in_paired)
+  UNION ALL
+  (SELECT read_id, sequence1, qual1 FROM in_paired EXCEPT ALL SELECT * FROM d1));
+----
+0
+
+# Paired R2 file round-trips against (read_id, sequence2, qual2) as a multiset.
+# Positional R1[i]<->R2[i] pairing is guaranteed structurally (R1 and R2 are the
+# same input row, emitted in one streaming pass), so this checks per-mate content
+# fidelity rather than ordering.
+query I
+WITH d2 AS (SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/rt/sampleB_2.fastq.gz'))
+SELECT count(*) FROM (
+  (SELECT * FROM d2 EXCEPT ALL SELECT read_id, sequence2, qual2 FROM in_paired)
+  UNION ALL
+  (SELECT read_id, sequence2, qual2 FROM in_paired EXCEPT ALL SELECT * FROM d2));
+----
+0
+
+# ---------------------------------------------------------------------------
+# paired_interleaved: one file carrying both mates; decoded == R1∪R2 multiset.
+# ---------------------------------------------------------------------------
+statement ok
+CREATE TABLE ri_result AS
+  SELECT * FROM ena_upload_reads(relation := 'in_paired',
+                                 target_url := 'file://__TEST_DIR__/ri/',
+                                 layout := 'paired_interleaved');
+
+query I
+WITH decoded AS (SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/ri/sampleB.fastq.gz')),
+     expanded AS (
+       SELECT read_id, sequence1, qual1 FROM in_paired
+       UNION ALL
+       SELECT read_id, sequence2, qual2 FROM in_paired)
+SELECT count(*) FROM (
+  (SELECT * FROM decoded EXCEPT ALL SELECT * FROM expanded)
+  UNION ALL
+  (SELECT * FROM expanded EXCEPT ALL SELECT * FROM decoded));
+----
+0
+
+# ---------------------------------------------------------------------------
+# Multi-chunk, multi-sample: 7500 rows across 3 samples (>2500 each) forces the
+# input across DataChunk boundaries. Every read must land in its own sample's
+# file and survive the round-trip.
+# ---------------------------------------------------------------------------
+statement ok
+CREATE TABLE in_big AS
+  SELECT 'bigS' || (i % 3) AS sample_ref,
+         'r' || i AS read_id,
+         'ACGTACGT' AS sequence1,
+         [40,40,40,40,40,40,40,40]::UTINYINT[] AS qual1,
+         CAST(NULL AS VARCHAR) AS sequence2, CAST(NULL AS UTINYINT[]) AS qual2,
+         i AS sequence_index
+  FROM range(1, 7501) t(i);
+
+statement ok
+CREATE TABLE big_result AS
+  SELECT * FROM ena_upload_reads(relation := 'in_big',
+                                 target_url := 'file://__TEST_DIR__/big/');
+
+# Three single-end files, one per sample.
+query II
+SELECT count(*), count(DISTINCT layout) FROM big_result;
+----
+3	1
+
+# Every read round-trips, across all three samples and all chunk boundaries.
+query I
+WITH decoded AS (
+  SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/big/bigS0.fastq.gz')
+  UNION ALL SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/big/bigS1.fastq.gz')
+  UNION ALL SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/big/bigS2.fastq.gz'))
+SELECT count(*) FROM (
+  (SELECT * FROM decoded EXCEPT ALL SELECT read_id, sequence1, qual1 FROM in_big)
+  UNION ALL
+  (SELECT read_id, sequence1, qual1 FROM in_big EXCEPT ALL SELECT * FROM decoded));
+----
+0
+
+# Per-sample read counts are preserved exactly (no cross-sample leakage).
+# read_fastx is a table function and doesn't take correlated args, so spell out
+# one count per file (2500 each: i in [1,7500] split by i%3).
+query I
+SELECT count(*) FROM read_fastx('__TEST_DIR__/big/bigS0.fastq.gz');
+----
+2500
+
+query I
+SELECT count(*) FROM read_fastx('__TEST_DIR__/big/bigS1.fastq.gz');
+----
+2500
+
+query I
+SELECT count(*) FROM read_fastx('__TEST_DIR__/big/bigS2.fastq.gz');
+----
+2500
+
+# ---------------------------------------------------------------------------
+# Schema / planning errors are raised before any upload (fail-fast).
+# ---------------------------------------------------------------------------
+
+# A relation with sequence2 but no qual2 is malformed — not single-end. Treating
+# it as single-end would silently drop the present mate, so it must error.
+statement ok
+CREATE TABLE in_partial_r2 AS
+  SELECT 'sP' AS sample_ref, read_id, sequence1, qual1, sequence2, sequence_index
+  FROM read_fastx('data/fastq/small_a_r1.fq', sequence2='data/fastq/small_a_r2.fq');
+
+statement error
+SELECT * FROM ena_upload_reads(relation := 'in_partial_r2',
+                               target_url := 'file://__TEST_DIR__/perr/');
+----
+qual2
+
+# layout=paired requested on a relation with no R2 columns at all → fail-fast.
+statement ok
+CREATE TABLE in_r1only AS
+  SELECT 'sR' AS sample_ref, read_id, sequence1, qual1, sequence_index
+  FROM read_fastx('data/fastq/small_a.fq');
+
+statement error
+SELECT * FROM ena_upload_reads(relation := 'in_r1only',
+                               target_url := 'file://__TEST_DIR__/perr2/',
+                               layout := 'paired');
+----
+layout=paired
+
+# Successful single-end upload from a relation with NO R2 columns at all
+# (exercises the 3-column data query + the bool_and(false) pre-pass branch, which
+# the other fixtures — carrying NULL sequence2/qual2 columns — never hit).
+statement ok
+CREATE TABLE in_noR2 AS
+  SELECT 'sN' AS sample_ref, read_id, sequence1, qual1, sequence_index
+  FROM read_fastx('data/fastq/small_a.fq');
+
+statement ok
+CREATE TABLE noR2_result AS
+  SELECT * FROM ena_upload_reads(relation := 'in_noR2',
+                                 target_url := 'file://__TEST_DIR__/nor2/');
+
+query II
+SELECT layout, bytes_written > 0 FROM noR2_result;
+----
+single	true
+
+query I
+WITH decoded AS (SELECT read_id, sequence1, qual1 FROM read_fastx('__TEST_DIR__/nor2/sN.fastq.gz'))
+SELECT count(*) FROM (
+  (SELECT * FROM decoded EXCEPT ALL SELECT read_id, sequence1, qual1 FROM in_noR2)
+  UNION ALL
+  (SELECT read_id, sequence1, qual1 FROM in_noR2 EXCEPT ALL SELECT * FROM decoded));
+----
+0
+
+# A sample_ref of '.' is rejected (path-traversal guard), with an accurate message.
+statement ok
+CREATE TABLE in_dot AS
+  SELECT '.' AS sample_ref, read_id, sequence1, qual1, sequence_index
+  FROM read_fastx('data/fastq/small_a.fq');
+
+statement error
+SELECT * FROM ena_upload_reads(relation := 'in_dot',
+                               target_url := 'file://__TEST_DIR__/derr/');
+----
+path-traversal


### PR DESCRIPTION
## Problem

`ena_upload_reads` read the entire input relation into RAM **twice** — a `MaterializedQueryResult` from `SELECT *`, then a copy into `std::vector` buffers — before uploading. That OOMs on large inputs.

## Change

Rewrite it to **stream per sample** so peak memory is `O(one DataChunk + one zlib window)`, independent of dataset size, for every transport (curl/FTP, Aspera, `file://`). A single sample may exceed RAM, so there is no per-sample buffering either.

- **`ValidateSchemaDetectR2`** — a `SELECT * … LIMIT 0` probe validates columns/types, detects the optional R2 columns, and **rejects a relation with only one of `sequence2`/`qual2`** (treating it as single-end would silently drop the present mate).
- **`PlanSamples`** — one cheap projected `GROUP BY` pre-pass resolves each sample's layout via `ResolveLayoutFromCounts` and **fails fast on mixed/conflicting layout before any upload** (no payload touched).
- **Per sample** — `conn.SendQuery` (deliberately *not* a prepared statement — those `FORCE_MATERIALIZE` even with `allow_stream_result=true`) streams rows chunk-by-chunk; `EncodeChunk` encodes into 1–2 `GzipMd5FileSink`s. Uniform staging across transports: write the gzipped file, then transport.

## Behavior changes (reviewer note)

- **Output read order = scan order** (no `sequence_index` sort — DuckDB can't spill large BLOB sorts). R1/R2 pairing is intra-row, so positional pairing holds regardless. MD5 is computed inline over the shipped bytes, so it always matches the uploaded bytes (what ENA validates); it is not byte-stable across reruns with differing scan parallelism.
- **curl** now stages a temp file then uploads (was socket-streaming).
- Layout errors no longer cite an offending row index; mixed/partial-R2 is caught fail-fast before upload.
- **`sequence_index` is no longer read or required.**

## Tests

- `test/sql/ena_upload_reads_stream.test` (new) — order-independent multiset round-trips for all four layouts, multi-chunk × multi-sample coverage, fail-fast error cases, and the no-R2-columns success path.
- `test/sql/ena_upload_reads_bigmem.test` (new, env-gated `MIINT_ENA_BIG_STREAM_TEST`) — a 3M-read single sample under a tight `memory_limit`, lossless (the old materialise path OOMs here). `run_tests.sh` gains the passthrough export.
- C++ unit tests updated for `ResolveLayoutFromCounts` (the vector-form `ResolveLayout` was removed).

## Verification

- Upload-reads SQL suite (`_local`, `_stream`, `_bigmem`) green, including the bounded-memory proof.
- Ran the full **ENA Webin mock submission suite** against the current build (502/503 assertions; the one failure is a pre-existing, unrelated `ena_lifecycle_mock.test` expectation-format issue on the empty `hold_until_date` column — code untouched by this PR, and the test normally skips because httpfs is disabled on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)