### PR TITLE
perf(qc): make adapter matcher Hamming-only to match fastp

### DIFF
--- a/src/include/qc_algorithms.hpp
+++ b/src/include/qc_algorithms.hpp
@@ -59,14 +59,16 @@ struct AdapterMatch {
 
 class AdapterMatcher {
 public:
-	// 3-phase adapter search ported from fastp:
-	//   phase 1: exact Hamming with 1 mismatch per 8 compared bases
-	//   phase 2: phase 1 + one insertion in seq (seq has one extra base)
-	//   phase 3: phase 1 + one deletion in seq (seq missing one base)
-	// Phases are tried in order; the first phase that finds a match wins.
-	// Within a phase, the LEFTMOST match wins (fastp's behavior — the leftmost
-	// hit is the most likely true adapter start; "best match" ranking would
-	// over-trim on genomic chatter that happens to match late in the read).
+	// Hamming-tolerant adapter search ported from fastp's
+	// AdapterTrimmer::trimBySequence: scan positions left-to-right, comparing
+	// adapter vs seq with a tolerance of 1 mismatch per 8 compared bases, and
+	// return the first match. No indel handling (fastp's by-sequence trim has
+	// none) — a single inserted/deleted base in the adapter region is not
+	// matched. The LEFTMOST match wins (fastp's behavior — the leftmost hit is
+	// the most likely true adapter start; "best match" ranking would over-trim
+	// on genomic chatter that happens to match late in the read). `indels` in
+	// the result is therefore always 0; the field is kept for symmetry with the
+	// other match metrics (only tests read it).
 	//
 	// `min_match` is the minimum length of compared region required for a
 	// match. fastp auto-scales this 4..6 based on adapter list size; here we

--- a/src/qc_algorithms.cpp
+++ b/src/qc_algorithms.cpp
@@ -257,20 +257,20 @@ TrimResult PolyXScanner::scan_polyx(const std::uint8_t *seq, std::size_t len, st
 }
 
 // ---------------------------------------------------------------------------
-// AdapterMatcher — 3-phase port of fastp's adapter trimming
+// AdapterMatcher — Hamming-tolerant port of fastp's by-sequence adapter trim
 // ---------------------------------------------------------------------------
 //
-// Phase 1: scan candidate positions left-to-right. At each position, compare
-// adapter vs seq with a tolerance of cmplen/8 mismatches. Return first match.
+// Scan candidate positions left-to-right. At each position, compare adapter vs
+// seq with a tolerance of cmplen/8 mismatches; return the first (leftmost)
+// match. This mirrors fastp's AdapterTrimmer::trimBySequence, which is
+// Hamming-only — it does NOT do indel-aware matching, so a single inserted or
+// deleted base in the adapter region frame-shifts the comparison past the
+// budget and the occurrence is not trimmed.
 //
-// Phase 2: same scan but allow exactly one insertion in seq (seq has one
-// extra base relative to adapter). Two-pointer walk; on first mismatch, skip
-// a seq base and continue. Mismatches AFTER the indel still count.
-//
-// Phase 3: same as phase 2 but the indel is a deletion in seq (seq missing
-// one base). On first mismatch, skip an adapter base.
-//
-// Phases are tried in order; first to find a match wins.
+// (An earlier build added an exhaustive single-indel search here. It matched
+// nothing on real data, dominated trim_adapters runtime — ~99% of it on a
+// 177-adapter set — and was never part of the fastp parity contract, which only
+// pins the clean exact-adapter cases.)
 
 namespace {
 
@@ -327,85 +327,6 @@ AdapterMatch phase1_hamming(const std::uint8_t *seq, std::size_t seq_len, const 
 	return {};
 }
 
-// Phase 2/3 shared body. For each candidate starting position, try every
-// possible indel position k in the adapter and pick the best (fewest
-// mismatches) result. Exhaustive search across k is required for
-// correctness: a greedy commit-on-first-mismatch approach produces false
-// negatives when a substitution precedes the true indel (e.g. one leading
-// sequencing error before the adapter's actual insertion site exhausts the
-// mismatch budget if the indel slot is wasted on the substitution).
-//
-// `insertion_in_seq` selects direction:
-//   true  → seq has one extra base at indel position k; skip seq[k]
-//   false → seq is missing one base at adapter position k; skip adapter[k]
-AdapterMatch phase_indel(const std::uint8_t *seq, std::size_t seq_len, const std::uint8_t *adapter,
-                         std::size_t adapter_len, std::size_t min_match, int start_pos, bool insertion_in_seq) {
-	const int seq_len_i = static_cast<int>(seq_len);
-	const int adapter_len_i = static_cast<int>(adapter_len);
-	const int min_match_i = static_cast<int>(min_match);
-
-	for (int pos = start_pos; pos + min_match_i <= seq_len_i; pos++) {
-		const int adapter_off = pos < 0 ? -pos : 0;
-		const int seq_off = pos < 0 ? 0 : pos;
-		const int adapter_remain = adapter_len_i - adapter_off;
-		const int seq_remain = seq_len_i - seq_off;
-		// Defensive guard: adapter_remain == 0 would underflow seq_region_len in the deletion case.
-		if (adapter_remain <= 0 || adapter_remain < min_match_i) {
-			continue;
-		}
-
-		const int seq_region_len = insertion_in_seq ? adapter_remain + 1 : adapter_remain - 1;
-		if (seq_region_len < min_match_i || seq_remain < seq_region_len) {
-			continue;
-		}
-
-		const std::uint32_t allowed = static_cast<std::uint32_t>(adapter_remain / MISMATCH_PER_8_BASES);
-		// max_k:
-		//   insertion: k can be any "gap" in adapter from 0 to adapter_remain inclusive
-		//              (inserted base at seq index k means adapter[j] maps to seq[j+1] for j>=k)
-		//   deletion:  k can be any adapter index 0..adapter_remain-1 to be "missing" from seq
-		const int max_k = insertion_in_seq ? adapter_remain : adapter_remain - 1;
-		std::uint32_t best_mm = allowed + 1; // sentinel: "no valid match yet"
-
-		for (int k = 0; k <= max_k; k++) {
-			std::uint32_t mm = 0;
-			bool ok = true;
-			for (int j = 0; j < adapter_remain; j++) {
-				if (!insertion_in_seq && j == k) {
-					continue; // adapter[k] is the deleted base; not in seq
-				}
-				int si;
-				if (insertion_in_seq) {
-					si = j < k ? j : j + 1;
-				} else {
-					si = j < k ? j : j - 1;
-				}
-				if (adapter[adapter_off + j] != seq[seq_off + si]) {
-					mm++;
-					if (mm > allowed) {
-						ok = false;
-						break;
-					}
-				}
-			}
-			if (ok && mm < best_mm) {
-				best_mm = mm;
-			}
-		}
-
-		if (best_mm <= allowed) {
-			AdapterMatch m;
-			m.matched = true;
-			m.trim_start = static_cast<std::size_t>(seq_off);
-			m.match_len = static_cast<std::size_t>(seq_region_len);
-			m.mismatches = best_mm;
-			m.indels = 1;
-			return m;
-		}
-	}
-	return {};
-}
-
 } // namespace
 
 AdapterMatch AdapterMatcher::find(const std::uint8_t *seq, std::size_t seq_len, const std::uint8_t *adapter,
@@ -416,15 +337,7 @@ AdapterMatch AdapterMatcher::find(const std::uint8_t *seq, std::size_t seq_len, 
 
 	const int start_pos = allow_pre_start ? pre_start_offset(adapter_len) : 0;
 
-	auto m = phase1_hamming(seq, seq_len, adapter, adapter_len, min_match, start_pos);
-	if (m.matched) {
-		return m;
-	}
-	m = phase_indel(seq, seq_len, adapter, adapter_len, min_match, start_pos, /*insertion_in_seq=*/true);
-	if (m.matched) {
-		return m;
-	}
-	return phase_indel(seq, seq_len, adapter, adapter_len, min_match, start_pos, /*insertion_in_seq=*/false);
+	return phase1_hamming(seq, seq_len, adapter, adapter_len, min_match, start_pos);
 }
 
 std::size_t AdapterMatcher::find_leftmost(const std::uint8_t *seq, std::size_t seq_len,

--- a/test/cpp/test_qc_algorithms.cpp
+++ b/test/cpp/test_qc_algorithms.cpp
@@ -422,58 +422,29 @@ TEST_CASE("AdapterMatcher::find phase 1 (exact Hamming)", "[qc][adapter]") {
 	}
 }
 
-TEST_CASE("AdapterMatcher::find phase 2 (insertion in seq)", "[qc][adapter]") {
+TEST_CASE("AdapterMatcher::find is Hamming-only — no indel detection (fastp parity)", "[qc][adapter]") {
+	// fastp's by-sequence adapter trim (AdapterTrimmer::trimBySequence) is a
+	// Hamming-tolerant sliding scan (1 mismatch per 8 compared bases) with NO
+	// indel handling. miint matches that exactly: a single inserted or deleted
+	// base in the adapter region frame-shifts the comparison past the mismatch
+	// budget, so the occurrence is deliberately NOT detected. (Earlier builds did
+	// an exhaustive per-position indel search here. It matched nothing on real
+	// data, cost ~99% of trim_adapters runtime, and was never fastp-faithful —
+	// the parity oracle only ever pinned the clean exact-adapter cases.)
 	const std::string adapter = "AGATCGGAAGAGC"; // 13bp
 
-	SECTION("seq has one inserted base in the middle of the adapter") {
-		// "AGATC" + 'X' + "GGAAGAGC" — adapter with extra X at position 5
-		const std::string seq = "ACGTACGTAGATCXGGAAGAGC"; // 22bp; adapter region starts at 8
+	SECTION("one inserted base in the adapter region is not matched") {
+		// "AGATC" + 'X' + "GGAAGAGC" — an extra X at adapter position 5.
+		const std::string seq = "ACGTACGTAGATCXGGAAGAGC";
 		auto m = AdapterMatcher::find(bp(seq), seq.size(), bp(adapter), adapter.size(), 4, false);
-		REQUIRE(m.matched);
-		CHECK(m.trim_start == 8);
-		CHECK(m.indels == 1);
-		CHECK(m.match_len == 14); // adapter_len + 1
+		CHECK_FALSE(m.matched);
 	}
 
-	SECTION("insertion + 1 mismatch within tolerance") {
-		// Insert + one substitution; cmplen=14 (adapter+1), allowed=14/8=1.
-		// Wait: allowed is based on adapter_len for indel phases. allowed=13/8=1.
-		std::string seq = "ACGTACGTAGATCXGGAAGAGC";
-		seq[16] = 'T'; // was 'G' — one mismatch after the insertion
+	SECTION("one deleted base in the adapter region is not matched") {
+		// Adapter with a 'G' deleted → "AGATCGAAGAGC" (12bp) in the read.
+		const std::string seq = "ACGTACGTAGATCGAAGAGC";
 		auto m = AdapterMatcher::find(bp(seq), seq.size(), bp(adapter), adapter.size(), 4, false);
-		REQUIRE(m.matched);
-		CHECK(m.trim_start == 8);
-		CHECK(m.indels == 1);
-		CHECK(m.mismatches == 1);
-	}
-
-	SECTION("substitution BEFORE true insertion site — exhaustive search required") {
-		// Adapter (13): "AGATCGGAAGAGC"
-		// Seq region (14): "TGATCXGGAAGAGC" — substitution T@0 + insertion X@5
-		// A greedy commit-on-first-mismatch algorithm wastes the indel slot
-		// on position 0 (the T-vs-A substitution) and then runs out of
-		// mismatch budget. Exhaustive search across indel positions finds
-		// k=5 with 1 mismatch (the T at position 0) and matches.
-		const std::string seq = std::string("ACGT") + "TGATCXGGAAGAGC";
-		auto m = AdapterMatcher::find(bp(seq), seq.size(), bp(adapter), adapter.size(), 4, false);
-		REQUIRE(m.matched);
-		CHECK(m.trim_start == 4);
-		CHECK(m.indels == 1);
-		CHECK(m.mismatches == 1);
-	}
-}
-
-TEST_CASE("AdapterMatcher::find phase 3 (deletion in seq)", "[qc][adapter]") {
-	const std::string adapter = "AGATCGGAAGAGC"; // 13bp
-
-	SECTION("seq is missing one base from the adapter") {
-		// Adapter minus the 'C' at position 5 → "AGATCGAAGAGC" (12bp)
-		const std::string seq = "ACGTACGTAGATCGAAGAGC"; // 20bp; adapter region at 8
-		auto m = AdapterMatcher::find(bp(seq), seq.size(), bp(adapter), adapter.size(), 4, false);
-		REQUIRE(m.matched);
-		CHECK(m.trim_start == 8);
-		CHECK(m.indels == 1);
-		CHECK(m.match_len == 12); // adapter_len - 1
+		CHECK_FALSE(m.matched);
 	}
 }
 


### PR DESCRIPTION
## Summary

`trim_adapters` / `trim_adapters_pe`'s by-sequence adapter fallback ran an
**exhaustive per-position single-indel search** (`phase_indel`, "phases 2/3")
for every candidate adapter. On a real qiita QC workload (2,024,535 PE reads,
2×151, the canonical **177-adapter** set) this ran at **~25.9 ms/PE-read on
4 cores — ~14.6 h for the file**. Profiling (`perf` + instrumented counters)
showed `phase_indel` was **98.8% of all comparison work** (~31 B char-compares
per 1,000 reads) while finding essentially nothing.

fastp's own by-sequence trim (`AdapterTrimmer::trimBySequence`) is **Hamming-only
with no indel handling**, so the indel phases were never part of the fastp parity
contract — the committed parity oracle pins only clean exact-adapter cases. This
PR removes `phase_indel`; `AdapterMatcher::find` now does the phase-1
Hamming-tolerant scan only (1 mismatch / 8 compared bases, leftmost wins).

## Performance (measured on the real data, 4 cores)

| adapter set | before | after | speedup | full 2.02M file |
|---|---|---|---|---|
| 177 adapters | 25.3 ms/read | **0.263** | ~96× | 14.2 h → **~8.9 min** |
| 2 Illumina TruSeq | 0.132 ms/read | **0.0065** | ~20× | 4.5 min → **~13 s** |

The by-sequence fallback over 2 TruSeq adapters is now within ~1.6× of pure
overlap-only — effectively free.

## Correctness — improved, not just preserved

The old exhaustive indel search **spuriously over-trimmed**: a false single-indel
"match" landing near position 0 trimmed the entire 151 bp read, which was then
dropped as `qc_too_short`. Removing it (on a 10,000-read sample, 2-TruSeq config):

- **+4 reads/10,000 now correctly pass** (9293 → 9297) — reads the indel search
  was wrongly discarding as a false adapter dimer.
- 2 reads move `qc_too_short` → `qc_low_quality` (still fail, but for the honest
  reason — they're low quality, not adapter).
- Every difference is in the **fastp-faithful direction** (less spurious trimming).

This is a deliberate behavior change for ~0.01–0.07% of reads, all toward fastp parity.

## Tests

- Full C++ suite green (**1182 passed**, 1 require-env skip, 0 failed).
- **fastp parity SQL test** (`qc_trim_adapters_pe_parity`) stays green, plus all
  `qc_trim_adapters*`, `qc_pipeline`, `qc_filter` tests.
- Red/green TDD: the two indel unit tests were flipped to assert the new
  Hamming-only behavior (indel occurrences are not matched).
- `make format-check` passes.

## Scope

3 files, +39/−153 (deletes the 78-line `phase_indel`). No API/signature/SQL
changes; production consumers (`find_leftmost` → `trim_start`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
