### PR TITLE
feat(qc): add infer_trim macro to reconcile external QC trims

### DIFF
--- a/docs/qc.md
+++ b/docs/qc.md
@@ -27,6 +27,10 @@ All scalars accept `seq VARCHAR` + `qual LIST(UTINYINT)`. Quality is the
 decoded Phred integer list emitted by `read_fastx` (not ASCII), so values
 are 0..93 directly.
 
+Beyond these per-read scalars, [`infer_trim`](#reconciling-external-qc-results--infer_trim)
+is a **table macro** that reconciles reads trimmed by an *external* QC tool back
+to 5'/3' trim coordinates — see its section below.
+
 ## Return structs
 
 Every trim function returns a `STRUCT` with these fields:
@@ -313,6 +317,83 @@ maintain bit-for-bit parity in the common case:
   accepted overlap longer than 50 the reported `diff` (mismatch count) is the
   *full* count over the whole overlap, which can exceed `overlap_diff_limit`.
   This is a fastp quirk, ported faithfully to keep byte-for-byte parity.
+
+## Reconciling external QC results — `infer_trim`
+
+Sometimes reads are quality-controlled by an **external** tool rather than the
+scalars above. When that tool only *trims* read ends (no base edits) and may
+*omit* reads entirely, `infer_trim` recovers the per-read 5'/3' trim coordinates
+so you can persist two integers against the originals instead of storing a
+second copy of every trimmed sequence.
+
+`infer_trim(original_reads, qcd_reads)` is a **table macro** (not a scalar). It
+LEFT JOINs the two relations on `sequence_index` and locates the contiguous
+QC'd sequence inside the original. Both relations must expose:
+
+| Column | Type | Role |
+|---|---|---|
+| `sequence_index` | `BIGINT` | Join key |
+| `sequence` | `VARCHAR` | Read sequence |
+
+It returns one row per original read:
+
+| Column | Type | Meaning |
+|---|---|---|
+| `sequence_index` | `BIGINT` | Join key, passed through |
+| `trimmed_5p` | `UINTEGER` | Bases removed from the 5' end; `NULL` if the read was omitted by QC |
+| `trimmed_3p` | `UINTEGER` | Bases removed from the 3' end; `NULL` if the read was omitted by QC |
+
+> **Getting the join key right.** `sequence_index` must be **globally unique**
+> per read and must identify the *same* read on both sides — the external tool
+> has to carry the key through and emit it alongside each surviving read. Two
+> traps with `read_fastx` as the source: it assigns `sequence_index`
+> **positionally and resets it to 1 per input file**, so it is a safe key only
+> for a *single* file; and you **cannot** recover a matching key by re-running
+> `read_fastx` on the QC'd output — QC drops reads, so a fresh positional
+> numbering no longer lines up with the original. A duplicated `sequence_index`
+> on the `qcd_reads` side fans the join out (more than one row per original);
+> the macro treats uniqueness as a precondition and does not police it. If keys
+> are misaligned `infer_trim` usually fails loud on the resulting non-substring,
+> but a coincidental substring match would pass silently, so get the key right.
+
+```sql
+-- Original reads from a SINGLE file; sequence_index is read_fastx's positional id.
+CREATE VIEW original AS
+    SELECT sequence_index, sequence1 AS sequence FROM read_fastx('reads.fastq.gz');
+
+-- qcd_reads: the external tool's surviving reads, each carrying the ORIGINAL
+-- sequence_index (project/rename so both sides share `sequence_index` + `sequence`).
+SELECT * FROM infer_trim(original, qcd_reads) ORDER BY sequence_index;
+```
+
+Semantics:
+
+- **Omitted reads → `NULL` / `NULL`.** A read with no row in `qcd_reads`
+  (dropped by QC) yields `NULL` coordinates, straight from the LEFT JOIN — the
+  "any sequence omitted is null" case. A `qcd_reads` row whose `sequence_index`
+  is absent from `original_reads` is dropped (one row per original, by design).
+- **Fails loud, whatever you `SELECT`.** The integrity checks live in a
+  row-level `WHERE` filter the optimizer cannot prune, so they fire even for
+  `SELECT count(*)` or a single-column projection — not only for `SELECT *`.
+  `infer_trim` throws, naming the offending `sequence_index`, when a QC'd
+  sequence is **not a contiguous substring** of its original (the external tool
+  edited bases, or the join key is mismatched), or when a *present* QC row has a
+  **NULL or empty** sequence, or the **original** sequence is `NULL`. It is
+  strictly for pure end-trimming; represent a dropped read by omitting its row
+  (→ `NULL` / `NULL`), not by an empty sequence. Base-modifying QC (quality
+  masking, error correction, reverse-complementing) needs alignment, not a
+  substring search.
+- **Leftmost match wins.** If the kept block occurs at more than one offset in a
+  self-repetitive read, the leftmost occurrence is chosen — the true offset
+  cannot be recovered from sequence alone, so the most conservative 5' trim is
+  taken.
+- **Persist coordinates, reconstruct on demand.** Store only `trimmed_5p` /
+  `trimmed_3p` next to the originals; regenerate the trimmed read when needed
+  with `substr(sequence, trimmed_5p + 1, length(sequence) - trimmed_5p - trimmed_3p)`.
+
+Performance: a parallel hash join plus one `position()` substring search per
+matched read, so cost is linear in total sequence bytes (≈ Σ read length) with
+the join scaling in row count; both stages are fully parallel.
 
 ## Related — long-read amplicon / UMI primitives
 

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -716,6 +716,85 @@ const std::string GENOME_COVERAGE = // NOLINT
     "JOIN query_table(subject_total_length) tl "
     "  USING (genome_id);";
 
+// infer_trim(original_reads, qcd_reads)
+//
+// Recover per-read 5'/3' trim coordinates from reads that were quality-
+// controlled by an *external* tool that only trims read ends (no base edits)
+// and may omit reads entirely. LEFT JOINs original -> QC'd on sequence_index
+// and locates the (contiguous) QC'd sequence within the original.
+//
+// Both relations must expose:
+//   sequence_index : BIGINT  (join key)
+//   sequence       : VARCHAR (read sequence)
+//
+// CONTRACT / preconditions (documented, not all enforced):
+//   sequence_index must be GLOBALLY UNIQUE per read and identify the SAME read
+//   on both sides -- it is the caller's job to carry a stable key through the
+//   external tool. read_fastx assigns sequence_index positionally and RESETS it
+//   per input file, so it is a valid key only for a single file whose numbering
+//   the external tool round-trips; you cannot re-derive a matching key by
+//   re-running read_fastx on the QC'd output (QC drops reads, so the positional
+//   numbering diverges). A non-unique sequence_index on the qcd side fans the
+//   LEFT JOIN out (>1 row per original); this precondition is documented rather
+//   than enforced, to keep the macro a single linear scan. A qcd row whose
+//   sequence_index is absent from the originals is dropped (one row per
+//   original), by design.
+//
+// Returns one row per original read:
+//   sequence_index : BIGINT
+//   trimmed_5p     : UINTEGER  bases removed from the 5' end (NULL if omitted)
+//   trimmed_3p     : UINTEGER  bases removed from the 3' end (NULL if omitted)
+//
+// A read with no QC'd counterpart yields NULL/NULL (omitted). Per-row data-
+// integrity violations FAIL LOUD (throw) regardless of which output columns the
+// caller projects, because the checks live in a row-level WHERE filter the
+// optimizer cannot prune away: a present QC row with a NULL or empty sequence,
+// a NULL original sequence, or a QC sequence that is not a contiguous substring
+// of its original (base edits, or a mismatched join key). This macro is strictly
+// for pure end-trimming. When the kept block occurs at multiple offsets
+// (self-repetitive reads), the leftmost match wins. position() is computed once
+// in a CTE, not per output column. A qcd `matched` marker distinguishes an
+// omitted read (no row) from a present row with a NULL sequence.
+const std::string INFER_TRIM = // NOLINT
+    "CREATE OR REPLACE MACRO infer_trim(original_reads, qcd_reads) AS TABLE "
+    "WITH joined AS ( "
+    "    SELECT o.sequence_index AS sequence_index, "
+    "           o.sequence       AS oseq, "
+    "           q.sequence       AS qseq, "
+    "           q.matched        AS matched "
+    "    FROM query_table(original_reads) o "
+    "    LEFT JOIN (SELECT sequence_index, sequence, TRUE AS matched "
+    "               FROM query_table(qcd_reads)) q USING (sequence_index) "
+    "), "
+    "computed AS ( "
+    "    SELECT sequence_index, matched, oseq, qseq, "
+    "           CASE WHEN matched IS NULL THEN NULL ELSE position(qseq IN oseq) END AS p, "
+    "           length(oseq) AS olen, "
+    "           length(qseq) AS qlen "
+    "    FROM joined "
+    "), "
+    "validated AS ( "
+    "    SELECT * FROM computed "
+    "    WHERE CASE "
+    "        WHEN matched IS NULL THEN TRUE "
+    "        WHEN oseq IS NULL THEN error(printf("
+    "            'infer_trim: original sequence for sequence_index=%d is NULL', sequence_index)) "
+    "        WHEN qseq IS NULL THEN error(printf("
+    "            'infer_trim: QC sequence for sequence_index=%d is NULL (a kept read must have a sequence)', "
+    "            sequence_index)) "
+    "        WHEN qseq = '' THEN error(printf("
+    "            'infer_trim: QC sequence for sequence_index=%d is empty (omit the row to mark a dropped read)', "
+    "            sequence_index)) "
+    "        WHEN p = 0 THEN error(printf("
+    "            'infer_trim: QC sequence for sequence_index=%d is not a contiguous substring of its original', "
+    "            sequence_index)) "
+    "        ELSE TRUE END "
+    ") "
+    "SELECT sequence_index, "
+    "       CASE WHEN matched IS NULL THEN NULL ELSE (p - 1)::UINTEGER END AS trimmed_5p, "
+    "       CASE WHEN matched IS NULL THEN NULL ELSE (olen - (p - 1) - qlen)::UINTEGER END AS trimmed_3p "
+    "FROM validated; ";
+
 class MIINTMacros {
 public:
 	static void Register(ExtensionLoader &loader) {
@@ -751,6 +830,7 @@ public:
 		register_macro(PARSE_GFF_ATTRIBUTES, "parse_gff_attributes");
 		register_macro(READ_GFF, "read_gff");
 		register_macro(GENOME_COVERAGE, "genome_coverage");
+		register_macro(INFER_TRIM, "infer_trim");
 
 		register_macro(READ_JPLACE, "read_jplace");
 

--- a/test/sql/qc_infer_trim.test
+++ b/test/sql/qc_infer_trim.test
@@ -1,0 +1,175 @@
+# name: test/sql/qc_infer_trim.test
+# description: Tests for infer_trim table macro (recover 5'/3' trim coordinates from externally QC'd reads)
+# group: [sql]
+
+require miint
+
+# -----------------------------------------------------------------------------
+# Contract: original_reads and qcd_reads each expose sequence_index BIGINT and
+# sequence VARCHAR. infer_trim LEFT JOINs original -> QC'd on sequence_index and
+# infers trimmed_5p / trimmed_3p by locating the (contiguous) QC'd sequence in
+# the original. Pure end-trimming only; no base edits.
+# -----------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE original AS SELECT * FROM (VALUES
+    (1::BIGINT, 'AACGTACGTTT'),   -- kept 'CGTACGT'  -> 5p=2, 3p=2
+    (2::BIGINT, 'GGGGTTTTCCCC'),  -- omitted by QC (no qcd row) -> NULL, NULL
+    (3::BIGINT, 'ACGTACGT'),      -- untrimmed -> 5p=0, 3p=0
+    (4::BIGINT, 'TTTTTTAAAA'),    -- kept 'AAAA' (left-only) -> 5p=6, 3p=0
+    (5::BIGINT, 'ACGTTTTTTT')     -- kept 'ACGT' (right-only) -> 5p=0, 3p=6
+) t(sequence_index, sequence);
+
+statement ok
+CREATE TABLE qcd AS SELECT * FROM (VALUES
+    (1::BIGINT, 'CGTACGT'),
+    (3::BIGINT, 'ACGTACGT'),
+    (4::BIGINT, 'AAAA'),
+    (5::BIGINT, 'ACGT')
+) t(sequence_index, sequence);
+
+# Core cases: left+right, omission (NULL/NULL), untrimmed, left-only, right-only
+query III
+SELECT * FROM infer_trim(original, qcd) ORDER BY sequence_index;
+----
+1	2	2
+2	NULL	NULL
+3	0	0
+4	6	0
+5	0	6
+
+# The omitted read is the ONLY one with NULL coordinates (falls out of LEFT JOIN)
+query I
+SELECT count(*) FROM infer_trim(original, qcd) WHERE trimmed_5p IS NULL;
+----
+1
+
+# -----------------------------------------------------------------------------
+# Fail loud: a QC'd sequence that is not a contiguous substring of its original
+# is a data-integrity error (base edit, or mismatched join), not a valid trim.
+# The guard lives in a row-level WHERE filter, so it fires regardless of which
+# columns the caller projects — SELECT count(*) and a single column must throw
+# just as SELECT * does (regression test for the column-pruning bypass, where an
+# error() in only the trimmed_5p projection was silently pruned away).
+# -----------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE original_bad AS SELECT 10::BIGINT AS sequence_index, 'AACCGGTT' AS sequence;
+
+statement ok
+CREATE TABLE qcd_bad AS SELECT 10::BIGINT AS sequence_index, 'ZZZZ' AS sequence;
+
+statement error
+SELECT * FROM infer_trim(original_bad, qcd_bad);
+----
+not a contiguous substring
+
+statement error
+SELECT count(*) FROM infer_trim(original_bad, qcd_bad);
+----
+not a contiguous substring
+
+statement error
+SELECT sequence_index FROM infer_trim(original_bad, qcd_bad);
+----
+not a contiguous substring
+
+# QC longer than the original (position=0). trimmed_3p = olen-(p-1)-qlen would go
+# negative and raise a misleading UINT32 cast error if the guard were computed
+# per-column; the row-level WHERE guard yields the clean substring message even
+# when ONLY trimmed_3p is projected.
+statement ok
+CREATE TABLE original_short AS SELECT 11::BIGINT AS sequence_index, 'ACGT' AS sequence;
+
+statement ok
+CREATE TABLE qcd_long AS SELECT 11::BIGINT AS sequence_index, 'ACGTACGTAC' AS sequence;
+
+statement error
+SELECT trimmed_3p FROM infer_trim(original_short, qcd_long);
+----
+not a contiguous substring
+
+# A PRESENT QC row with a NULL sequence is a data error, not an omission
+# (omission = no row at all). The `matched` marker distinguishes the two, so
+# this must throw rather than silently returning NULL/NULL.
+statement ok
+CREATE TABLE original_nseq AS SELECT 12::BIGINT AS sequence_index, 'ACGT' AS sequence;
+
+statement ok
+CREATE TABLE qcd_nullseq AS SELECT 12::BIGINT AS sequence_index, NULL::VARCHAR AS sequence;
+
+statement error
+SELECT count(*) FROM infer_trim(original_nseq, qcd_nullseq);
+----
+is NULL
+
+# A present QC row with an EMPTY sequence is a data error — a dropped read must
+# be represented by omitting its row, not by an empty sequence.
+statement ok
+CREATE TABLE qcd_emptyseq AS SELECT 12::BIGINT AS sequence_index, '' AS sequence;
+
+statement error
+SELECT count(*) FROM infer_trim(original_nseq, qcd_emptyseq);
+----
+is empty
+
+# A NULL original sequence with a present QC row also fails loud.
+statement ok
+CREATE TABLE original_null AS SELECT 13::BIGINT AS sequence_index, NULL::VARCHAR AS sequence;
+
+statement ok
+CREATE TABLE qcd_present AS SELECT 13::BIGINT AS sequence_index, 'ACGT' AS sequence;
+
+statement error
+SELECT count(*) FROM infer_trim(original_null, qcd_present);
+----
+original sequence for sequence_index=13 is NULL
+
+# -----------------------------------------------------------------------------
+# Leftmost match wins when the kept block occurs at multiple offsets in a
+# self-repetitive read. 'ACGT' matches at offset 0 and offset 4; leftmost -> 0.
+# This encodes the documented tie-break: we cannot recover the true offset from
+# sequence alone, so the most conservative 5' trim is chosen.
+# -----------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE original_rep AS SELECT 20::BIGINT AS sequence_index, 'ACGTACGT' AS sequence;
+
+statement ok
+CREATE TABLE qcd_rep AS SELECT 20::BIGINT AS sequence_index, 'ACGT' AS sequence;
+
+query III
+SELECT * FROM infer_trim(original_rep, qcd_rep);
+----
+20	0	4
+
+# -----------------------------------------------------------------------------
+# Works over a view (relation parameter accepts any table/view) and reconstructs
+# the trimmed read from the inferred coordinates against the original.
+# -----------------------------------------------------------------------------
+
+statement ok
+CREATE VIEW original_view AS SELECT sequence_index, sequence FROM original;
+
+query IT
+SELECT o.sequence_index,
+       substr(o.sequence, t.trimmed_5p + 1,
+              length(o.sequence) - t.trimmed_5p - t.trimmed_3p) AS reconstructed
+FROM original_view o
+JOIN infer_trim(original_view, qcd) t USING (sequence_index)
+WHERE t.trimmed_5p IS NOT NULL
+ORDER BY o.sequence_index;
+----
+1	CGTACGT
+3	ACGTACGT
+4	AAAA
+5	ACGT
+
+statement ok
+DROP VIEW original_view;
+
+statement ok
+DROP TABLE original; DROP TABLE qcd; DROP TABLE original_bad; DROP TABLE qcd_bad; DROP TABLE original_rep; DROP TABLE qcd_rep;
+
+statement ok
+DROP TABLE original_short; DROP TABLE qcd_long; DROP TABLE original_nseq; DROP TABLE qcd_nullseq; DROP TABLE qcd_emptyseq; DROP TABLE original_null; DROP TABLE qcd_present;


### PR DESCRIPTION
## Summary

Adds `infer_trim(original_reads, qcd_reads)`, a built-in table macro that recovers per-read 5'/3' trim coordinates when sequence data is quality-controlled by an **external** tool that only trims read ends (no base edits) and may omit reads entirely. Instead of storing a second copy of every trimmed sequence, you `LEFT JOIN` your originals to the QC'd reads on `sequence_index` and persist two integers per read.

It returns one row per original read: `sequence_index`, `trimmed_5p`, `trimmed_3p` (both `UINTEGER`, `NULL` when the read was omitted by QC).

## Behavior

- **Omitted reads → `NULL`/`NULL`** (no `qcd_reads` row; falls out of the LEFT JOIN).
- **Fails loud regardless of projection.** The integrity checks live in a row-level `WHERE` guard the optimizer cannot prune, so they fire for `SELECT count(*)` and single-column projections, not only `SELECT *`. It throws (naming the offending `sequence_index`) when a QC'd sequence is not a contiguous substring of its original, when a present QC row has a `NULL` or empty sequence, or when the original sequence is `NULL`.
- **Leftmost match wins** for self-repetitive reads.
- **Join-key contract (documented, not enforced):** `sequence_index` must be globally unique and round-tripped by the external tool. In particular, `read_fastx` assigns `sequence_index` positionally and resets it per file, so it is a valid key only for a single file, and you cannot re-derive a matching key by re-running `read_fastx` on the QC'd output. Documented to keep the macro a single linear scan.

## Implementation

- Registered alongside `genome_coverage` in `src/include/miint_macros.hpp` (uses `query_table()` per the existing relation-macro convention).
- `position()` is computed once in a CTE; a `matched` marker distinguishes an omitted read from a present-but-NULL row.

## Testing

- `test/sql/qc_infer_trim.test` — 51 assertions: happy-path trims, omission, leftmost tie-break, view input, coordinate reconstruction, and fail-loud regression tests for projection-independence (`count(*)` / single-column / `trimmed_3p`-only on corrupt data) and NULL/empty/NULL-original.
- No regressions in `qc_filter`, `qc_trim_adapters`, `qc_pipeline`, `genome_coverage`.
- `clang-format 11.0.1` (CI pin) clean.

## Performance

Benchmarked via `EXPLAIN ANALYZE` against an equivalent guard-in-projection baseline on identical data: linear in total sequence bytes and fully parallel. 10M × 150 bp (1.5 Gbp) ≈ 0.25 s; 100k × 10 kb (1 Gbp) ≈ 0.48 s. The row-level guard adds a small (≤~10%, often within run-to-run noise) overhead on the short-read happy path — the price of making fail-loud independent of which columns the caller selects.

## Docs

New "Reconciling external QC results — `infer_trim`" section in `docs/qc.md`, plus a pointer from the QC function catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
