### PR TITLE
perf(build): compile embedded vsearch (-O3) and htslib (-O2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,10 +363,13 @@ elseif(APPLE AND OSX_BUILD_ARCH)
     endif()
 endif()
 
+# -O2: passing CFLAGS to htslib's configure overrides its Makefile default
+# (-g -Wall -O2), so an explicit -O is required or htslib builds at -O0. -O2
+# matches htslib/samtools upstream's shipping optimization level.
 if(EMSCRIPTEN)
-    set(HTSLIB_CFLAGS "CFLAGS=-fPIC ${HTSLIB_ARCH_CFLAGS} ${EMSCRIPTEN_THREAD_CFLAGS} -I${ZLIB_INCLUDE_DIRS}")
+    set(HTSLIB_CFLAGS "CFLAGS=-O2 -fPIC ${HTSLIB_ARCH_CFLAGS} ${EMSCRIPTEN_THREAD_CFLAGS} -I${ZLIB_INCLUDE_DIRS}")
 else()
-    set(HTSLIB_CFLAGS "CFLAGS=-fPIC ${HTSLIB_ARCH_CFLAGS} -I${ZLIB_INCLUDE_DIRS}")
+    set(HTSLIB_CFLAGS "CFLAGS=-O2 -fPIC ${HTSLIB_ARCH_CFLAGS} -I${ZLIB_INCLUDE_DIRS}")
 endif()
 if(ZLIB_LIBRARY_DIR)
     set(HTSLIB_LDFLAGS "LDFLAGS=${HTSLIB_ARCH_CFLAGS} -L${ZLIB_LIBRARY_DIR}")
@@ -642,7 +645,11 @@ if(MIINT_ENABLE_VSEARCH)
         # fresh CI checkout has none of them, so we must regenerate here before
         # invoking configure.
         CONFIGURE_COMMAND ${CMAKE_COMMAND} -E chdir ${VSEARCH_SRC_DIR} sh ./autogen.sh
-            COMMAND ${CMAKE_COMMAND} -E env "CXXFLAGS=-fPIC ${VSEARCH_ARCH_CFLAGS}" "CFLAGS=-fPIC ${VSEARCH_ARCH_CFLAGS}"
+            # -O3: autoconf treats a user-supplied CXXFLAGS/CFLAGS as authoritative and
+            # drops its default -O2, and vsearch's Makefile.am does not hardcode an
+            # optimization level — so without an explicit -O here the whole library
+            # (including the SIMD Needleman-Wunsch aligner) builds at -O0, ~4x slower.
+            COMMAND ${CMAKE_COMMAND} -E env "CXXFLAGS=-O3 -fPIC ${VSEARCH_ARCH_CFLAGS}" "CFLAGS=-O3 -fPIC ${VSEARCH_ARCH_CFLAGS}"
             ${VSEARCH_SRC_DIR}/configure ${VSEARCH_HOST_FLAG}
         BUILD_COMMAND make -C src libvsearch.a
         INSTALL_COMMAND ""


### PR DESCRIPTION
## Problem

Embedded **vsearch** and **htslib** were being compiled at **`-O0`**, making every vsearch-backed function (`search_sequences_vsearch`, `detect_chimera_uchime`, `cluster_sequences_vsearch`, `merge_pairs`) run roughly **4× slower than the native tool**, and slowing htslib SAM/BAM decode by a smaller ~6–9%.

## Root cause

Both are autotools/`configure` builds. `CMakeLists.txt` passed `CFLAGS=-fPIC` / `CXXFLAGS=-fPIC` to their `./configure`. Autoconf treats a user-supplied `CFLAGS`/`CXXFLAGS` as authoritative and **drops its default `-O2`**, and neither vsearch's `Makefile.am` nor htslib's `config.mk` restores an `-O` when the flags are overridden. Result: the generated Makefile had `CXXFLAGS = -fPIC` (no `-O`) → `-O0`, including vsearch's SIMD Needleman–Wunsch aligner hot path.

## Fix

Add an explicit `-O` to each `configure` invocation:
- **vsearch → `-O3`** (matches bioconda; it's the compute-heavy SIMD aligner)
- **htslib → `-O2`** (matches samtools upstream's shipping level)

Audited every embedded build; only these two were affected. minimap2 (`-O2`), WFA2 (`-O2`), mafft (`-O3`), skbb (`-O3`), unifrac (`-O3`), abpoa (CMake `Release`), and rype/sylph (`cargo --release`) already set optimization explicitly.

## Verification

### vsearch search — the headline (~3.8×)

50k gg_13_5 queries vs 20,286-seq LTP reference, `id=0.9`, 32 threads, identical results (43,634 hits):

| | wall | total CPU-s |
|---|---|---|
| Native vsearch (conda) | 38.6s | 1198 |
| Extension **before** (`-O0`) | 150.1s | 4672 |
| Extension **after** (`-O3`) | **39.4s** | 1206 |

Now at parity with native. A batch-count sweep confirmed the slowdown was a flat per-query multiplier (codegen), not batching/parallelism.

### htslib BAM decode — modest (~6–9%)

1.1 GB BAM, 1,317,491 HiFi records (minimap2 `--MD --eqx`, 3.48 Gbp), single-threaded, warm cache, median of 3:

| decode path | `-O0` before | `-O2` after | speedup |
|---|---|---|---|
| `read_alignments` (cigar + NM + MD tags) | 6.90s | 6.30s | 1.10× |
| `read_sequences_sam` (seq + qual) | 3.10s | 2.92s | 1.06× |

Smaller than vsearch because BGZF decompression is dominated by zlib (compiled separately, already optimized); htslib's own C parsing is a minority of decode time. Still a free, correctness-neutral win worth keeping.

### Correctness (after rebuild)

- C++ unit tests: **1179 passed** / 12948 assertions (1 skip = expected `MZXML_REAL_DATA` guard).
- SQL: `search_sequences`(+realworld), `cluster_sequences`(+realworld), `merge_pairs`, `read_sam`, `read_alignments`, `copy_bam`, `copy_sam` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
