### PR TITLE
feat(align): emit extended =/X CIGAR from pairwise KSW2 functions

### DIFF
--- a/docs/analysis-functions.md
+++ b/docs/analysis-functions.md
@@ -623,10 +623,12 @@ NULL inputs produce NULL output. Alignment failure (e.g., z-drop early terminati
 
 | Family | Backend | Score semantic | CIGAR ops | Pick when |
 |---|---|---|---|---|
-| `align_pairwise_wfa2_*` | WFA2-lib (Wavefront) | Penalty: `0` = identical, larger = more divergent | Extended (`=` / `X`) | Short to long DNA; want match/mismatch distinguished in CIGAR |
-| `align_pairwise_ksw2_*` | KSW2 `ksw_extz2_sse` (SIMD banded DP) | Native positive: identical = `qlen * match` | Standard (`M` lumps match and mismatch) | General DNA alignment; optional bandwidth / z-drop tuning |
-| `align_pairwise_ksw2_dual_affine_*` | KSW2 `ksw_extd2_sse` | Native positive | `M`, `I`, `D` | Long-read alignment; long indels amortize over a second affine pair |
-| `align_pairwise_ksw2_splice_*` | KSW2 `ksw_exts2_sse` | Native positive | `M`, `I`, `D`, `N` (intron skip) | Splice-aware (RNA-seq); intron-open penalty + non-canonical-boundary penalty |
+| `align_pairwise_wfa2_*` | WFA2-lib (Wavefront) | Penalty: `0` = identical, larger = more divergent | Extended (`=` / `X`) | Short to long DNA; exact gap-affine global alignment |
+| `align_pairwise_ksw2_*` | KSW2 `ksw_extz2_sse` (SIMD banded DP) | Native positive: identical = `qlen * match` | Extended (`=` / `X`, plus `I` / `D`) | General DNA alignment; optional bandwidth / z-drop tuning |
+| `align_pairwise_ksw2_dual_affine_*` | KSW2 `ksw_extd2_sse` | Native positive | `=`, `X`, `I`, `D` | Long-read alignment; long indels amortize over a second affine pair |
+| `align_pairwise_ksw2_splice_*` | KSW2 `ksw_exts2_sse` | Native positive | `=`, `X`, `I`, `D`, `N` (intron skip) | Splice-aware (RNA-seq); intron-open penalty + non-canonical-boundary penalty |
+
+All families emit **extended** CIGAR (`=` for match, `X` for mismatch). KSW2 natively produces only `M`; the `_cigar` and `_full` outputs run an eqx post-pass that splits each `M` into `=` / `X` by comparing the aligned bases (case-insensitive, so soft-masked lowercase bases are not counted as mismatches). This means sequence identity can be read directly off any family's CIGAR with `cigar_sequence_identity`.
 
 WFA2 scores and KSW2 scores are on different scales -- WFA2 is penalty-style (lower is better, identical = 0), KSW2 is additive (higher is better, positive contributions from matches). Do not compare scores across families.
 
@@ -685,7 +687,7 @@ SELECT align_pairwise_ksw2_score(query, subject, 2, 4, 6, 2, 100, 400);
 ```sql
 SELECT align_pairwise_ksw2_score('ACGT', 'ACGT');           -- 8  (4 * match=2)
 SELECT align_pairwise_ksw2_score('ACGT', 'ACAT');           -- 2  (3*2 - 4)
-SELECT (align_pairwise_ksw2_cigar('ACGT', 'ACAT')).cigar;   -- 4M (KSW2 lumps match/mismatch)
+SELECT (align_pairwise_ksw2_cigar('ACGT', 'ACAT')).cigar;   -- 2=1X1= (eqx post-pass splits M into =/X)
 ```
 
 ### `align_pairwise_ksw2_dual_affine_*` -- KSW2 extd (dual affine)

--- a/src/KSW2Aligner.cpp
+++ b/src/KSW2Aligner.cpp
@@ -241,7 +241,9 @@ std::optional<KSW2CigarResult> KSW2Aligner::align_extz_cigar(const std::string &
 
 	std::optional<KSW2CigarResult> result;
 	if (ez.score != KSW_NEG_INF) {
-		result = KSW2CigarResult {ez.score, decode_ksw2_cigar(ez.cigar, ez.n_cigar)};
+		// eqx post-pass: KSW2 emits only 'M'; split into '='/'X' so identity is readable
+		// from the CIGAR alone (see eqx_split_cigar in cigar_reconstruction.hpp).
+		result = KSW2CigarResult {ez.score, eqx_split_cigar(decode_ksw2_cigar(ez.cigar, ez.n_cigar), query, subject)};
 	}
 	kfree(nullptr, ez.cigar);
 	return result;
@@ -327,7 +329,9 @@ std::optional<KSW2CigarResult> KSW2Aligner::align_extd_cigar(const std::string &
 
 	std::optional<KSW2CigarResult> result;
 	if (ez.score != KSW_NEG_INF) {
-		result = KSW2CigarResult {ez.score, decode_ksw2_cigar(ez.cigar, ez.n_cigar)};
+		// eqx post-pass: KSW2 emits only 'M'; split into '='/'X' so identity is readable
+		// from the CIGAR alone (see eqx_split_cigar in cigar_reconstruction.hpp).
+		result = KSW2CigarResult {ez.score, eqx_split_cigar(decode_ksw2_cigar(ez.cigar, ez.n_cigar), query, subject)};
 	}
 	kfree(nullptr, ez.cigar);
 	return result;
@@ -402,7 +406,9 @@ std::optional<KSW2CigarResult> KSW2Aligner::align_exts_cigar(const std::string &
 
 	std::optional<KSW2CigarResult> result;
 	if (ez.score != KSW_NEG_INF) {
-		result = KSW2CigarResult {ez.score, decode_ksw2_cigar(ez.cigar, ez.n_cigar)};
+		// eqx post-pass: split 'M' into '='/'X'. 'N' (intron skip) passes through unchanged
+		// (see eqx_split_cigar in cigar_reconstruction.hpp).
+		result = KSW2CigarResult {ez.score, eqx_split_cigar(decode_ksw2_cigar(ez.cigar, ez.n_cigar), query, subject)};
 	}
 	kfree(nullptr, ez.cigar);
 	return result;

--- a/src/include/cigar_reconstruction.hpp
+++ b/src/include/cigar_reconstruction.hpp
@@ -5,25 +5,13 @@
 
 namespace miint {
 
-// Reconstruct gapped alignment strings from a CIGAR string and the original sequences.
-// Accepts the union of CIGAR operations used by WFA2 (extended: '=' / 'X') and KSW2
-// (standard: 'M' for match-or-mismatch; 'N' for intron skip emitted by ksw_exts2_sse).
-// 'I' = insertion in query (gap in subject), 'D' = deletion from query (gap in subject).
-// 'N' is treated the same as 'D' for the purposes of alignment display: subject base shown,
-// query rendered as '-'. The op-name distinction (intron vs deletion) lives in the CIGAR;
-// the reconstructed strings collapse them visually.
-inline void reconstruct_aligned_from_cigar(const std::string &query, const std::string &subject,
-                                           const std::string &cigar, std::string &query_aligned,
-                                           std::string &subject_aligned) {
-	query_aligned.clear();
-	subject_aligned.clear();
-	query_aligned.reserve(query.size() + subject.size());
-	subject_aligned.reserve(query.size() + subject.size());
-
-	size_t qi = 0;
-	size_t si = 0;
+// Parse a run-length CIGAR string, invoking `fn(count, op)` for each operation in order.
+// Validates the grammar: a run of digits forms a positive length; a bare operation
+// character (no leading digits) means length 1. Shared by reconstruct_aligned_from_cigar
+// and eqx_split_cigar so the parse (and its error handling) lives in exactly one place.
+template <typename Fn>
+inline void for_each_cigar_op(const std::string &cigar, Fn &&fn) {
 	size_t ci = 0;
-
 	while (ci < cigar.size()) {
 		size_t num_start = ci;
 		while (ci < cigar.size() && cigar[ci] >= '0' && cigar[ci] <= '9') {
@@ -43,8 +31,30 @@ inline void reconstruct_aligned_from_cigar(const std::string &query, const std::
 				throw std::runtime_error("CIGAR operation length must be positive");
 			}
 		}
-
 		char op = cigar[ci++];
+		fn(count, op);
+	}
+}
+
+// Reconstruct gapped alignment strings from a CIGAR string and the original sequences.
+// Accepts the union of CIGAR operations used by WFA2 (extended: '=' / 'X') and KSW2
+// (standard: 'M' for match-or-mismatch; 'N' for intron skip emitted by ksw_exts2_sse).
+// 'I' = insertion in query (gap in subject), 'D' = deletion from query (gap in subject).
+// 'N' is treated the same as 'D' for the purposes of alignment display: subject base shown,
+// query rendered as '-'. The op-name distinction (intron vs deletion) lives in the CIGAR;
+// the reconstructed strings collapse them visually.
+inline void reconstruct_aligned_from_cigar(const std::string &query, const std::string &subject,
+                                           const std::string &cigar, std::string &query_aligned,
+                                           std::string &subject_aligned) {
+	query_aligned.clear();
+	subject_aligned.clear();
+	query_aligned.reserve(query.size() + subject.size());
+	subject_aligned.reserve(query.size() + subject.size());
+
+	size_t qi = 0;
+	size_t si = 0;
+
+	for_each_cigar_op(cigar, [&](int count, char op) {
 		for (int k = 0; k < count; k++) {
 			switch (op) {
 			case '=':
@@ -75,7 +85,7 @@ inline void reconstruct_aligned_from_cigar(const std::string &query, const std::
 				throw std::runtime_error(std::string("Unknown CIGAR operation: ") + op);
 			}
 		}
-	}
+	});
 
 	if (qi != query.size()) {
 		throw std::runtime_error("CIGAR did not consume all query bases: consumed " + std::to_string(qi) + " of " +
@@ -85,6 +95,93 @@ inline void reconstruct_aligned_from_cigar(const std::string &query, const std::
 		throw std::runtime_error("CIGAR did not consume all subject bases: consumed " + std::to_string(si) + " of " +
 		                         std::to_string(subject.size()));
 	}
+}
+
+// ASCII-uppercase one character (locale-independent; safe for signed char). Used so base
+// comparison in eqx_split_cigar is case-insensitive.
+inline char cigar_ascii_upper(char c) {
+	return (c >= 'a' && c <= 'z') ? static_cast<char>(c - ('a' - 'A')) : c;
+}
+
+// Rewrite the 'M' (match-or-mismatch) operations of a CIGAR into extended '=' (match) /
+// 'X' (mismatch) operations by comparing the aligned bases of the original sequences. This
+// is the "eqx" post-pass, matching the repo-wide convention (minimap2's MM_F_EQX flag, the
+// `eqx=true` default on the align_minimap2*/save_minimap2_index table functions, and WFA2's
+// native extended CIGAR). It exists because the pairwise KSW2 functions call ksw_extz2_sse
+// directly and so never reach minimap2's internal eqx pass. Splitting here lets sequence
+// identity be read straight off a KSW2 CIGAR (e.g. cigar_sequence_identity), which a bare
+// 'M'-only CIGAR cannot support. 'I', 'D', and 'N' operations pass through unchanged.
+//
+// Base comparison is case-insensitive (as minimap2's own eqx effectively is, working on
+// case-folded encoded bases), so soft-masked (lowercase) bases are matches, not mismatches;
+// two distinct letters (including different IUPAC ambiguity codes) are mismatches. '=' / 'X'
+// inputs are re-derived from the bases (idempotent for honest input); KSW2 never emits them.
+//
+// Unlike reconstruct_aligned_from_cigar, this does NOT require the CIGAR to consume every base
+// of both sequences: a z-drop-truncated alignment yields a CIGAR shorter than the inputs, and
+// we faithfully re-encode whatever ops are present (the inner bounds checks still reject a
+// CIGAR that consumes MORE bases than exist).
+inline std::string eqx_split_cigar(const std::string &cigar, const std::string &query, const std::string &subject) {
+	std::string out;
+	out.reserve(cigar.size() + cigar.size() / 2);
+
+	size_t qi = 0;
+	size_t si = 0;
+
+	auto append_run = [&out](int count, char op) {
+		if (count > 0) {
+			out += std::to_string(count);
+			out += op;
+		}
+	};
+
+	for_each_cigar_op(cigar, [&](int count, char op) {
+		switch (op) {
+		case 'M':
+		case '=':
+		case 'X': {
+			// Walk the aligned columns, coalescing consecutive same-result columns into
+			// a single '=' or 'X' run.
+			int run = 0;
+			bool run_is_match = false;
+			for (int k = 0; k < count; k++) {
+				if (qi >= query.size() || si >= subject.size()) {
+					throw std::runtime_error("CIGAR consumes more bases than available in sequences");
+				}
+				bool is_match = cigar_ascii_upper(query[qi]) == cigar_ascii_upper(subject[si]);
+				qi++;
+				si++;
+				if (run > 0 && is_match != run_is_match) {
+					append_run(run, run_is_match ? '=' : 'X');
+					run = 0;
+				}
+				run_is_match = is_match;
+				run++;
+			}
+			append_run(run, run_is_match ? '=' : 'X');
+			break;
+		}
+		case 'I':
+			if (qi + static_cast<size_t>(count) > query.size()) {
+				throw std::runtime_error("CIGAR consumes more query bases than available");
+			}
+			qi += count;
+			append_run(count, 'I');
+			break;
+		case 'D':
+		case 'N':
+			if (si + static_cast<size_t>(count) > subject.size()) {
+				throw std::runtime_error("CIGAR consumes more subject bases than available");
+			}
+			si += count;
+			append_run(count, op);
+			break;
+		default:
+			throw std::runtime_error(std::string("Unknown CIGAR operation: ") + op);
+		}
+	});
+
+	return out;
 }
 
 } // namespace miint

--- a/test/cpp/test_KSW2Aligner.cpp
+++ b/test/cpp/test_KSW2Aligner.cpp
@@ -85,17 +85,28 @@ TEST_CASE("KSW2Aligner - align_extz_score", "[KSW2Aligner]") {
 TEST_CASE("KSW2Aligner - align_extz_cigar", "[KSW2Aligner]") {
 	KSW2Aligner aligner;
 
-	SECTION("Identical sequences -> 4M") {
+	SECTION("Identical sequences -> 4= (eqx post-pass splits M into =/X)") {
 		auto result = aligner.align_extz_cigar("ACGT", "ACGT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 8);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "4=");
 	}
-	SECTION("Single mismatch -> still 4M (KSW2 lumps match+mismatch)") {
+	SECTION("Single mismatch -> 2=1X1= (eqx post-pass distinguishes the mismatch)") {
 		auto result = aligner.align_extz_cigar("ACGT", "ACAT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 2);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "2=1X1=");
+	}
+	SECTION("Adjacent mismatches coalesce into one X run") {
+		// AAAA vs TTAA: mismatch, mismatch, match, match (ungapped) -> 2X2=
+		auto result = aligner.align_extz_cigar("AAAA", "TTAA");
+		REQUIRE(result.has_value());
+		REQUIRE(result->cigar == "2X2=");
+	}
+	SECTION("Soft-masked (lowercase) bases are matches, not mismatches") {
+		auto result = aligner.align_extz_cigar("acgt", "ACGT");
+		REQUIRE(result.has_value());
+		REQUIRE(result->cigar == "4=");
 	}
 	SECTION("CIGAR contains I for insertion") {
 		auto result = aligner.align_extz_cigar("ACGGT", "ACGT");
@@ -116,7 +127,7 @@ TEST_CASE("KSW2Aligner - align_extz_full", "[KSW2Aligner]") {
 		auto result = aligner.align_extz_full("ACGT", "ACGT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 8);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "4=");
 		REQUIRE(result->query_aligned == "ACGT");
 		REQUIRE(result->subject_aligned == "ACGT");
 	}
@@ -368,17 +379,17 @@ TEST_CASE("KSW2Aligner - align_extd_score: long gap uses second affine", "[KSW2A
 TEST_CASE("KSW2Aligner - align_extd_cigar", "[KSW2Aligner]") {
 	KSW2Aligner aligner(2, 4, 6, 2, 24, 1, -1, -1);
 
-	SECTION("Identical sequences -> 4M") {
+	SECTION("Identical sequences -> 4= (eqx post-pass)") {
 		auto result = aligner.align_extd_cigar("ACGT", "ACGT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 8);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "4=");
 	}
-	SECTION("Single mismatch -> still 4M (KSW2 lumps M)") {
+	SECTION("Single mismatch -> 2=1X1= (eqx post-pass)") {
 		auto result = aligner.align_extd_cigar("ACGT", "ACAT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 2);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "2=1X1=");
 	}
 	SECTION("CIGAR contains I for insertion") {
 		auto result = aligner.align_extd_cigar("ACGGT", "ACGT");
@@ -493,17 +504,17 @@ TEST_CASE("KSW2Aligner - align_exts_score: identical and short gaps behave like 
 TEST_CASE("KSW2Aligner - align_exts_cigar", "[KSW2Aligner]") {
 	KSW2Aligner aligner(2, 4, 6, 2, 24, 9, -1);
 
-	SECTION("Identical -> 4M, score 8") {
+	SECTION("Identical -> 4=, score 8 (eqx post-pass)") {
 		auto result = aligner.align_exts_cigar("ACGT", "ACGT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 8);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "4=");
 	}
-	SECTION("Mismatch -> 4M, score 2") {
+	SECTION("Mismatch -> 2=1X1=, score 2 (eqx post-pass)") {
 		auto result = aligner.align_exts_cigar("ACGT", "ACAT");
 		REQUIRE(result.has_value());
 		REQUIRE(result->score == 2);
-		REQUIRE(result->cigar == "4M");
+		REQUIRE(result->cigar == "2=1X1=");
 	}
 }
 

--- a/test/sql/align_pairwise_ksw2.test
+++ b/test/sql/align_pairwise_ksw2.test
@@ -103,19 +103,19 @@ s2	2
 # align_pairwise_ksw2_cigar
 ###############################################################################
 
-# Identical -> 4M (KSW2 does not distinguish = from X)
+# Identical -> 4= (eqx post-pass splits M into =/X)
 query IT
 SELECT (align_pairwise_ksw2_cigar('ACGT', 'ACGT')).score,
        (align_pairwise_ksw2_cigar('ACGT', 'ACGT')).cigar;
 ----
-8	4M
+8	4=
 
-# Single mismatch -> still 4M, score 2
+# Single mismatch -> 2=1X1=, score 2 (eqx post-pass distinguishes the mismatch)
 query IT
 SELECT (align_pairwise_ksw2_cigar('ACGT', 'ACAT')).score,
        (align_pairwise_ksw2_cigar('ACGT', 'ACAT')).cigar;
 ----
-2	4M
+2	2=1X1=
 
 # NULL -> NULL
 query I
@@ -128,7 +128,26 @@ query IT
 SELECT (align_pairwise_ksw2_cigar('ACGT', 'ACAT', 1, 4, 6, 2)).score,
        (align_pairwise_ksw2_cigar('ACGT', 'ACAT', 1, 4, 6, 2)).cigar;
 ----
--1	4M
+-1	2=1X1=
+
+# eqx post-pass: sequence identity is now readable directly from the KSW2 CIGAR.
+# This is the point of the =/X split — a bare 'M' CIGAR returns NULL here.
+query I
+SELECT cigar_sequence_identity((align_pairwise_ksw2_cigar('ACGT', 'ACAT')).cigar);
+----
+0.75
+
+# Adjacent mismatches coalesce into a single X run
+query T
+SELECT (align_pairwise_ksw2_cigar('AAAA', 'TTAA')).cigar;
+----
+2X2=
+
+# Soft-masked (lowercase) bases are matches, not mismatches
+query T
+SELECT (align_pairwise_ksw2_cigar('acgt', 'ACGT')).cigar;
+----
+4=
 
 ###############################################################################
 # align_pairwise_ksw2_full
@@ -141,7 +160,7 @@ SELECT (align_pairwise_ksw2_full('ACGT', 'ACGT')).score,
        (align_pairwise_ksw2_full('ACGT', 'ACGT')).query_aligned,
        (align_pairwise_ksw2_full('ACGT', 'ACGT')).subject_aligned;
 ----
-8	4M	ACGT	ACGT
+8	4=	ACGT	ACGT
 
 # Single mismatch -> aligned seqs match originals (no gaps)
 query TT

--- a/test/sql/align_pairwise_ksw2_dual_affine.test
+++ b/test/sql/align_pairwise_ksw2_dual_affine.test
@@ -117,17 +117,18 @@ s2	2
 # align_pairwise_ksw2_dual_affine_cigar
 ###############################################################################
 
+# eqx post-pass splits M into =/X
 query IT
 SELECT (align_pairwise_ksw2_dual_affine_cigar('ACGT', 'ACGT')).score,
        (align_pairwise_ksw2_dual_affine_cigar('ACGT', 'ACGT')).cigar;
 ----
-8	4M
+8	4=
 
 query IT
 SELECT (align_pairwise_ksw2_dual_affine_cigar('ACGT', 'ACAT')).score,
        (align_pairwise_ksw2_dual_affine_cigar('ACGT', 'ACAT')).cigar;
 ----
-2	4M
+2	2=1X1=
 
 query I
 SELECT align_pairwise_ksw2_dual_affine_cigar(NULL, 'ACGT') IS NULL;
@@ -144,7 +145,7 @@ SELECT (align_pairwise_ksw2_dual_affine_full('ACGT', 'ACGT')).score,
        (align_pairwise_ksw2_dual_affine_full('ACGT', 'ACGT')).query_aligned,
        (align_pairwise_ksw2_dual_affine_full('ACGT', 'ACGT')).subject_aligned;
 ----
-8	4M	ACGT	ACGT
+8	4=	ACGT	ACGT
 
 query I
 SELECT (align_pairwise_ksw2_dual_affine_full('ACGGT', 'ACGT')).subject_aligned LIKE '%-%';

--- a/test/sql/align_pairwise_ksw2_splice.test
+++ b/test/sql/align_pairwise_ksw2_splice.test
@@ -93,17 +93,18 @@ s2	2
 # align_pairwise_ksw2_splice_cigar
 ###############################################################################
 
+# eqx post-pass splits M into =/X (N intron ops pass through unchanged)
 query IT
 SELECT (align_pairwise_ksw2_splice_cigar('ACGT', 'ACGT')).score,
        (align_pairwise_ksw2_splice_cigar('ACGT', 'ACGT')).cigar;
 ----
-8	4M
+8	4=
 
 query IT
 SELECT (align_pairwise_ksw2_splice_cigar('ACGT', 'ACAT')).score,
        (align_pairwise_ksw2_splice_cigar('ACGT', 'ACAT')).cigar;
 ----
-2	4M
+2	2=1X1=
 
 query I
 SELECT align_pairwise_ksw2_splice_cigar(NULL, 'ACGT') IS NULL;
@@ -120,7 +121,7 @@ SELECT (align_pairwise_ksw2_splice_full('ACGT', 'ACGT')).score,
        (align_pairwise_ksw2_splice_full('ACGT', 'ACGT')).query_aligned,
        (align_pairwise_ksw2_splice_full('ACGT', 'ACGT')).subject_aligned;
 ----
-8	4M	ACGT	ACGT
+8	4=	ACGT	ACGT
 
 query I
 SELECT align_pairwise_ksw2_splice_full(NULL, 'ACGT') IS NULL;
@@ -136,7 +137,8 @@ true
 # for canonical), the kernel prefers a single intron skip over a 104bp deletion:
 #   intron-open cost           = gap_open2 + noncan = 24 + 0 = 24
 #   pure-deletion cost (104bp) = gap_open + 104*gap_extend = 6 + 208 = 214
-# Expected CIGAR is "12M104N12M" and score = 24 matches * 2 - 24 = 24.
+# Both 12bp exons match exactly, so the eqx post-pass renders them as "12=" (the N intron
+# op passes through). Expected CIGAR is "12=104N12=" and score = 24 matches * 2 - 24 = 24.
 ###############################################################################
 
 query IT
@@ -148,7 +150,7 @@ SELECT (align_pairwise_ksw2_splice_cigar(q, s)).score,
        (align_pairwise_ksw2_splice_cigar(q, s)).cigar
 FROM t;
 ----
-24	12M104N12M
+24	12=104N12=
 
 # Reconstructed aligned-subject must contain dashes for every position skipped by
 # the N op (104 of them), preserving alignment length = subject length.


### PR DESCRIPTION
## Summary

The `align_pairwise_ksw2{,_dual_affine,_splice}_{cigar,full}` functions call `ksw_extz2_sse` directly, which emits only `M` (match-or-mismatch). That left sequence identity **unreadable from the CIGAR alone** — `cigar_sequence_identity` returns `NULL` on an `M`-only CIGAR. These were the lone outlier among the repo's alignment surfaces: WFA2 pairwise emits `=`/`X` natively, and minimap2 defaults `eqx=true` (`MM_F_EQX`). minimap2's eqx pass lives inside its mapper, which the raw-KSW2 pairwise path never reaches — so a small standalone post-pass was needed.

This adds an **unconditional** eqx post-pass, so every pairwise KSW2 CIGAR now uses extended `=`/`X`.

## Changes

- **`eqx_split_cigar`** (`src/include/cigar_reconstruction.hpp`): rewrites each `M` run into `=`/`X` by comparing the aligned bases **case-insensitively** (so soft-masked lowercase bases are not counted as mismatches, matching minimap2's effective behavior). `I`/`D`/`N` (intron) ops pass through. Does **not** require the CIGAR to consume every base, so a z-drop-truncated alignment keeps its current lenient behavior.
- Extracted a shared **`for_each_cigar_op`** tokenizer so `reconstruct_aligned_from_cigar` and `eqx_split_cigar` share one CIGAR parser (DRY).
- Wired into all three KSW2 cigar methods (`align_ext{z,d,s}_cigar`); `_full` inherits via `_cigar`.
- Tests + docs updated to the extended CIGAR.

## Behavior change

`align_pairwise_ksw2*_cigar`/`_full` now return `=`/`X` instead of `M` by default (e.g. `align_pairwise_ksw2_cigar('ACGT','ACAT').cigar` is `2=1X1=`, was `4M`). Chosen unconditionally (no opt-out) so the KSW2 pairwise family matches its WFA2 sibling and the rest of the repo; `=`/`X` → `M` is a trivial regex if the collapsed form is ever needed, whereas the reverse is impossible without the sequences.

## Verification

- **C++**: `[KSW2Aligner]` 177 assertions / 26 cases, `[WFA2Aligner]` 143 / 21 (shares the refactored header).
- **SQL**: `align_pairwise_ksw2` (39), `_dual_affine` (30), `_splice` (31), `_wfa2` (33) — all pass. New coverage: identity read straight off the CIGAR (`0.75`), adjacent-mismatch run merging (`2X2=`), soft-mask handling (`4=`).
- `clang-format` 11.0.1 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)