### PR TITLE
fix: clarify alignment_is_primary semantics + preserve id types in alignment_slice

### DIFF
--- a/docs/scalar-functions.md
+++ b/docs/scalar-functions.md
@@ -30,7 +30,8 @@ Test individual SAM flag bits. Each function takes a `USMALLINT` (the flags colu
 - `alignment_is_read1(flags)` - Read is first in pair (0x40)
 - `alignment_is_read2(flags)` - Read is second in pair (0x80)
 - `alignment_is_secondary(flags)` - Secondary alignment (0x100)
-- `alignment_is_primary(flags)` - Primary alignment (neither secondary nor supplementary)
+- `alignment_is_primary(flags)` - Primary *line* — neither secondary (0x100) nor supplementary (0x800) set, i.e. `FLAG & 0x900 == 0`. ⚠️ **TRUE for an unmapped read** (see note below).
+- `alignment_is_mapped_primary(flags)` - Primary line **and** mapped — `FLAG & 0x904 == 0`; equivalent to `alignment_is_primary(flags) AND NOT alignment_is_unmapped(flags)`. Use this when you mean "a real, mapped primary alignment".
 - `alignment_is_qc_failed(flags)` - QC failure (0x200)
 - `alignment_is_duplicate(flags)` - PCR/optical duplicate (0x400)
 - `alignment_is_supplementary(flags)` - Supplementary alignment (0x800)
@@ -38,12 +39,13 @@ Test individual SAM flag bits. Each function takes a `USMALLINT` (the flags colu
 **HTSlib-compatible aliases:**
 `is_paired`, `is_proper_pair`, `is_unmapped`, `is_munmap`, `is_reverse`, `is_mreverse`, `is_read1`, `is_read2`, `is_secondary`, `is_qcfail`, `is_dup`, `is_supplementary`
 
+> **Note on `alignment_is_primary` and unmapped reads.** `alignment_is_primary` intentionally matches the SAM spec's definition of the *primary line*: the one line per read with neither the SECONDARY (0x100) nor SUPPLEMENTARY (0x800) bit set (`FLAG & 0x900 == 0`). The spec guarantees exactly one such line per read, and that line exists **whether or not the read is mapped** — so `alignment_is_primary(flags)` is `true` for an unmapped read (`flags = 0x4`). This is consistent with the SAM specification (see [SAMv1, §1.4 FLAG](https://samtools.github.io/hts-specs/SAMv1.pdf), the primary-line definition) and with HTSlib/samtools. If you actually want "a mapped primary alignment", use `alignment_is_mapped_primary(flags)` (or spell out `alignment_is_primary(flags) AND NOT alignment_is_unmapped(flags)`).
+
 **Example:**
 ```sql
 SELECT read_id, flags
 FROM read_alignments('alignments.sam')
-WHERE alignment_is_paired(flags)
-  AND NOT alignment_is_unmapped(flags);
+WHERE alignment_is_mapped_primary(flags);
 ```
 
 ## `alignment_seq_identity(cigar, nm, md, type)`

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -180,7 +180,7 @@ Slice alignment data from a table or view to a genomic region. Each alignment is
 
 **Required input columns:** `cigar` (VARCHAR), `position` (BIGINT), `stop_position` (BIGINT)
 
-**Output schema:** Same columns as found in the input table (from the recognized alignment column set), with adjusted values for overlapping reads.
+**Output schema:** Same columns as found in the input table (from the recognized alignment column set), with adjusted values for overlapping reads. The identifier columns `read_id`, `reference`, and `mate_reference` keep their input storage type — `VARCHAR`, `BIGINT`, or `UUID` — rather than being coerced to `VARCHAR`, so a `BIGINT`/`UUID` id round-trips through slicing unchanged (consistent with `align_minimap2`).
 
 **Behavior:**
 - Reads that don't overlap the region are excluded
@@ -189,6 +189,7 @@ Slice alignment data from a table or view to a genomic region. Each alignment is
 - Tags (`tag_as` through `tag_sa`) are set to NULL when trimming occurs
 - `template_length` is set to NULL when trimming occurs
 - `mapq` and mate fields are preserved
+- `read_id`, `reference`, and `mate_reference` must each be `VARCHAR`, `BIGINT`, or `UUID` if present; another type is rejected at bind time
 - If the input table has a `reference` column, all rows must have the same reference (single-region slicing)
 - Rows with NULL `cigar`, `position`, or `stop_position` are skipped
 

--- a/src/alignment_flag_functions.cpp
+++ b/src/alignment_flag_functions.cpp
@@ -65,6 +65,15 @@ static void AlignmentIsPrimaryFunction(DataChunk &args, ExpressionState &state, 
 	});
 }
 
+// SAM spec "primary line" (FLAG & 0x900 == 0) is TRUE for unmapped reads. This companion
+// adds the mapped requirement (FLAG & 0x904 == 0) for callers who mean "mapped primary".
+static void AlignmentIsMappedPrimaryFunction(DataChunk &args, ExpressionState &state, Vector &result) {
+	auto &flags_vector = args.data[0];
+	UnaryExecutor::Execute<uint16_t, bool>(flags_vector, result, args.size(), [&](uint16_t flags) {
+		return (flags & 0x100) == 0 && (flags & 0x800) == 0 && (flags & 0x4) == 0;
+	});
+}
+
 static void AlignmentIsQcFailedFunction(DataChunk &args, ExpressionState &state, Vector &result) {
 	auto &flags_vector = args.data[0];
 	UnaryExecutor::Execute<uint16_t, bool>(flags_vector, result, args.size(),
@@ -143,6 +152,10 @@ void AlignmentFlagFunctions::Register(ExtensionLoader &loader) {
 	ScalarFunction alignment_is_primary("alignment_is_primary", {LogicalType::USMALLINT}, LogicalType::BOOLEAN,
 	                                    AlignmentIsPrimaryFunction);
 	loader.RegisterFunction(alignment_is_primary);
+
+	ScalarFunction alignment_is_mapped_primary("alignment_is_mapped_primary", {LogicalType::USMALLINT},
+	                                           LogicalType::BOOLEAN, AlignmentIsMappedPrimaryFunction);
+	loader.RegisterFunction(alignment_is_mapped_primary);
 
 	ScalarFunction is_secondary("is_secondary", {LogicalType::USMALLINT}, LogicalType::BOOLEAN,
 	                            AlignmentIsSecondaryFunction);

--- a/src/alignment_slice.cpp
+++ b/src/alignment_slice.cpp
@@ -1,5 +1,6 @@
 #include "alignment_slice.hpp"
 #include "catalog_utils.hpp"
+#include "id_column_utils.hpp"
 #include "AlignmentSlicer.hpp"
 
 #include "duckdb/common/exception.hpp"
@@ -124,7 +125,24 @@ unique_ptr<FunctionData> AlignmentSliceTableFunction::Bind(ClientContext &contex
 	for (const auto &col : recognized) {
 		if (input_col_present[col.name] >= 0) {
 			data->output_names.push_back(col.name);
-			data->output_types.push_back(col.type);
+
+			// read_id, reference, and mate_reference are identifier columns:
+			// preserve the input's storage type (VARCHAR/BIGINT/UUID) instead of
+			// coercing to VARCHAR, matching align_minimap2 (query id_type drives
+			// read_id; subject id_type drives reference + mate_reference). Without
+			// this a BIGINT/UUID id is silently stringified on the pass-through
+			// path. mate_reference is pass-through here (no "="/"*" resolution), so
+			// mirroring the column's own type is always correct.
+			LogicalType out_type = col.type;
+			if (col.name == "read_id" || col.name == "reference" || col.name == "mate_reference") {
+				const auto &actual_type = table_info.types[static_cast<idx_t>(input_col_present[col.name])];
+				if (!IsAllowedIdType(actual_type)) {
+					throw BinderException("alignment_slice: '%s' column must be %s, got %s", col.name,
+					                      AllowedIdTypeList(), actual_type.ToString());
+				}
+				out_type = actual_type;
+			}
+			data->output_types.push_back(out_type);
 			data->output_input_idx.push_back(select_col_idx.at(col.name));
 
 			ColRole role;

--- a/src/alignment_slice.cpp
+++ b/src/alignment_slice.cpp
@@ -19,31 +19,31 @@ namespace duckdb {
 using ColRole = AlignmentSliceTableFunction::ColRole;
 
 const vector<AlignmentSliceTableFunction::ColumnInfo> &AlignmentSliceTableFunction::GetRecognizedColumns() {
-	// name, type, required, is_tag, invalidate_on_trim
+	// name, type, required, is_tag, invalidate_on_trim, is_id
 	static const vector<ColumnInfo> columns = {
-	    {"read_id", LogicalType::VARCHAR, false, false, false},
-	    {"flags", LogicalType::USMALLINT, false, false, false},
-	    {"reference", LogicalType::VARCHAR, false, false, false},
-	    {"position", LogicalType::BIGINT, true, false, false},
-	    {"stop_position", LogicalType::BIGINT, true, false, false},
-	    {"mapq", LogicalType::UTINYINT, false, false, false},
-	    {"cigar", LogicalType::VARCHAR, true, false, false},
-	    {"mate_reference", LogicalType::VARCHAR, false, false, false},
-	    {"mate_position", LogicalType::BIGINT, false, false, false},
-	    {"template_length", LogicalType::BIGINT, false, false, true},
-	    {"tag_as", LogicalType::BIGINT, false, true, false},
-	    {"tag_xs", LogicalType::BIGINT, false, true, false},
-	    {"tag_ys", LogicalType::BIGINT, false, true, false},
-	    {"tag_xn", LogicalType::BIGINT, false, true, false},
-	    {"tag_xm", LogicalType::BIGINT, false, true, false},
-	    {"tag_xo", LogicalType::BIGINT, false, true, false},
-	    {"tag_xg", LogicalType::BIGINT, false, true, false},
-	    {"tag_nm", LogicalType::BIGINT, false, true, false},
-	    {"tag_yt", LogicalType::VARCHAR, false, true, false},
-	    {"tag_md", LogicalType::VARCHAR, false, true, false},
-	    {"tag_sa", LogicalType::VARCHAR, false, true, false},
-	    {"sequence", LogicalType::VARCHAR, false, false, false},
-	    {"qual", LogicalType::LIST(LogicalType::UTINYINT), false, false, false},
+	    {"read_id", LogicalType::VARCHAR, false, false, false, true},
+	    {"flags", LogicalType::USMALLINT, false, false, false, false},
+	    {"reference", LogicalType::VARCHAR, false, false, false, true},
+	    {"position", LogicalType::BIGINT, true, false, false, false},
+	    {"stop_position", LogicalType::BIGINT, true, false, false, false},
+	    {"mapq", LogicalType::UTINYINT, false, false, false, false},
+	    {"cigar", LogicalType::VARCHAR, true, false, false, false},
+	    {"mate_reference", LogicalType::VARCHAR, false, false, false, true},
+	    {"mate_position", LogicalType::BIGINT, false, false, false, false},
+	    {"template_length", LogicalType::BIGINT, false, false, true, false},
+	    {"tag_as", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_xs", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_ys", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_xn", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_xm", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_xo", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_xg", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_nm", LogicalType::BIGINT, false, true, false, false},
+	    {"tag_yt", LogicalType::VARCHAR, false, true, false, false},
+	    {"tag_md", LogicalType::VARCHAR, false, true, false, false},
+	    {"tag_sa", LogicalType::VARCHAR, false, true, false, false},
+	    {"sequence", LogicalType::VARCHAR, false, false, false, false},
+	    {"qual", LogicalType::LIST(LogicalType::UTINYINT), false, false, false, false},
 	};
 	return columns;
 }
@@ -126,15 +126,15 @@ unique_ptr<FunctionData> AlignmentSliceTableFunction::Bind(ClientContext &contex
 		if (input_col_present[col.name] >= 0) {
 			data->output_names.push_back(col.name);
 
-			// read_id, reference, and mate_reference are identifier columns:
-			// preserve the input's storage type (VARCHAR/BIGINT/UUID) instead of
-			// coercing to VARCHAR, matching align_minimap2 (query id_type drives
-			// read_id; subject id_type drives reference + mate_reference). Without
-			// this a BIGINT/UUID id is silently stringified on the pass-through
-			// path. mate_reference is pass-through here (no "="/"*" resolution), so
+			// Identifier columns (read_id, reference, mate_reference) preserve the
+			// input's storage type (VARCHAR/BIGINT/UUID) instead of coercing to
+			// VARCHAR, matching align_minimap2 (query id_type drives read_id;
+			// subject id_type drives reference + mate_reference). Without this a
+			// BIGINT/UUID id is silently stringified on the pass-through path.
+			// mate_reference is pass-through here (no "="/"*" resolution), so
 			// mirroring the column's own type is always correct.
 			LogicalType out_type = col.type;
-			if (col.name == "read_id" || col.name == "reference" || col.name == "mate_reference") {
+			if (col.is_id) {
 				const auto &actual_type = table_info.types[static_cast<idx_t>(input_col_present[col.name])];
 				if (!IsAllowedIdType(actual_type)) {
 					throw BinderException("alignment_slice: '%s' column must be %s, got %s", col.name,

--- a/src/include/alignment_slice.hpp
+++ b/src/include/alignment_slice.hpp
@@ -20,6 +20,7 @@ public:
 		bool required;           // cigar, position, stop_position are required
 		bool is_tag;             // tag columns are NULLed after trimming
 		bool invalidate_on_trim; // template_length is NULLed on any trim
+		bool is_id;              // read_id/reference/mate_reference: preserve input id type, don't coerce to VARCHAR
 	};
 
 	// Per-output-column role, precomputed at bind time for fast dispatch in Execute

--- a/test/sql/alignment_flags.test
+++ b/test/sql/alignment_flags.test
@@ -127,6 +127,57 @@ SELECT
 ----
 true	false	false	false
 
+# alignment_is_primary matches the SAM spec's "primary line" (FLAG & 0x900 == 0),
+# which is deliberately independent of the unmapped bit (0x4): an unmapped read's
+# single line IS its primary line. So alignment_is_primary is TRUE for an unmapped
+# read. Callers who mean "mapped primary" must exclude unmapped explicitly (or use
+# alignment_is_mapped_primary). Pinning this so the spec semantics can't silently drift.
+query I
+SELECT alignment_is_primary(4::USMALLINT);
+----
+true
+
+# alignment_is_mapped_primary: primary line AND mapped (FLAG & 0x904 == 0)
+query I
+SELECT alignment_is_mapped_primary(0::USMALLINT);
+----
+true
+
+# unmapped: primary line but not mapped -> false (this is the whole point of the companion)
+query I
+SELECT alignment_is_mapped_primary(4::USMALLINT);
+----
+false
+
+# secondary (0x100): not primary -> false regardless of mapped state
+query I
+SELECT alignment_is_mapped_primary(256::USMALLINT);
+----
+false
+
+# supplementary (0x800): not primary -> false
+query I
+SELECT alignment_is_mapped_primary(2048::USMALLINT);
+----
+false
+
+# unmapped secondary (0x104): false
+query I
+SELECT alignment_is_mapped_primary(260::USMALLINT);
+----
+false
+
+# alignment_is_mapped_primary(flags) is equivalent to
+# alignment_is_primary(flags) AND NOT alignment_is_unmapped(flags)
+query IIII
+SELECT
+    alignment_is_mapped_primary(0::USMALLINT),      -- mapped primary: true
+    alignment_is_mapped_primary(4::USMALLINT),      -- unmapped primary: false
+    alignment_is_mapped_primary(256::USMALLINT),    -- secondary: false
+    alignment_is_mapped_primary(2048::USMALLINT);   -- supplementary: false
+----
+true	false	false	false
+
 query I
 SELECT alignment_is_qc_failed(512::USMALLINT);
 ----

--- a/test/sql/alignment_slice.test
+++ b/test/sql/alignment_slice.test
@@ -389,3 +389,134 @@ query TIIT
 SELECT read_id, cigar, position, stop_position FROM alignment_slice('sam_data', 140, 145) ORDER BY read_id
 ----
 read_hclip	5H5M5H	140	145
+
+# =====================================================================
+# Phase 6: read_id type preservation
+#
+# read_id is an identifier column: its storage type (VARCHAR / BIGINT /
+# UUID) must survive slicing rather than being silently coerced to VARCHAR,
+# matching align_minimap2 and the other id-emitting functions. A user
+# reported a BIGINT read_id coming back as VARCHAR (the whole point of these
+# tests is to pin the type, not just the value).
+# =====================================================================
+
+# BIGINT read_id round-trips as BIGINT, not VARCHAR
+statement ok
+CREATE TABLE slice_bigint_id (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id BIGINT)
+
+statement ok
+INSERT INTO slice_bigint_id VALUES ('10M', 5, 15, 42)
+
+query T
+SELECT typeof(read_id) FROM alignment_slice('slice_bigint_id', 1, 20)
+----
+BIGINT
+
+query I
+SELECT read_id FROM alignment_slice('slice_bigint_id', 1, 20)
+----
+42
+
+# UUID read_id round-trips as UUID
+statement ok
+CREATE TABLE slice_uuid_id (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id UUID)
+
+statement ok
+INSERT INTO slice_uuid_id VALUES ('10M', 5, 15, '123e4567-e89b-12d3-a456-426614174000')
+
+query T
+SELECT typeof(read_id) FROM alignment_slice('slice_uuid_id', 1, 20)
+----
+UUID
+
+query T
+SELECT read_id FROM alignment_slice('slice_uuid_id', 1, 20)
+----
+123e4567-e89b-12d3-a456-426614174000
+
+# VARCHAR read_id remains VARCHAR (unchanged behavior)
+query T
+SELECT typeof(read_id) FROM alignment_slice('t1', 1, 20)
+----
+VARCHAR
+
+# Type is preserved even when the row is trimmed (read_id is pass-through;
+# trimming must not perturb its type)
+statement ok
+CREATE TABLE slice_bigint_trim (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id BIGINT, sequence VARCHAR)
+
+statement ok
+INSERT INTO slice_bigint_trim VALUES ('10M', 1, 11, 99, 'ABCDEFGHIJ')
+
+query TIT
+SELECT typeof(read_id), read_id, cigar FROM alignment_slice('slice_bigint_trim', 4, 8)
+----
+BIGINT	99	3H4M3H
+
+# A read_id column of a type outside the allowed id set is rejected at bind
+# (mirrors align_minimap2's VARCHAR/BIGINT/UUID contract) rather than being
+# silently stringified as before.
+statement ok
+CREATE TABLE slice_badid (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id INTEGER)
+
+statement error
+SELECT * FROM alignment_slice('slice_badid', 1, 20)
+----
+read_id
+
+# reference is the subject-side identifier column (align_minimap2 drives it and
+# mate_reference from subject id_type); its type must be preserved too, and the
+# single-reference check must still work on a non-VARCHAR reference.
+statement ok
+CREATE TABLE slice_bigint_ref (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference BIGINT)
+
+statement ok
+INSERT INTO slice_bigint_ref VALUES ('5M', 1, 6, 7), ('5M', 10, 15, 7)
+
+query T
+SELECT DISTINCT typeof(reference) FROM alignment_slice('slice_bigint_ref', 1, 20)
+----
+BIGINT
+
+query I
+SELECT count(*) FROM alignment_slice('slice_bigint_ref', 1, 20)
+----
+2
+
+# single-reference check still fires for a BIGINT reference with two distinct values
+statement ok
+CREATE TABLE slice_bigint_multiref (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference BIGINT)
+
+statement ok
+INSERT INTO slice_bigint_multiref VALUES ('5M', 1, 6, 7), ('5M', 10, 15, 9)
+
+statement error
+SELECT * FROM alignment_slice('slice_bigint_multiref', 1, 20)
+----
+multiple references found
+
+# mate_reference type is preserved as well
+statement ok
+CREATE TABLE slice_uuid_materef (cigar VARCHAR, position BIGINT, stop_position BIGINT, mate_reference UUID)
+
+statement ok
+INSERT INTO slice_uuid_materef VALUES ('10M', 5, 15, '123e4567-e89b-12d3-a456-426614174000')
+
+query T
+SELECT typeof(mate_reference) FROM alignment_slice('slice_uuid_materef', 1, 20)
+----
+UUID
+
+query T
+SELECT mate_reference FROM alignment_slice('slice_uuid_materef', 1, 20)
+----
+123e4567-e89b-12d3-a456-426614174000
+
+# a reference column of a disallowed type is rejected at bind
+statement ok
+CREATE TABLE slice_badref (cigar VARCHAR, position BIGINT, stop_position BIGINT, reference INTEGER)
+
+statement error
+SELECT * FROM alignment_slice('slice_badref', 1, 20)
+----
+reference

--- a/test/sql/alignment_slice.test
+++ b/test/sql/alignment_slice.test
@@ -520,3 +520,28 @@ statement error
 SELECT * FROM alignment_slice('slice_badref', 1, 20)
 ----
 reference
+
+# A NULL id value must round-trip as NULL (not 0 / empty) while keeping the
+# column's storage type. Pins the pass-through egress against a future switch to
+# an id codec whose BIGINT branch maps empty/"*" to NULL.
+statement ok
+CREATE TABLE slice_null_bigint_id (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id BIGINT)
+
+statement ok
+INSERT INTO slice_null_bigint_id VALUES ('10M', 5, 15, NULL)
+
+query TT
+SELECT typeof(read_id), read_id FROM alignment_slice('slice_null_bigint_id', 1, 20)
+----
+BIGINT	NULL
+
+statement ok
+CREATE TABLE slice_null_uuid_id (cigar VARCHAR, position BIGINT, stop_position BIGINT, read_id UUID)
+
+statement ok
+INSERT INTO slice_null_uuid_id VALUES ('10M', 5, 15, NULL)
+
+query TT
+SELECT typeof(read_id), read_id FROM alignment_slice('slice_null_uuid_id', 1, 20)
+----
+UUID	NULL


### PR DESCRIPTION
Two related alignment-flag / alignment-table correctness fixes, both raised via review feedback.

## 1. `alignment_is_primary` is misleading (from [Qiita#270 review](https://github.com/the-miint/Qiita/pull/270#discussion_r3574853245))

`alignment_is_primary(flags)` returns `true` for an **unmapped** read (`flags=0x4`), because it implements the SAM spec's *primary line* definition (`FLAG & 0x900 == 0`) — that line exists whether or not the read is mapped. The name reads like "a real, mapped primary alignment," which trips people up.

The behavior is spec-correct (matches samtools/HTSlib), so it is **kept unchanged**. Instead:
- **Docs** now describe it as the primary *line*, link [SAMv1 §1.4 FLAG](https://samtools.github.io/hts-specs/SAMv1.pdf), and warn it is `TRUE` for unmapped reads.
- **New companion** `alignment_is_mapped_primary(flags)` = `FLAG & 0x904 == 0` (primary line **and** mapped) for callers who mean a mapped primary alignment.
- **Tests** pin `alignment_is_primary(4) == true` so the spec semantics can't silently drift, plus full coverage of the companion.

## 2. `alignment_slice` silently coerced `read_id` (and `reference`/`mate_reference`) to VARCHAR

`alignment_slice` hardcoded the three identifier columns to `VARCHAR` in its recognized-column set. Since they're pass-through, a `BIGINT`/`UUID` id from the input table was silently stringified on output (user-reported for `read_id`).

Fix: capture each id column's actual storage type at bind time and emit it, matching `align_minimap2` (query id_type → `read_id`; subject id_type → `reference` + `mate_reference`). Non-id types are rejected at bind via the shared `IsAllowedIdType`/`AllowedIdTypeList` contract (`VARCHAR`/`BIGINT`/`UUID`). The single-reference check is unaffected (it compares via `GetValue<string>()`, verified for BIGINT and UUID references).

Type-preservation is driven off a new `bool is_id` field on `ColumnInfo`, consistent with the file's existing flag-driven role design (`is_tag`, `invalidate_on_trim`) rather than name-string comparisons.

Tests pin the output **type** (not just value) for BIGINT/UUID `read_id`, UUID `mate_reference`, BIGINT `reference` (incl. the single-reference check firing on BIGINT), the trimmed-row path, NULL-id round-trip, VARCHAR back-compat, and disallowed-type rejection.

## Verification
- `alignment_flags.test` (63 assertions) and `alignment_slice.test` (159 assertions) pass
- C++ `[alignment_slicer]` unit tests (204 assertions) pass
- `make format-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)