### PR TITLE
fix(read_gff): percent-decode attributes and stop truncating values at the 2nd '='

### DIFF
--- a/data/gff/encoded.gff
+++ b/data/gff/encoded.gff
@@ -1,0 +1,7 @@
+##gff-version 3
+##sequence-region chr1 1 2000
+chr1	SynDNA	insert	100	200	.	+	.	ID=SynDNA_gc=0.46;Note=first%20insert
+chr1	SynDNA	insert	300	400	.	+	.	ID=SynDNA_gc=0.50;Note=second%20insert
+chr1	NCBI	gene	500	600	.	+	.	ID=gene%3D1;Dbxref=taxon%3A9606;desc=a%2Cb%3Bc%26d
+chr1	NCBI	gene	700	800	.	+	.	ID=gene4;weird%20key=val
+chr1	NCBI	gene	900	1000	.	+	.	ID=gene5;Name=caf%C3%A9

--- a/docs/table-functions.md
+++ b/docs/table-functions.md
@@ -631,6 +631,7 @@ Read GFF3 (General Feature Format) annotation files. GFF is a standard format fo
 - Automatically filters comment lines starting with '##'
 - Converts '.' to NULL for score, strand, and phase fields
 - Parses the attributes column (semicolon-separated key=value pairs) into a SQL MAP
+- Percent-decodes (`%XX`) attribute keys and values per the GFF3 spec (e.g. `%3D` → `=`, `%2C` → `,`, `%3B` → `;`, `%26` → `&`); the value is everything after the first `=`, so a raw `=` inside a value is preserved rather than truncated
 - Supports standard GFF3 specification
 
 **Examples:**

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -17,14 +17,21 @@ const std::string MIINT_WARNINGS = // NOLINT
     "WHERE type = 'MiintWarning' "
     "ORDER BY timestamp;";
 
+// GFF3 (col 9) reserves ; = & , and requires them percent-encoded inside keys and
+// values, so decode every key/value with url_decode. The value is everything after
+// the FIRST '=' (rejoined), not string_split(x,'=')[2] — a raw '=' in a value (e.g.
+// an insert name "gc=0.46") must not be truncated, which would silently collapse
+// distinct features onto one id. A token with no '=' keeps a NULL value.
 const std::string PARSE_GFF_ATTRIBUTES = // NOLINT
     "CREATE OR REPLACE MACRO parse_gff_attributes(kvp_string) AS ( "
     "  map_from_entries( "
     "    list_transform( "
     "      string_split(kvp_string, ';'), "
     "      lambda x: struct_pack( "
-    "        key := string_split(x, '=')[1], "
-    "        value := string_split(x, '=')[2] "
+    "        key := url_decode(string_split(x, '=')[1]), "
+    "        value := CASE WHEN contains(x, '=') "
+    "                      THEN url_decode(array_to_string(string_split(x, '=')[2:], '=')) "
+    "                      ELSE NULL END "
     "      ) "
     "    ) "
     "  ) "

--- a/test/sql/read_gff.test
+++ b/test/sql/read_gff.test
@@ -190,6 +190,51 @@ SELECT COUNT(*) FROM gff_data WHERE seqid LIKE '##%';
 statement ok
 DROP TABLE gff_data;
 
+# GFF3 spec requires %XX percent-decoding of attribute keys and values (reserved
+# chars ;=&, must be encoded). read_gff must decode them, and must not truncate a
+# value at a second '=' — a raw '=' inside a value (e.g. an insert name "gc=0.46")
+# would otherwise collapse distinct features onto one ID.
+
+# Raw '=' inside a value must survive intact (regression: values truncated at 2nd '=')
+query T
+SELECT attributes['ID'] FROM read_gff('data/gff/encoded.gff') WHERE type = 'insert' ORDER BY position;
+----
+SynDNA_gc=0.46
+SynDNA_gc=0.50
+
+# The two inserts must remain distinct IDs, not collapse to one
+query I
+SELECT COUNT(DISTINCT attributes['ID']) FROM read_gff('data/gff/encoded.gff') WHERE type = 'insert';
+----
+2
+
+# Percent-encoded reserved characters in values must be decoded
+# ID=gene%3D1 -> gene=1 ; taxon%3A9606 -> taxon:9606 ; a%2Cb%3Bc%26d -> a,b;c&d
+query TTT
+SELECT attributes['ID'], attributes['Dbxref'], attributes['desc']
+FROM read_gff('data/gff/encoded.gff') WHERE position = 500;
+----
+gene=1	taxon:9606	a,b;c&d
+
+# %20 must decode to a space
+query T
+SELECT attributes['Note'] FROM read_gff('data/gff/encoded.gff') WHERE type = 'insert' ORDER BY position;
+----
+first insert
+second insert
+
+# Percent-encoded characters in KEYS must be decoded too (weird%20key -> "weird key")
+query T
+SELECT attributes['weird key'] FROM read_gff('data/gff/encoded.gff') WHERE position = 700;
+----
+val
+
+# Multi-byte UTF-8 percent-encoding must decode correctly (caf%C3%A9 -> café)
+query T
+SELECT attributes['Name'] FROM read_gff('data/gff/encoded.gff') WHERE position = 900;
+----
+café
+
 # Test error: nonexistent file
 statement error
 SELECT * FROM read_gff('data/gff/nonexistent.gff');


### PR DESCRIPTION
## Problem

A user reported that `read_gff` doesn't percent-decode column-9 attribute values, violating the GFF3 spec (reserved chars `;=&,` must be `%XX`-encoded in keys/values). Two consequences, one silent:

- **Encoded values come back mangled** — `%3D`, `%2C`, `%3B`, `%26` survive into the string literally.
- **A raw `=` inside a value truncates it** — the macro did `value := string_split(x,'=')[2]`, taking only the second element. `ID=SynDNA_gc=0.46` parsed to `SynDNA_gc`, so distinct features silently collapse onto one ID.

Hit on a real SynDNA plasmid map (insert names contain `gc=0.46`) where **10 inserts collapsed to 2 IDs**. Also matters for NCBI annotations, which percent-encode routinely.

## Fix

`parse_gff_attributes` (in `src/include/miint_macros.hpp`) now:

```sql
key   := url_decode(string_split(x, '=')[1]),
value := CASE WHEN contains(x, '=')
              THEN url_decode(array_to_string(string_split(x, '=')[2:], '='))
              ELSE NULL END
```

- **`url_decode`** — a DuckDB built-in (`main`/`system`, always present, no new dependency). Decodes `%XX` bytes and multi-byte UTF-8 correctly, passes malformed `%` sequences through unchanged (never throws — worst case is a no-op), and does **not** turn `+` into a space (correct for GFF3, unlike form-encoding).
- **Value = everything after the first `=`**, rejoined — so a raw `=` in a value is preserved instead of truncated.
- A token with no `=` still yields a `NULL` value (prior behavior preserved).

## Testing (TDD, red→green)

Added fixture `data/gff/encoded.gff` and regression tests to `test/sql/read_gff.test` covering:

- the SynDNA collapse (raw `=` in an ID value; `COUNT(DISTINCT ID) = 2`)
- encoded reserved chars: `%3D`→`=`, `%2C`→`,`, `%3B`→`;`, `%26`→`&`, `%3A`→`:`
- `%20`→space
- encoded **keys** (`weird%20key` → `weird key`)
- multi-byte UTF-8 (`caf%C3%A9` → `café`)

Confirmed RED before the fix, GREEN after (164 assertions). No regressions in the other GFF-touching tests (`read_only_load`, `null_input_guards`). `clang-format` (11.0.1, matching CI) clean.

## Scope note

`read_ncbi_annotation` (the C++ sibling sharing this schema) builds attributes from INSDC feature-table qualifiers, not GFF text, so those aren't percent-encoded — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)