### PR TITLE
fix(woltka_ogu): preserve BIGINT/UUID reference and sample_id types

### DIFF
--- a/docs/analysis-functions.md
+++ b/docs/analysis-functions.md
@@ -29,13 +29,13 @@ Compute [Woltka](https://github.com/qiyunzhu/woltka) OGU (Operational Genomic Un
 
 **Required columns in relation:**
 - Column named by `sequence_id_field`: read/sequence identifier
-- `reference` (VARCHAR): reference sequence name (becomes `feature_id`)
+- `reference` (VARCHAR, BIGINT, or UUID): reference sequence name (becomes `feature_id`, preserving the storage type). A non-identifier type is rejected at bind time.
 - `flags` (USMALLINT): SAM alignment flags
 - When `sample_id` is supplied: the named column (any comparable type) — NULLs are rejected at bind time
 
 **Returns:**
-- When `sample_id` is omitted: `(feature_id VARCHAR, value DOUBLE)`
-- When `sample_id` is supplied: `(<sample_id_column> <its_type>, feature_id VARCHAR, value DOUBLE)` — the first column's name matches the value you passed to `sample_id`.
+- When `sample_id` is omitted: `(feature_id <reference_type>, value DOUBLE)` — `feature_id` preserves the `reference` column's storage type (VARCHAR/BIGINT/UUID), mirroring `align_minimap2`/`alignment_slice` id-type preservation.
+- When `sample_id` is supplied: `(<sample_id_column> <its_type>, feature_id <reference_type>, value DOUBLE)` — the first column's name matches the value you passed to `sample_id`, and both id columns preserve their input storage types.
 
 **Algorithm:**
 1. Orients reads using alignment flags (forward/reverse via `alignment_is_read1`).

--- a/src/woltka_ogu_function.cpp
+++ b/src/woltka_ogu_function.cpp
@@ -3,6 +3,7 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/database.hpp"
+#include "id_column_utils.hpp"
 #include "per_sample_table_function.hpp"
 
 namespace duckdb {
@@ -81,11 +82,18 @@ static unique_ptr<MaterializedQueryResult> RunGlobalAggregation(Connection &conn
 // scoped to `conn`. Each thread has its own Connection, so names don't collide.
 static unique_ptr<MaterializedQueryResult> RunSampleAggregation(Connection &conn, const string &source,
                                                                 const string &seq_id_col, const string &sample_col,
-                                                                const Value &sample_value) {
+                                                                const Value &sample_value,
+                                                                const LogicalType &sample_type) {
 	auto q_src = KeywordHelper::WriteOptionallyQuoted(source);
 	auto q_sample = KeywordHelper::WriteOptionallyQuoted(sample_col);
 	// ToSQLString handles all Value types (integers, timestamps, strings) safely.
 	auto sample_literal = sample_value.ToSQLString();
+	// Cast the inlined literal back to the sample column's declared type before
+	// projecting it: a bare integer literal (e.g. 100) binds as INTEGER, so a
+	// BIGINT sample_id would otherwise emit an INTEGER column and mismatch the
+	// declared output type at output.Reference(). The comparison below is done
+	// as VARCHAR, so it's unaffected.
+	auto sample_expr = "CAST(" + sample_literal + " AS " + sample_type.ToString() + ")";
 
 	auto view_sql = "CREATE OR REPLACE TEMP VIEW __woltka_per_sample AS SELECT * FROM " + q_src + " WHERE CAST(" +
 	                q_sample + " AS VARCHAR) = CAST(" + sample_literal + " AS VARCHAR)";
@@ -95,7 +103,7 @@ static unique_ptr<MaterializedQueryResult> RunSampleAggregation(Connection &conn
 	}
 
 	auto inner_sql = BuildAggregationSql("__woltka_per_sample", seq_id_col);
-	auto wrapped_sql = "SELECT " + sample_literal + " AS " + q_sample + ", __q.* FROM (" + inner_sql + ") __q";
+	auto wrapped_sql = "SELECT " + sample_expr + " AS " + q_sample + ", __q.* FROM (" + inner_sql + ") __q";
 
 	auto result = conn.Query(wrapped_sql);
 	if (result->HasError()) {
@@ -129,14 +137,38 @@ static unique_ptr<FunctionData> WoltkaOguBind(ClientContext &context, TableFunct
 	auto q_src = KeywordHelper::WriteOptionallyQuoted(data->source);
 	auto q_seq = KeywordHelper::WriteOptionallyQuoted(data->seq_id_col);
 
-	// Validate source resolves AND required columns exist AND their types are compatible
-	// with the aggregation (reference → VARCHAR, flags → USMALLINT). LIMIT 0 binds the
-	// casts without scanning rows.
-	auto probe = conn.Query("SELECT " + q_seq + ", reference::VARCHAR, flags::USMALLINT FROM " + q_src + " LIMIT 0");
+	// Validate source resolves AND required columns exist AND flags casts to USMALLINT.
+	// reference is selected natively (not cast to VARCHAR) so its storage type can
+	// drive feature_id below. LIMIT 0 binds the casts without scanning rows.
+	auto probe = conn.Query("SELECT " + q_seq + ", reference, flags::USMALLINT FROM " + q_src + " LIMIT 0");
 	if (probe->HasError()) {
 		throw InvalidInputException("woltka_ogu: source, required columns (reference, flags), or their types "
 		                            "are not compatible: %s",
 		                            probe->GetError());
+	}
+
+	// feature_id inherits reference's storage type (VARCHAR/BIGINT/UUID), mirroring
+	// align_minimap2 / alignment_slice id-type preservation. BuildAggregationSql
+	// passes `reference` through uncasted, so the declared output type must match
+	// or output.Reference() aborts with an internal type-mismatch error. Resolve
+	// the column by name (not by position in the probe above) so a future edit to
+	// the probe's select list can't silently pick the wrong column's type.
+	LogicalType reference_type;
+	bool reference_found = false;
+	for (idx_t i = 0; i < probe->names.size(); i++) {
+		if (StringUtil::CIEquals(probe->names[i], "reference")) {
+			reference_type = probe->types[i];
+			reference_found = true;
+			break;
+		}
+	}
+	if (!reference_found) {
+		// Unreachable: the probe above selected `reference` and succeeded.
+		throw InternalException("woltka_ogu: 'reference' column missing from validation probe result");
+	}
+	if (!IsAllowedIdType(reference_type)) {
+		throw BinderException("woltka_ogu: 'reference' column must be %s, got %s", AllowedIdTypeList(),
+		                      reference_type.ToString());
 	}
 
 	if (data->has_sample_id) {
@@ -152,7 +184,7 @@ static unique_ptr<FunctionData> WoltkaOguBind(ClientContext &context, TableFunct
 	}
 
 	names.emplace_back("feature_id");
-	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(reference_type);
 	names.emplace_back("value");
 	return_types.emplace_back(LogicalType::DOUBLE);
 
@@ -215,8 +247,9 @@ static void WoltkaOguExecute(ClientContext &context, TableFunctionInput &input, 
 			output.SetCardinality(0);
 			return;
 		}
-		lstate.result = RunSampleAggregation(*lstate.conn, data.source, data.seq_id_col, data.sample_info.sample_id_col,
-		                                     data.sample_info.sample_values[sample_idx]);
+		lstate.result =
+		    RunSampleAggregation(*lstate.conn, data.source, data.seq_id_col, data.sample_info.sample_id_col,
+		                         data.sample_info.sample_values[sample_idx], data.sample_info.sample_id_type);
 	}
 }
 

--- a/test/sql/woltka.test
+++ b/test/sql/woltka.test
@@ -149,6 +149,174 @@ SELECT * FROM woltka_ogu('test_sam_data', 'read_id', sample_id := 'no_such_col')
 ----
 not found
 
+# ── Identifier type preservation (BIGINT / UUID) ────────────────────────────
+# align_minimap2 & friends preserve read_id/reference/mate_reference storage
+# types (VARCHAR/BIGINT/UUID). woltka_ogu consumes that output, so it must
+# preserve the reference type into feature_id and the sample_id type, and
+# tolerate a non-VARCHAR sequence_id_field (used only as an internal grouping
+# key). Mirrors alignment_slice's id-type handling.
+
+# reference -> feature_id preserves BIGINT (was: INTERNAL crash "Vector::Reference
+# used on vector of different type (source VARCHAR referenced BIGINT)")
+statement ok
+CREATE TABLE aln_ref_bigint AS SELECT * FROM (VALUES
+  ('r1', 100::BIGINT, 0),
+  ('r2', 100::BIGINT, 0),
+  ('r3', 200::BIGINT, 0)
+) t(read_id, reference, flags);
+
+query T
+SELECT DISTINCT typeof(feature_id) FROM woltka_ogu('aln_ref_bigint', 'read_id');
+----
+BIGINT
+
+query II
+SELECT feature_id, value FROM woltka_ogu('aln_ref_bigint', 'read_id') ORDER BY feature_id;
+----
+100	2.0
+200	1.0
+
+# reference -> feature_id preserves UUID
+statement ok
+CREATE TABLE aln_ref_uuid AS SELECT * FROM (VALUES
+  ('r1', '11111111-1111-1111-1111-111111111111'::UUID, 0),
+  ('r2', '11111111-1111-1111-1111-111111111111'::UUID, 0),
+  ('r3', '22222222-2222-2222-2222-222222222222'::UUID, 0)
+) t(read_id, reference, flags);
+
+query T
+SELECT DISTINCT typeof(feature_id) FROM woltka_ogu('aln_ref_uuid', 'read_id');
+----
+UUID
+
+query II
+SELECT feature_id, value FROM woltka_ogu('aln_ref_uuid', 'read_id') ORDER BY feature_id;
+----
+11111111-1111-1111-1111-111111111111	2.0
+22222222-2222-2222-2222-222222222222	1.0
+
+# sequence_id_field may be BIGINT (internal grouping key, not an output column)
+statement ok
+CREATE TABLE aln_seq_bigint AS SELECT * FROM (VALUES
+  (10::BIGINT, 'refA', 0),
+  (20::BIGINT, 'refA', 0),
+  (30::BIGINT, 'refB', 0)
+) t(read_id, reference, flags);
+
+query II
+SELECT feature_id, value FROM woltka_ogu('aln_seq_bigint', 'read_id') ORDER BY feature_id;
+----
+refA	2.0
+refB	1.0
+
+# sequence_id_field may be UUID
+statement ok
+CREATE TABLE aln_seq_uuid AS SELECT * FROM (VALUES
+  ('aaaaaaaa-0000-0000-0000-000000000001'::UUID, 'refA', 0),
+  ('aaaaaaaa-0000-0000-0000-000000000002'::UUID, 'refA', 0),
+  ('aaaaaaaa-0000-0000-0000-000000000003'::UUID, 'refB', 0)
+) t(read_id, reference, flags);
+
+query II
+SELECT feature_id, value FROM woltka_ogu('aln_seq_uuid', 'read_id') ORDER BY feature_id;
+----
+refA	2.0
+refB	1.0
+
+# sample_id preserves BIGINT (was: INTERNAL crash "source BIGINT referenced INTEGER"
+# -- Value::ToSQLString() renders a bare integer literal that binds as INTEGER)
+statement ok
+CREATE TABLE aln_samp_bigint AS SELECT * FROM (VALUES
+  ('r1', 'refA', 0, 100::BIGINT),
+  ('r2', 'refB', 0, 100::BIGINT),
+  ('r3', 'refA', 0, 200::BIGINT)
+) t(read_id, reference, flags, samp);
+
+query T
+SELECT DISTINCT typeof(samp) FROM woltka_ogu('aln_samp_bigint', 'read_id', sample_id := 'samp');
+----
+BIGINT
+
+query III
+SELECT samp, feature_id, value FROM woltka_ogu('aln_samp_bigint', 'read_id', sample_id := 'samp') ORDER BY samp, feature_id;
+----
+100	refA	1.0
+100	refB	1.0
+200	refA	1.0
+
+# sample_id preserves UUID
+statement ok
+CREATE TABLE aln_samp_uuid AS SELECT * FROM (VALUES
+  ('r1', 'refA', 0, 'bbbbbbbb-0000-0000-0000-000000000001'::UUID),
+  ('r2', 'refB', 0, 'bbbbbbbb-0000-0000-0000-000000000001'::UUID)
+) t(read_id, reference, flags, samp);
+
+query T
+SELECT DISTINCT typeof(samp) FROM woltka_ogu('aln_samp_uuid', 'read_id', sample_id := 'samp');
+----
+UUID
+
+query III
+SELECT samp, feature_id, value FROM woltka_ogu('aln_samp_uuid', 'read_id', sample_id := 'samp') ORDER BY feature_id;
+----
+bbbbbbbb-0000-0000-0000-000000000001	refA	1.0
+bbbbbbbb-0000-0000-0000-000000000001	refB	1.0
+
+# Combined: BIGINT reference AND BIGINT sample_id together
+statement ok
+CREATE TABLE aln_both_bigint AS SELECT * FROM (VALUES
+  ('r1', 100::BIGINT, 0, 7::BIGINT),
+  ('r2', 200::BIGINT, 0, 7::BIGINT)
+) t(read_id, reference, flags, samp);
+
+query T
+SELECT DISTINCT typeof(samp) || ',' || typeof(feature_id)
+FROM woltka_ogu('aln_both_bigint', 'read_id', sample_id := 'samp');
+----
+BIGINT,BIGINT
+
+query III
+SELECT samp, feature_id, value FROM woltka_ogu('aln_both_bigint', 'read_id', sample_id := 'samp') ORDER BY feature_id;
+----
+7	100	1.0
+7	200	1.0
+
+# A non-identifier reference type is rejected at bind (mirrors alignment_slice)
+statement ok
+CREATE TABLE aln_ref_double AS SELECT * FROM (VALUES
+  ('r1', 1.5::DOUBLE, 0)
+) t(read_id, reference, flags);
+
+statement error
+SELECT * FROM woltka_ogu('aln_ref_double', 'read_id')
+----
+VARCHAR, BIGINT, or UUID
+
+# Cleanup type-preservation tables
+statement ok
+DROP TABLE aln_ref_bigint;
+
+statement ok
+DROP TABLE aln_ref_uuid;
+
+statement ok
+DROP TABLE aln_seq_bigint;
+
+statement ok
+DROP TABLE aln_seq_uuid;
+
+statement ok
+DROP TABLE aln_samp_bigint;
+
+statement ok
+DROP TABLE aln_samp_uuid;
+
+statement ok
+DROP TABLE aln_both_bigint;
+
+statement ok
+DROP TABLE aln_ref_double;
+
 # Cleanup
 statement ok
 DROP TABLE test_sam_data;


### PR DESCRIPTION
## Problem

`woltka_ogu` declared its `feature_id` output column as `VARCHAR`
unconditionally, but the aggregation SQL passes `reference` through
**uncasted** (`reference AS feature_id`). When the `reference` column is a
`BIGINT` or `UUID` — exactly the storage types `align_minimap2` /
`alignment_slice` now preserve for id columns — the materialized result's
`feature_id` type no longer matches the declared type, so `output.Reference()`
aborts with an internal error:

```
INTERNAL Error: Vector::Reference used on vector of different type (source VARCHAR referenced BIGINT)
```

The per-sample path had a related latent bug: `Value::ToSQLString()` renders a
bare integer literal (`100`) that binds as `INTEGER`, so a `BIGINT` `sample_id`
column mismatched its declared type and crashed the same way (`source BIGINT
referenced INTEGER`). This made `woltka_ogu` unable to consume alignment output
that the alignment functions themselves happily produce.

## Fix

- **`feature_id` inherits `reference`'s storage type.** The bind probe now
  selects `reference` natively and its type is resolved **by column name** from
  the probe result (not a positional index, so a future edit to the probe's
  select list can't silently pick the wrong column). `reference` is validated
  against the shared id-type set via `IsAllowedIdType` / `AllowedIdTypeList`,
  throwing a clean `BinderException` for anything outside `VARCHAR/BIGINT/UUID`
  — mirroring `alignment_slice`.
- **`sample_id` type is enforced with a `CAST`.** `RunSampleAggregation` wraps
  the inlined sample literal in `CAST(... AS <sample_id_type>)`, so the
  projected column matches the declared type for every `sample_id` type
  (`BIGINT`, `DECIMAL`, ...), not just those whose `ToSQLString()`
  self-annotates (`UUID`, `TIMESTAMP`).
- **`sequence_id_field`** already tolerated any type (it's only an internal
  grouping key, never surfaced) — covered by tests for regression safety.

## Behavior change

`reference` is now restricted to `VARCHAR/BIGINT/UUID` with a clean bind-time
error. Previously any type castable to `VARCHAR` was accepted at the probe but
then crashed at execution for non-`VARCHAR` types (only `VARCHAR` actually
worked). Real SAM/alignment references are always in the id-type set, so this
is a strict improvement (clean error instead of an internal crash).

## Tests

Added an id-type-preservation section to `test/sql/woltka.test` (red before the
fix, green after): `BIGINT`/`UUID` `feature_id`, `BIGINT`/`UUID`
`sequence_id_field`, `BIGINT`/`UUID` `sample_id`, a combined
`BIGINT`-reference-and-`sample_id` case, and a bind-time rejection of a
non-identifier (`DOUBLE`) reference. `typeof()` assertions lock the output
types.

- SQL: `test/sql/woltka.test` — All tests passed (202 assertions).
- C++ unit tests: 1179 passed / 1 skipped.
- `make format-check`: clean.

## Docs

`docs/analysis-functions.md` updated to document that `feature_id` preserves the
`reference` storage type and that non-identifier reference types are rejected at
bind time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)