### PR TITLE
fix(wasm): unblock UniFrac in WASM by pinning the rust-glue toolchain

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -50,9 +50,11 @@ jobs:
       # On pull_request also exclude windows_amd64_mingw and wasm_eh — Windows
       # and WASM build/verify only on push to main/v1.5-variegata/tags so
       # release candidates still cover them, while PRs only pay for Linux + macOS.
-      #exclude_archs: ${{ github.event_name == 'pull_request' && 'windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;wasm_eh;wasm_mvp;wasm_threads' || 'windows_amd64_rtools;windows_amd64;osx_amd64;wasm_mvp;wasm_threads' }}
-      # temporarily disable windows and wasm builds entirely
-      exclude_archs: ${{ 'windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;wasm_eh;wasm_mvp;wasm_threads' }}
+      # WASM (wasm_eh) is an expensive build, so it runs ONLY on tag pushes —
+      # excluded on branch pushes and PRs. Windows (all variants) + osx_amd64 +
+      # wasm_mvp/wasm_threads stay excluded everywhere (broken / not shipped).
+      # Tag builds drop wasm_eh from the exclude list so release artifacts carry it.
+      exclude_archs: ${{ startsWith(github.ref, 'refs/tags/') && 'windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_threads' || 'windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;wasm_eh;wasm_mvp;wasm_threads' }}
 
   test-with-bowtie2:
     name: Test with Bowtie2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -895,6 +895,19 @@ endif()
 find_program(CARGO cargo REQUIRED)
 message(STATUS "Found cargo: ${CARGO}")
 
+# emsdk 3.1.71 (the version DuckDB v1.5.4 pins for its WASM build) ships
+# binaryen v120, which predates the `bulk-memory-opt` and
+# `call-indirect-overlong` target-features that newer rustc/LLVM (>= LLVM 20,
+# i.e. Rust >= 1.87) stamp into wasm objects. At link time emcc forwards those
+# features to wasm-opt, and the older binaryen aborts with
+# "Unknown option '--enable-bulk-memory-opt'" — which builds the C++ extension
+# to 100% and then fails linking the Rust glue. Pin the glue's wasm cargo build
+# to an LLVM-19-era toolchain so the emitted objects stay within emsdk 3.1.71's
+# binaryen feature set. Matches the CI wasm-load job's `rust-toolchain@1.86.0`.
+# Override only if you have verified a different toolchain against emsdk 3.1.71.
+set(MIINT_WASM_RUST_TOOLCHAIN "1.86.0" CACHE STRING
+    "Rust toolchain used to cross-compile the rust glue for WASM (emsdk 3.1.71 binaryen compat)")
+
 set(GLUE_LIB_NAME "libmiint_rust_glue.a")
 set(GLUE_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR}/miint_rust_glue_target)
 
@@ -902,12 +915,33 @@ set(GLUE_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR}/miint_rust_glue_target)
 set(GLUE_CARGO_TARGET_FLAG "")
 set(GLUE_LIB_SUBDIR "release")
 set(GLUE_CONFIGURE_CMD "")
+# Rust toolchain to run the glue build under (empty = the default toolchain).
+# Set for EMSCRIPTEN so cargo emits binaryen-compatible objects (see
+# MIINT_WASM_RUST_TOOLCHAIN above); propagated to the build via RUSTUP_TOOLCHAIN.
+set(GLUE_RUSTUP_TOOLCHAIN "")
 if(EMSCRIPTEN)
     find_program(RUSTUP rustup)
     set(GLUE_CARGO_TARGET_FLAG "--target" "wasm32-unknown-emscripten")
     set(GLUE_LIB_SUBDIR "wasm32-unknown-emscripten/release")
     if(RUSTUP)
-        set(GLUE_CONFIGURE_CMD ${RUSTUP} target add wasm32-unknown-emscripten)
+        # Idempotently ensure the pinned toolchain + wasm target are installed,
+        # then build cargo under it (RUSTUP_TOOLCHAIN, set in GLUE_BUILD_ENV).
+        # Bracket-argument ([=[ ]=]) so CMake does NOT expand ${ver} — the shell
+        # must see it verbatim at build time.
+        set(GLUE_WASM_RUST_PIN_SH ${CMAKE_CURRENT_BINARY_DIR}/glue_wasm_rust_pin.sh)
+        file(WRITE ${GLUE_WASM_RUST_PIN_SH}
+[=[#!/bin/sh
+# Pin the miint rust-glue WASM build to an emsdk-3.1.71-compatible toolchain.
+set -e
+ver="$1"
+if ! rustup toolchain list | grep -q "^${ver}"; then
+    rustup toolchain install "${ver}" --profile minimal
+fi
+rustup target add --toolchain "${ver}" wasm32-unknown-emscripten
+]=])
+        set(GLUE_CONFIGURE_CMD sh ${GLUE_WASM_RUST_PIN_SH} ${MIINT_WASM_RUST_TOOLCHAIN})
+        set(GLUE_RUSTUP_TOOLCHAIN ${MIINT_WASM_RUST_TOOLCHAIN})
+        message(STATUS "Rust glue: pinning WASM build to toolchain ${MIINT_WASM_RUST_TOOLCHAIN} (emsdk 3.1.71 binaryen compat)")
     endif()
     message(STATUS "Rust glue cross-compiling for wasm32-unknown-emscripten")
 elseif(WIN32)
@@ -983,9 +1017,17 @@ if(WIN32 AND MINGW)
     list(APPEND GLUE_RUSTFLAGS_LIST "-C" "link-arg=-L${GLUE_MINGW_STUB_DIR}")
 endif()
 
+set(GLUE_ENV_ARGS "")
 if(GLUE_RUSTFLAGS_LIST)
     string(JOIN " " GLUE_RUSTFLAGS_STR ${GLUE_RUSTFLAGS_LIST})
-    set(GLUE_BUILD_ENV ${CMAKE_COMMAND} -E env "RUSTFLAGS=${GLUE_RUSTFLAGS_STR}")
+    list(APPEND GLUE_ENV_ARGS "RUSTFLAGS=${GLUE_RUSTFLAGS_STR}")
+endif()
+if(GLUE_RUSTUP_TOOLCHAIN)
+    # Force cargo (the rustup shim) onto the pinned toolchain for this build.
+    list(APPEND GLUE_ENV_ARGS "RUSTUP_TOOLCHAIN=${GLUE_RUSTUP_TOOLCHAIN}")
+endif()
+if(GLUE_ENV_ARGS)
+    set(GLUE_BUILD_ENV ${CMAKE_COMMAND} -E env ${GLUE_ENV_ARGS})
 else()
     set(GLUE_BUILD_ENV)
 endif()

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -145,7 +145,7 @@ Pass these to CMake via `EXT_FLAGS` (e.g. `EXT_FLAGS="-DMIINT_ENABLE_UNIFRAC=OFF
 | `MIINT_ENABLE_GPL_BOUNDARY` | `ON` | gpl-boundary subsystem (process pipes + Arrow IPC over POSIX shm) |
 | `MIINT_ENABLE_UNIFRAC` | `ON` | UniFrac (PCoA / PERMANOVA / Faith PD) — requires libomp on macOS |
 
-WASM (Emscripten) builds automatically disable HDF5, SortMeRNA, sylph, gpl-boundary, MAFFT, and UniFrac.
+WASM (Emscripten) builds automatically disable HDF5, SortMeRNA, sylph, gpl-boundary, vsearch, and libcurl. UniFrac and MAFFT remain enabled — UniFrac builds against a dedicated single-threaded WASM target (`libssu_wasm.a` / `libskbb_wasm.a`, Eigen-backed, OpenMP stubbed out).
 
 ### Build steps
 Now to build the extension, run:

--- a/scripts/test_wasm_extension.c
+++ b/scripts/test_wasm_extension.c
@@ -74,6 +74,50 @@ int main(int argc, char **argv) {
     printf("\n3. miint_version()\n");
     if (run_query_check(conn, "SELECT miint_version()", NULL)) return 1;
 
+    // Test UniFrac end-to-end: build a feature table + phylogeny inline (no
+    // read_biom/read_newick — HDF5 and the filesystem are unavailable under
+    // WASM) and compute Faith's phylogenetic diversity. Expected values are
+    // hand-checked against test/sql/unifrac_faith_pd.test for the gg_otu tree
+    // ((GG_OTU_1:0.1,GG_OTU_2:0.2)Int1:0.3,(GG_OTU_3:0.4,(GG_OTU_4:0.5,GG_OTU_5:0.6)Int2:0.7)Int3:0.8);
+    //   Sample1 {OTU_2,OTU_4}      = 0.2+0.3+0.5+0.7+0.8 = 2.5
+    //   Sample3 {OTU_1,OTU_3,OTU_4,OTU_5} = 0.1+0.3+0.4+0.5+0.6+0.7+0.8 = 3.4
+    printf("\n4. UniFrac faith_pd (end-to-end libssu compute)\n");
+    const char *setup[] = {
+        "CREATE TABLE observations(sample_id VARCHAR, feature_id VARCHAR, value DOUBLE)",
+        "INSERT INTO observations VALUES "
+        "('Sample1','GG_OTU_2',1),('Sample1','GG_OTU_4',1),"
+        "('Sample2','GG_OTU_2',1),('Sample2','GG_OTU_4',1),('Sample2','GG_OTU_5',1),"
+        "('Sample3','GG_OTU_1',1),('Sample3','GG_OTU_3',1),('Sample3','GG_OTU_4',1),('Sample3','GG_OTU_5',1),"
+        "('Sample4','GG_OTU_2',1),('Sample4','GG_OTU_3',1),"
+        "('Sample5','GG_OTU_2',1),"
+        "('Sample6','GG_OTU_2',1),('Sample6','GG_OTU_3',1),('Sample6','GG_OTU_4',1)",
+        "CREATE TABLE tree(node_index BIGINT, name VARCHAR, branch_length DOUBLE, edge_id BIGINT, "
+        "parent_index BIGINT, is_tip BOOLEAN)",
+        "INSERT INTO tree VALUES "
+        "(0,'GG_OTU_1',0.1,NULL,2,true),(1,'GG_OTU_2',0.2,NULL,2,true),(2,'Int1',0.3,NULL,8,false),"
+        "(3,'GG_OTU_3',0.4,NULL,7,true),(4,'GG_OTU_4',0.5,NULL,6,true),(5,'GG_OTU_5',0.6,NULL,6,true),"
+        "(6,'Int2',0.7,NULL,7,false),(7,'Int3',0.8,NULL,8,false),(8,'',NULL,NULL,NULL,false)",
+    };
+    for (size_t i = 0; i < sizeof(setup) / sizeof(setup[0]); i++) {
+        if (duckdb_query(conn, setup[i], &result) != DuckDBSuccess) {
+            fprintf(stderr, "  FAIL (setup): %s\n", duckdb_result_error(&result));
+            duckdb_destroy_result(&result);
+            return 1;
+        }
+        duckdb_destroy_result(&result);
+    }
+    // round() to 4dp so the check is robust to floating-point summation noise.
+    if (run_query_check(conn,
+                        "SELECT round(faith_pd, 4) FROM unifrac_faith_pd('observations', 'tree') "
+                        "WHERE sample_id = 'Sample1'",
+                        "2.5"))
+        return 1;
+    if (run_query_check(conn,
+                        "SELECT round(faith_pd, 4) FROM unifrac_faith_pd('observations', 'tree') "
+                        "WHERE sample_id = 'Sample3'",
+                        "3.4"))
+        return 1;
+
     printf("\n=== All tests passed ===\n");
 
     duckdb_disconnect(&conn);


### PR DESCRIPTION
## Summary

UniFrac was reported as "not working in WASM." Investigation showed the **C++ extension (UniFrac included) already compiles and links** for `wasm_eh` — the build only died at the final `wasm-opt` step.

**Root cause (not the extension code):** the rust glue (`rype`), built with the default toolchain (Rust ≥ 1.87 / LLVM ≥ 20), stamps the `bulk-memory-opt` and `call-indirect-overlong` target-features into its wasm objects. `emcc` forwards those to `wasm-opt`, and **emsdk 3.1.71's binaryen (v120 — the emsdk DuckDB v1.5.4 pins)** rejects them with `Unknown option '--enable-bulk-memory-opt'`.

Matching emsdk 3.1.71 isn't just a build detail — the extension is a side module loaded into a duckdb-wasm main module DuckDB built with that same emsdk, so the toolchain must stay ABI/feature-compatible.

## Changes

- **`CMakeLists.txt`** — pin the WASM rust-glue build to an LLVM-19-era toolchain (`1.86.0`, matching the CI wasm-load job) via `RUSTUP_TOOLCHAIN`; auto-install the toolchain + wasm target idempotently. **Scoped to `EMSCRIPTEN` only — native builds are unchanged.** Overridable via `MIINT_WASM_RUST_TOOLCHAIN` (tracks DuckDB's emsdk; bump/drop when DuckDB bumps its wasm toolchain).
- **`scripts/test_wasm_extension.c`** — the headless load test now exercises `unifrac_faith_pd` end-to-end (was load + `miint_version()` only), so re-enabled CI actually guards UniFrac.
- **`.github/workflows/MainDistributionPipeline.yml`** — re-enable the `wasm_eh` build **on tag pushes only** (expensive job; excluded on branches/PRs).
- **`docs/installation.md`** — correct the stale claim that WASM disables UniFrac/MAFFT (it does not; contradicted `docs/internals/embedded-tools.md`).

## Verification

Built `miint.duckdb_extension.wasm` (emsdk 3.1.71) and ran the headless node harness against a duckdb-wasm core built from the same source:

```
2. Loading miint extension — OK
3. miint_version() — OK
4. UniFrac faith_pd (end-to-end libssu compute)
   OK: 2.5   ← Sample1 Faith's PD, computed in WASM
   OK: 3.4   ← Sample3 Faith's PD, computed in WASM
=== All tests passed ===
```

Also confirmed: static import check passes (loadable side module, `miint_duckdb_cpp_init` exported, 223 UniFrac symbols), the CMake pin injects `RUSTUP_TOOLCHAIN=1.86.0` into the generated cargo command (builds green even with default Rust 1.96 active), and `make format-check` passes.

## Notes

- The WASM build minutes only apply on **tags**, per request.
- `ext/miint-rust-glue/Cargo.lock` has a pre-existing working-tree modification (an unrelated arrow 57→59 bump) that predates this work; it is intentionally **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)