### PR TITLE
feat(diversity): unifrac_distances (condensed COO) + suite-wide sample-ID parity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1333,7 +1333,8 @@ if(MIINT_ENABLE_UNIFRAC)
         src/unifrac_function_common.cpp
         src/unifrac_pcoa_function.cpp
         src/unifrac_permanova_function.cpp
-        src/unifrac_faith_pd_function.cpp)
+        src/unifrac_faith_pd_function.cpp
+        src/unifrac_distances_function.cpp)
 endif()
 
 build_static_extension(${TARGET_NAME} ${EXTENSION_SOURCES})
@@ -1813,6 +1814,7 @@ if(MIINT_ENABLE_UNIFRAC)
         test/cpp/test_UnifracBptree.cpp
         test/cpp/test_UnifracMetadata.cpp
         test/cpp/test_UnifracDistance.cpp
+        test/cpp/test_UnifracCondensed.cpp
         test/cpp/test_UnifracSubsampleBridge.cpp)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1815,6 +1815,7 @@ if(MIINT_ENABLE_UNIFRAC)
         test/cpp/test_UnifracMetadata.cpp
         test/cpp/test_UnifracDistance.cpp
         test/cpp/test_UnifracCondensed.cpp
+        test/cpp/test_UnifracDenseDistance.cpp
         test/cpp/test_UnifracSubsampleBridge.cpp)
 endif()
 

--- a/docs/diversity.md
+++ b/docs/diversity.md
@@ -12,6 +12,8 @@ Methods to estimate alpha and beta diversity, and supporting statistics.
 - [Rarefaction](#rarefaction) - Rarefaction detail with UniFrac and Faith PD.
 - [UniFrac distances](#unifrac-distances) - Condensed (pairwise) UniFrac distances in long form
 - [Beta-distance macros](#beta-distance-macros) - within/between-group distributions and k-nearest-neighbors over a distance table
+- [PCoA (from a distance table)](#pcoa-from-a-distance-table) - metric-agnostic PCoA over any condensed distance table
+- [PERMANOVA (from a distance table)](#permanova-from-a-distance-table) - metric-agnostic PERMANOVA over any condensed distance table
 - [UniFrac PCoA](#unifrac-pcoa) - UniFrac distance + Principal Coordinates Analysis
 - [UniFrac PERMANOVA](#unifrac-permanova) - UniFrac distance + PERMANOVA pseudo-F + p-value
 - [Faith PD](#faith-pd) - Faith's phylogenetic diversity per sample
@@ -203,6 +205,75 @@ FROM dm_weighted x JOIN dm_unweighted y USING (sample_a, sample_b);
 ```
 
 The permutation-based Mantel **p-value** is not yet implemented; it is tracked in [issue #160](https://github.com/the-miint/duckdb-miint/issues/160).
+
+---
+
+### PCoA (from a distance table)
+
+`pcoa(distances, ...)` runs Principal Coordinates Analysis over **any** condensed distance table with columns `(sample_a, sample_b, distance)` — the [`unifrac_distances`](#unifrac-distances) output, a [beta-distance](#beta-distance-macros) relation, or a precomputed Bray-Curtis / Jaccard / Euclidean table you built yourself. It is **metric-agnostic**: the ordination is decoupled from UniFrac. [`unifrac_pcoa`](#unifrac-pcoa) remains the end-to-end convenience wrapper (feature table + tree → coordinates); `pcoa` is the same ordination over a distance matrix you already have.
+
+It takes a relation *name* (a table or view), so materialize the distances first:
+
+```sql
+CREATE TABLE dm AS SELECT sample_a, sample_b, distance
+    FROM unifrac_distances('observations', 'tree', seed := 42);
+
+SELECT * FROM pcoa('dm', n_dims := 3, seed := 42);
+```
+
+**Parameters:**
+- `distances` (VARCHAR): name of the condensed distance relation exposing `(sample_a, sample_b, distance)`
+- `n_dims` (INTEGER, default 3): number of PCoA axes to compute; must be `≤ n_samples - 1`
+- `seed` (INTEGER, default -1): FSVD randomization seed; `-1` = unseeded
+- `threads` (INTEGER, default 0): OpenMP threads; `0` follows DuckDB's thread count
+
+**Output schema:** identical to [`unifrac_pcoa`](#unifrac-pcoa) — `(iteration, sample_id, axis, coordinate, eigenvalue, proportion_explained)`. `iteration` is always `0` (kept for schema parity; a distance table is a single fixed matrix, so there is no subsampling). `sample_id` mirrors the input `sample_a` type — see [Sample identifier types](#sample-identifier-types).
+
+**Behavior:**
+- **Input shape:** distinct ids are collected from *both* `sample_a` and `sample_b`, sorted lexicographically, and assembled into a dense symmetric matrix with a zero diagonal. `sample_a` and `sample_b` must resolve to the same output type (a BIGINT/VARCHAR mix is rejected at bind).
+- <a name="distance-table-completeness"></a>**Completeness (fail loud):** the matrix must be complete — every unordered pair present exactly once. A missing pair, a negative or non-finite distance, a nonzero self-distance, or a pair given two conflicting values is an error that names the offending pair. Rows with a NULL `sample_a`/`sample_b` are skipped; a NULL/NaN `distance` is treated as "not provided" (its ids are still recorded, so a sample whose every distance is NULL/NaN surfaces as an incompleteness error rather than silently vanishing). `unifrac_distances` always emits the full triangle, so its output is complete by construction; a hand-built table you must complete yourself.
+- **Equivalence:** `pcoa` over `unifrac_distances(obs, tree, variant := v, seed := s)` reproduces `unifrac_pcoa(obs, tree, variant := v, n_dims := d, seed := s)` — same matrix, same FSVD call, same seed. Coordinates match up to axis sign (compare `abs(coordinate)`) within the fp32 tolerance noted under [Reproducibility](#reproducibility).
+- **Fewer than two samples**, or **`n_dims > n_samples - 1`**: an error (an ordination is undefined).
+
+**Example:**
+
+```sql
+-- Bray-Curtis PCoA with no tree involved: build the distance table however you
+-- like (here a placeholder), then ordinate it.
+CREATE TABLE bc AS SELECT sample_a, sample_b, distance FROM my_bray_curtis_distances;
+SELECT sample_id, axis, coordinate
+FROM pcoa('bc', n_dims := 2, seed := 42)
+ORDER BY axis, sample_id;
+```
+
+---
+
+### PERMANOVA (from a distance table)
+
+`permanova(distances, metadata, ...)` runs PERMANOVA (pseudo-F + a permutation p-value) over any condensed distance table and a wide-form metadata relation. Like [`pcoa`](#pcoa-from-a-distance-table) it is **metric-agnostic** — the omnibus test is decoupled from UniFrac. [`unifrac_permanova`](#unifrac-permanova) remains the end-to-end wrapper.
+
+```sql
+CREATE TABLE dm AS SELECT sample_a, sample_b, distance
+    FROM unifrac_distances('observations', 'tree', seed := 42);
+
+SELECT * FROM permanova('dm', 'metadata',
+    variables := ['body_site'], n_permutations := 999, seed := 42);
+```
+
+**Parameters:**
+- `distances` (VARCHAR): name of the condensed distance relation exposing `(sample_a, sample_b, distance)`
+- `metadata` (VARCHAR): name of the wide-form metadata relation — a `sample_id` column plus one column per variable (see [Metadata](#metadata))
+- `n_permutations` (INTEGER, default 999): permutations for the p-value
+- `variables` (VARCHAR[], default all non-`sample_id` columns): metadata columns to test
+- `seed` (INTEGER, default -1): permutation seed; `-1` = unseeded
+- `threads` (INTEGER, default 0): OpenMP threads; `0` follows DuckDB's thread count
+
+**Output schema:** identical to [`unifrac_permanova`](#unifrac-permanova) — `(iteration, variable, n_groups, f_stat, p_value, n_permutations)`. `iteration` is always `0`. There is no `sample_id` output, so no id-type mirroring.
+
+**Behavior:**
+- **Input shape / completeness:** the same dense-matrix construction and [completeness requirement](#distance-table-completeness) as `pcoa`.
+- **Metadata alignment:** every sample in the distance matrix must have a row for each tested variable, else an error naming the missing sample and variable; metadata samples not present in the distance matrix are ignored. A NULL metadata value is treated as an (empty-string) group value — filter the metadata first if you want NULL samples dropped.
+- **Equivalence:** `permanova` over `unifrac_distances(obs, tree, variant := v, seed := s)` reproduces `unifrac_permanova(obs, tree, metadata, variant := v, seed := s)` under the same `seed` and `n_permutations`: `p_value` is byte-identical (same permutations) and `f_stat` matches within `1e-5` (fp32; see the [reproducibility note](#reproducibility)).
 
 ---
 

--- a/docs/diversity.md
+++ b/docs/diversity.md
@@ -7,8 +7,11 @@ Methods to estimate alpha and beta diversity, and supporting statistics.
 - [Feature table](#feature-table) - Feature table expectations.
 - [Tree](#tree) - Tree expectations.
 - [Metadata](#metadata) - Metadata expectations.
+- [Sample identifier types](#sample-identifier-types) - How VARCHAR/BIGINT/UUID sample ids are handled.
 - [UniFrac algorithm variants](#unifrac-algorithm-variants) - Detail on different UniFrac algorithms and how to specify them.
 - [Rarefaction](#rarefaction) - Rarefaction detail with UniFrac and Faith PD.
+- [UniFrac distances](#unifrac-distances) - Condensed (pairwise) UniFrac distances in long form
+- [Beta-distance macros](#beta-distance-macros) - within/between-group distributions and k-nearest-neighbors over a distance table
 - [UniFrac PCoA](#unifrac-pcoa) - UniFrac distance + Principal Coordinates Analysis
 - [UniFrac PERMANOVA](#unifrac-permanova) - UniFrac distance + PERMANOVA pseudo-F + p-value
 - [Faith PD](#faith-pd) - Faith's phylogenetic diversity per sample
@@ -45,9 +48,13 @@ CREATE TABLE metadata AS SELECT * FROM read_csv('data/unifrac/small_metadata.csv
 
 Samples appearing in the metadata but not in the feature-table are silently ignored. Samples missing from the metadata fail loudly with an error naming both the missing sample and the variable.
 
+### Sample identifier types
+
+The feature table's `sample_id` column may be `VARCHAR`, `BIGINT`, or `UUID` (any other type is accepted and read as text). `unifrac_distances`, `unifrac_pcoa`, and `unifrac_faith_pd` **mirror the input `sample_id` type onto their output identifier columns** — `BIGINT → BIGINT`, `UUID → UUID`, otherwise `VARCHAR` — so results join back to typed metadata without a cast (parity with `align_minimap2`). `unifrac_permanova` emits no per-sample identifier column, so this does not apply to it.
+
 ### UniFrac algorithm variants 
 
-`unifrac_pcoa` and `unifrac_permanova` accept the following `variant` values (passed unquoted to libssu, with `_fp32` appended internally):
+`unifrac_distances`, `unifrac_pcoa`, and `unifrac_permanova` accept the following `variant` values (passed unquoted to libssu, with `_fp32` appended internally):
 
 | Variant | Description |
 |---|---|
@@ -59,12 +66,143 @@ Samples appearing in the metadata but not in the feature-table are silently igno
 
 ### Rarefaction
 
-All three functions accept `subsample_depth`, `subsample_with_replacement`, `n_subsamples`, and `seed` parameters.
+`unifrac_distances`, `unifrac_pcoa`, `unifrac_permanova`, and `unifrac_faith_pd` all accept `subsample_depth`, `subsample_with_replacement`, `n_subsamples`, and `seed` parameters.
 
 - `subsample_depth := 0` (default): no subsampling; iterations would be identical so `n_subsamples > 1` is rejected at bind.
 - `subsample_depth > 0`: libssu rarefies every sample to exactly `subsample_depth` total counts. **Samples whose total count is below the depth are dropped** from the result; depending on the function's invariants this can also cause a bind-time error (e.g., `unifrac_pcoa` requires `n_dims ≤ n_samples - 1` after subsampling).
 - `subsample_with_replacement := true` uses multinomial sampling; the default `false` uses permutation without replacement.
 - `seed := -1` (default) uses system entropy; any `seed >= 0` is deterministic. Per-iteration seed is `seed + iteration_index`; bind rejects `seed + n_subsamples - 1 > INT_MAX`.
+
+---
+
+### UniFrac distances
+
+Compute the UniFrac distance matrix and return it in **condensed long form** — one row per unordered sample pair, `(iteration, sample_a, sample_b, distance)`. This is the primitive underneath [PCoA](#unifrac-pcoa) and [PERMANOVA](#unifrac-permanova); exposing it directly lets you build within/between-group distributions, k-nearest-neighbors, and correlations between distance matrices with ordinary SQL (see [Beta-distance macros](#beta-distance-macros)).
+
+```sql
+SELECT * FROM unifrac_distances('observations', 'tree',
+    variant := 'weighted_normalized',
+    variance_adjust := false,
+    alpha := 1.0,
+    bypass_tips := false,
+    normalize_sample_counts := true,
+    subsample_depth := 0,
+    subsample_with_replacement := false,
+    n_subsamples := 1,
+    seed := -1);
+```
+
+**Parameters:**
+- `observations` (VARCHAR): name of the feature-table relation
+- `tree` (VARCHAR): name of the tree relation
+- `variant` (VARCHAR, default `'weighted_normalized'`): one of the [variants](#unifrac-algorithm-variants) above
+- `variance_adjust` (BOOLEAN, default false): apply Chang & Liu's variance adjustment
+- `alpha` (DOUBLE, default 1.0): GUniFrac alpha, only relevant when `variant := 'generalized'`
+- `bypass_tips` (BOOLEAN, default false): skip tip-level contributions (≈50% faster, mildly different result)
+- `normalize_sample_counts` (BOOLEAN, default true): normalize each sample to relative abundances before computing distances
+- `subsample_depth`, `subsample_with_replacement`, `n_subsamples`, `seed`: see [Rarefaction](#rarefaction)
+
+**Output schema:**
+- `iteration` (INTEGER): 0-indexed iteration; constant when `n_subsamples = 1`
+- `sample_a`, `sample_b` (mirror input type — see [Sample identifier types](#sample-identifier-types)): the two samples of the pair
+- `distance` (DOUBLE): the UniFrac distance between them (fp32-computed, widened to DOUBLE)
+
+**Behavior:**
+- **Condensed / upper triangle:** each unordered pair is emitted exactly once, no self-pairs. Pairs are ordered by the canonical *lexical* sample-id form, so `sample_a < sample_b` holds for VARCHAR; for BIGINT/UUID the direction follows the text form (e.g. `10` may sort before `2`) — uniqueness holds regardless.
+- **Streaming:** the full N×N matrix is held in memory once (O(N²) — intrinsic to the distance computation), but the pairs are streamed out, so the O(N²) *result rows* are never all materialized at once.
+- **Fewer than two samples:** an empty result (the condensed form of a <2-sample matrix has no pairs). This differs from `unifrac_pcoa`, which errors — an ordination is undefined for <2 samples, whereas "no pairs" is a valid distance answer.
+- **Rarefaction:** with `subsample_depth > 0`, samples whose total count falls below the depth are dropped from that iteration; each iteration emits its own triangle, tagged by `iteration`.
+- **Reproducibility:** same `seed` → same distances at fp32 precision (compare with a `1e-5` tolerance; see the [PCoA reproducibility note](#reproducibility)).
+
+> **Output size:** the result has `N·(N-1)/2` rows per iteration — ~50M rows at 10k samples, growing quadratically. Aggregate or filter it (the macros below, a `GROUP BY`, a `WHERE`) rather than `SELECT *`-ing it into a client.
+
+**Examples:**
+
+```sql
+-- Condensed distances for the whole table
+SELECT * FROM unifrac_distances('observations', 'tree', seed := 42)
+ORDER BY sample_a, sample_b;
+
+-- Within/between-group distribution via a plain SQL join to metadata
+SELECT CASE WHEN a.body_site = b.body_site THEN 'within' ELSE 'between' END AS comparison,
+       count(*) AS n, avg(distance) AS mean,
+       quantile_cont(distance, [0.25, 0.5, 0.75]) AS quartiles
+FROM unifrac_distances('observations', 'tree') d
+JOIN metadata a ON d.sample_a = a.sample_id
+JOIN metadata b ON d.sample_b = b.sample_id
+GROUP BY comparison;
+```
+
+---
+
+### Beta-distance macros
+
+Three SQL macros operate over any **condensed distance table** with columns `(sample_a, sample_b, distance)` — the [`unifrac_distances`](#unifrac-distances) output, or any distance relation you build yourself. They take relation *names* (a table or view), following the `query_table` convention, so materialize the distances first:
+
+```sql
+-- Macros take a relation name, not a table function call
+CREATE TABLE dm AS SELECT * FROM unifrac_distances('observations', 'tree', seed := 42);
+```
+
+> **One iteration at a time:** these macros are `iteration`-blind. If the distance table carries multiple iterations (`n_subsamples > 1`), filter to a single iteration first (e.g. build `dm` with `n_subsamples := 1`, or `... WHERE iteration = 0`) — otherwise distributions and neighbor rankings pool across bootstrap replicates. Pass the distances **as a materialized table**, not a view over `unifrac_distances`, since it is referenced more than once.
+
+#### `beta_group_distances(distances, groups)`
+
+Labels each pair within- or between-group. `groups` is a `(sample_id, grouping)` relation — reduce your metadata to the one grouping column of interest:
+
+```sql
+CREATE VIEW groups AS SELECT sample_id, body_site AS grouping FROM metadata;
+
+-- Aggregated within/between distribution (the group-cohesion question)
+SELECT comparison, count(*) AS n,
+       quantile_cont(distance, [0.25, 0.5, 0.75]) AS quartiles
+FROM beta_group_distances(dm, groups)
+GROUP BY comparison ORDER BY comparison;
+```
+
+Returns `(sample_a, sample_b, distance, group_a, group_b, comparison)` where `comparison` is `'within'` when `group_a = group_b` else `'between'`. Notes: `sample_id` must be unique in `groups` (a duplicate fans the joins out and inflates counts); a pair whose either endpoint is absent from `groups` is dropped; two NULL-group samples are labeled `'between'` (SQL `NULL = NULL` is NULL).
+
+**Per-group-vs-rest:** the condensed table holds each pair once, so a naive `GROUP BY group_a` attributes a between-pair only to `sample_a`'s group. To get, for each group, its within-group distances and its distances to every other group, attribute each *between* pair to **both** its groups but each *within* pair to its group only once (both endpoints share it):
+
+```sql
+WITH bg AS (SELECT * FROM beta_group_distances(dm, groups))
+SELECT grp, comparison, count(*) AS n, avg(distance) AS mean FROM (
+    -- within pairs: count once for their (single) group
+    SELECT group_a AS grp, comparison, distance FROM bg WHERE comparison = 'within'
+    UNION ALL
+    -- between pairs: count once for each of the two groups
+    SELECT group_a AS grp, comparison, distance FROM bg WHERE comparison = 'between'
+    UNION ALL
+    SELECT group_b AS grp, comparison, distance FROM bg WHERE comparison = 'between'
+) GROUP BY grp, comparison ORDER BY grp, comparison;
+```
+
+#### `beta_knn(distances, k)`
+
+The `k` nearest neighbors of every sample (both orientations of the condensed table are considered). Returns `(sample_id, neighbor, distance, rank)`, `rank` in `1..k`, ties broken by neighbor id:
+
+```sql
+SELECT * FROM beta_knn(dm, 5) ORDER BY sample_id, rank;
+```
+
+#### `beta_knn_from_sample(distances, k, source)`
+
+The `k` samples nearest one `source` sample. Returns `(neighbor, distance)`, nearest first:
+
+```sql
+SELECT * FROM beta_knn_from_sample(dm, 10, 'Sample1');
+```
+
+#### Correlating two distance matrices (Mantel)
+
+The Mantel **r-statistic** — the correlation between two distance matrices over the same samples — is a one-liner over two condensed tables (both must be over the same sample set, so their `(sample_a, sample_b)` pairs align):
+
+```sql
+SELECT corr(x.distance, y.distance) AS mantel_r
+FROM dm_weighted x JOIN dm_unweighted y USING (sample_a, sample_b);
+```
+
+The permutation-based Mantel **p-value** is not yet implemented; it is tracked in [issue #160](https://github.com/the-miint/duckdb-miint/issues/160).
 
 ---
 
@@ -99,7 +237,7 @@ SELECT * FROM unifrac_pcoa('observations', 'tree',
 
 **Output schema:**
 - `iteration` (INTEGER): 0-indexed iteration; constant when `n_subsamples = 1`
-- `sample_id` (VARCHAR): sample identifier (post-subsample ordering)
+- `sample_id` (mirrors input type — see [Sample identifier types](#sample-identifier-types)): sample identifier (post-subsample ordering)
 - `axis` (INTEGER): 0-indexed PCoA axis; `axis = 0` is the largest eigenvalue
 - `coordinate` (DOUBLE): the sample's coordinate on this axis
 - `eigenvalue` (DOUBLE): eigenvalue for this axis — **replicated across all samples within `(iteration, axis)`**
@@ -226,7 +364,7 @@ SELECT * FROM unifrac_faith_pd('observations', 'tree',
 
 **Output schema:**
 - `iteration` (INTEGER): 0-indexed iteration; always 0 when `subsample_depth = 0`
-- `sample_id` (VARCHAR): sample identifier
+- `sample_id` (mirrors input type — see [Sample identifier types](#sample-identifier-types)): sample identifier
 - `faith_pd` (DOUBLE): sum of branch lengths on the spanning subtree (non-negative)
 
 #### Behavior

--- a/docs/internals/embedded-tools.md
+++ b/docs/internals/embedded-tools.md
@@ -105,7 +105,7 @@ Run-time / conditional: `MIINT_USE_JEMALLOC` is set when DuckDB's jemalloc is li
 
 ### unifrac-binaries + scikit-bio-binaries (UniFrac analytics)
 
-Two coupled submodules implementing the UniFrac distance + Faith's PD + PERMANOVA + PCoA stack consumed by `unifrac_pcoa`, `unifrac_permanova`, and `unifrac_faith_pd`.
+Two coupled submodules implementing the UniFrac distance + Faith's PD + PERMANOVA + PCoA stack consumed by `unifrac_distances`, `unifrac_pcoa`, `unifrac_permanova`, and `unifrac_faith_pd`.
 
 - **Locations:**
   - `ext/unifrac-binaries/` — libssu (the UniFrac and Faith PD engine). Version captured via `git describe` → `UNIFRAC_GIT_VERSION`.

--- a/src/include/miint_macros.hpp
+++ b/src/include/miint_macros.hpp
@@ -884,6 +884,71 @@ const std::string TAXONOMY_LINEAGE = // NOLINT
     "    AS lineage "
     "FROM collapsed; ";
 
+// beta_group_distances(distances, groups)
+//
+// Labels each pair in a condensed distance table (e.g. unifrac_distances output:
+// sample_a, sample_b, distance) as within- or between-group by joining each side
+// to a (sample_id, grouping) relation. Returns the per-pair rows; aggregate with
+// GROUP BY comparison + quantile_cont/avg for the within/between distribution.
+//
+// Preconditions (documented, not enforced — pass clean inputs):
+//   - `distances` holds each unordered pair once. If it carries multiple
+//     `iteration`s (unifrac_distances with n_subsamples > 1), pre-filter to a
+//     single iteration first, or the distribution pools across bootstrap
+//     replicates. query_table() rejects subqueries, so filter into a table/view.
+//   - `sample_id` is unique in `groups`; a duplicate fans the two joins out and
+//     silently inflates the counts.
+//   - A pair whose either endpoint is absent from `groups` is dropped (inner join).
+//   - NULL grouping: `NULL = NULL` is NULL in SQL, so a pair of two NULL-group
+//     samples is labeled 'between', the same as genuinely different groups.
+//   - `groups` is referenced twice; pass a materialized table, not a view over an
+//     expensive query.
+const std::string BETA_GROUP_DISTANCES = // NOLINT
+    "CREATE OR REPLACE MACRO beta_group_distances(distances, groups) AS TABLE "
+    "SELECT d.sample_a, d.sample_b, d.distance, "
+    "       ga.grouping AS group_a, gb.grouping AS group_b, "
+    "       CASE WHEN ga.grouping = gb.grouping THEN 'within' ELSE 'between' END AS comparison "
+    "FROM query_table(distances) d "
+    "JOIN query_table(groups) ga ON d.sample_a = ga.sample_id "
+    "JOIN query_table(groups) gb ON d.sample_b = gb.sample_id; ";
+
+// beta_knn(distances, k)
+//
+// The k nearest neighbors of every sample over a condensed distance table. The
+// input holds each unordered pair once, so both orientations are unioned before
+// ranking. Returns (sample_id, neighbor, distance, rank), rank in 1..k. Ties are
+// broken by neighbor id (deterministic); k <= 0 yields no rows.
+//
+// If `distances` carries multiple `iteration`s (unifrac_distances with
+// n_subsamples > 1), pre-filter to a single iteration first, or neighbors are
+// ranked across all iterations together. `distances` is referenced twice, so pass
+// a materialized table, not a view over an expensive query.
+const std::string BETA_KNN = // NOLINT
+    "CREATE OR REPLACE MACRO beta_knn(distances, k) AS TABLE "
+    "SELECT sample_id, neighbor, distance, rank FROM ( "
+    "    SELECT sample_id, neighbor, distance, "
+    "           ROW_NUMBER() OVER (PARTITION BY sample_id ORDER BY distance, neighbor) AS rank "
+    "    FROM ( "
+    "        SELECT sample_a AS sample_id, sample_b AS neighbor, distance FROM query_table(distances) "
+    "        UNION ALL "
+    "        SELECT sample_b AS sample_id, sample_a AS neighbor, distance FROM query_table(distances) "
+    "    ) "
+    ") WHERE rank <= k; ";
+
+// beta_knn_from_sample(distances, k, source)
+//
+// The k samples nearest a single `source` sample over a condensed distance table,
+// checking both orientations. Returns (neighbor, distance) ordered nearest-first;
+// ties broken by neighbor id. An absent source yields no rows. Same
+// iteration/materialization caveats as beta_knn.
+const std::string BETA_KNN_FROM_SAMPLE = // NOLINT
+    "CREATE OR REPLACE MACRO beta_knn_from_sample(distances, k, source) AS TABLE "
+    "SELECT neighbor, distance FROM ( "
+    "    SELECT sample_b AS neighbor, distance FROM query_table(distances) WHERE sample_a = source "
+    "    UNION ALL "
+    "    SELECT sample_a AS neighbor, distance FROM query_table(distances) WHERE sample_b = source "
+    ") ORDER BY distance, neighbor LIMIT k; ";
+
 class MIINTMacros {
 public:
 	static void Register(ExtensionLoader &loader) {
@@ -961,6 +1026,10 @@ public:
 		register_macro(MZML_EXCLUDED_MS1MZ, "mzml_excluded_ms1mz");
 		register_macro(MZML_EXCLUDED_MS2PREC, "mzml_excluded_ms2prec");
 		register_macro(MZML_ISOTOPE_PATTERN, "mzml_isotope_pattern");
+
+		register_macro(BETA_GROUP_DISTANCES, "beta_group_distances");
+		register_macro(BETA_KNN, "beta_knn");
+		register_macro(BETA_KNN_FROM_SAMPLE, "beta_knn_from_sample");
 	}
 };
 

--- a/src/include/unifrac_condensed.hpp
+++ b/src/include/unifrac_condensed.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdint>
+
+namespace miint::unifrac {
+
+// Row-major strict-upper-triangle iterator over an n×n symmetric matrix.
+//
+// Yields index pairs (i, j) with 0 <= i < j < n, in order:
+//   (0,1), (0,2), ..., (0,n-1), (1,2), ..., (n-2,n-1)
+// i.e. the condensed form of a symmetric distance matrix (each unordered pair
+// once, diagonal excluded). Total n*(n-1)/2 pairs; for n < 2 there are none.
+//
+// A plain value type with no heap state, so it can be snapshotted and resumed
+// across DuckDB execute-chunk boundaries just by copying it — which is exactly
+// how unifrac_distances streams the upper triangle without materializing all
+// O(n²) rows at once.
+struct CondensedCursor {
+	uint32_t n = 0;
+	uint32_t i = 0;
+	uint32_t j = 1;
+
+	static CondensedCursor Begin(uint32_t n_samples) {
+		CondensedCursor c;
+		c.n = n_samples;
+		c.i = 0;
+		c.j = 1;
+		return c;
+	}
+
+	// True when no pairs remain. `i + 1 >= n` (rather than `i >= n - 1`) avoids
+	// unsigned underflow for n == 0.
+	bool done() const {
+		return n < 2 || i + 1 >= n;
+	}
+
+	// Advance to the next (i, j). Precondition: !done().
+	void advance() {
+		++j;
+		if (j >= n) {
+			++i;
+			j = i + 1;
+		}
+	}
+};
+
+} // namespace miint::unifrac

--- a/src/include/unifrac_dense_distance.hpp
+++ b/src/include/unifrac_dense_distance.hpp
@@ -1,0 +1,129 @@
+#pragma once
+//
+// Pure (DuckDB-free) construction of a dense UniFrac-style distance matrix from
+// a condensed COO distance table (the `sample_a, sample_b, distance` shape that
+// `unifrac_distances` emits, or any precomputed Bray-Curtis/Jaccard relation).
+//
+// Kept header-only and dependency-free so the Catch2 unit-test target links it
+// without the duckdb library — mirroring unifrac_condensed.hpp. The DuckDB-aware
+// reader (ReadDistanceTable, unifrac_function_common.cpp) resolves ids to
+// indices, then delegates the fill + validation here.
+
+#include <cmath>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace miint::unifrac {
+
+// A single off-diagonal distance, addressed by indices into a caller-owned,
+// lexicographically-sorted `ids` vector. `distance` is carried as double (the
+// SQL wire type) and narrowed to fp32 on storage to match libssu's matrices.
+struct DistanceEntry {
+	uint32_t i;
+	uint32_t j;
+	double distance;
+};
+
+// Build a dense n×n symmetric row-major fp32 distance matrix (zero diagonal)
+// from resolved off-diagonal entries. Every unordered pair must be provided
+// exactly once; identical duplicates (including the reversed (b,a) orientation)
+// are tolerated as no-ops. `ids` (size == n) is used only for error messages.
+//
+// `ids` must have exactly `n` entries and every `DistanceEntry` index must be
+// < n — both are enforced (this header is DuckDB-free and callable directly, so
+// a bad index must become a clean throw, never an out-of-bounds access).
+//
+// Throws std::invalid_argument on:
+//   - n < 2                    — no unordered pairs; ordination/PERMANOVA undefined
+//   - ids.size() != n          — caller contract violation
+//   - n too large for size_t   — n*n would overflow the allocation (32-bit size_t)
+//   - an index >= n            — caller contract violation
+//   - a non-finite distance    — NaN/Inf poisons the downstream fp32 routines
+//   - distance < 0             — nonsensical distance
+//   - a nonzero self-distance  — the diagonal is definitionally zero
+//   - a duplicate unordered pair set to a *different* fp32 value — ambiguous input
+//   - an incomplete matrix     — names the first missing (ids[i], ids[j]) in
+//                                row-major upper-triangle order
+//
+// Self-pairs (i == j) with distance 0 are ignored: the diagonal is
+// definitionally zero and does not count toward completeness.
+inline std::vector<float> BuildDenseDistanceMatrix(const std::vector<DistanceEntry> &entries, uint32_t n,
+                                                   const std::vector<std::string> &ids) {
+	if (n < 2) {
+		throw std::invalid_argument("a distance matrix requires at least 2 distinct samples (got " + std::to_string(n) +
+		                            ")");
+	}
+	if (ids.size() != static_cast<size_t>(n)) {
+		throw std::invalid_argument("id vector size (" + std::to_string(ids.size()) + ") does not match n (" +
+		                            std::to_string(n) + ")");
+	}
+	// Guard n*n against wraparound on a 32-bit size_t (wasm32) before it drives
+	// the allocation size and every cell index. On 64-bit this never fires
+	// (uint32 squared fits in size_t); on 32-bit it turns a would-be silent
+	// empty allocation + out-of-bounds write into a clean throw.
+	const uint64_t nn64 = static_cast<uint64_t>(n) * static_cast<uint64_t>(n);
+	if (nn64 > static_cast<uint64_t>(SIZE_MAX)) {
+		throw std::invalid_argument("distance matrix too large: " + std::to_string(n) + " samples");
+	}
+	const size_t nn = static_cast<size_t>(nn64);
+	std::vector<float> matrix(nn, 0.0f);
+	// Separate "filled" bitmap: a genuine off-diagonal distance of 0.0 is
+	// indistinguishable from an unwritten cell in `matrix` alone, so we cannot
+	// use a value sentinel for the completeness / conflict checks.
+	std::vector<char> filled(nn, 0);
+	uint64_t pairs_filled = 0;
+
+	for (const auto &e : entries) {
+		if (e.i >= n || e.j >= n) {
+			throw std::invalid_argument("distance entry index out of range for n=" + std::to_string(n));
+		}
+		if (!std::isfinite(e.distance)) {
+			throw std::invalid_argument("non-finite distance between '" + ids[e.i] + "' and '" + ids[e.j] + "'");
+		}
+		if (e.distance < 0.0) {
+			throw std::invalid_argument("negative distance " + std::to_string(e.distance) + " between '" + ids[e.i] +
+			                            "' and '" + ids[e.j] + "'");
+		}
+		if (e.i == e.j) {
+			// The diagonal is definitionally zero; a nonzero self-distance is a
+			// contradiction (e.g. a botched join counting a sample against
+			// itself) and must be surfaced, not silently dropped.
+			if (e.distance != 0.0) {
+				throw std::invalid_argument("nonzero self-distance " + std::to_string(e.distance) + " for sample '" +
+				                            ids[e.i] + "'");
+			}
+			continue;
+		}
+		const size_t ij = static_cast<size_t>(e.i) * n + e.j;
+		const size_t ji = static_cast<size_t>(e.j) * n + e.i;
+		const float v = static_cast<float>(e.distance);
+		if (filled[ij]) {
+			if (matrix[ij] != v) {
+				throw std::invalid_argument("conflicting distances for pair ('" + ids[e.i] + "', '" + ids[e.j] + "')");
+			}
+			continue; // identical duplicate — no-op
+		}
+		matrix[ij] = v;
+		matrix[ji] = v;
+		filled[ij] = 1;
+		filled[ji] = 1;
+		++pairs_filled;
+	}
+
+	const uint64_t expected = static_cast<uint64_t>(n) * static_cast<uint64_t>(n - 1) / 2;
+	if (pairs_filled < expected) {
+		for (uint32_t i = 0; i + 1 < n; ++i) {
+			for (uint32_t j = i + 1; j < n; ++j) {
+				if (!filled[static_cast<size_t>(i) * n + j]) {
+					throw std::invalid_argument("incomplete distance matrix: no distance provided for pair ('" +
+					                            ids[i] + "', '" + ids[j] + "')");
+				}
+			}
+		}
+	}
+	return matrix;
+}
+
+} // namespace miint::unifrac

--- a/src/include/unifrac_function_common.hpp
+++ b/src/include/unifrac_function_common.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "duckdb/common/types.hpp"
 #include "duckdb/main/client_context.hpp"
 #include "unifrac_support_biom.hpp"
 
@@ -48,8 +49,32 @@ inline std::string AcceptedVariantList() {
 // Rows with NULL sample_id, feature_id, or value are silently dropped,
 // as are zero/NaN values (UnifracSupportBiomView's sparse-storage
 // invariant would drop them anyway).
+//
+// When `sample_id_type` is non-null, the original SQL type of the `sample_id`
+// column (before the internal `::VARCHAR` cast) is written through it, so
+// callers can mirror BIGINT/UUID identifiers back onto their output columns.
+// The ids themselves are always carried as canonical VARCHAR text internally.
 std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, const std::string &table_name,
-                                                     const std::string &caller_name);
+                                                     const std::string &caller_name,
+                                                     LogicalType *sample_id_type = nullptr);
+
+// Resolve the SQL type that a mirrored sample-id output column should carry.
+// BIGINT and UUID are mirrored (so results join back to typed metadata without
+// a cast — parity with align_minimap2); every other input type collapses to
+// VARCHAR, matching what the ::VARCHAR-cast feature-table reader already
+// accepts (so this never rejects a type ReadFeatureTable would have read).
+//
+// Deliberate divergence from align_minimap2: that function rejects any id
+// column outside {VARCHAR, BIGINT, UUID} at bind via IsAllowedIdType. The
+// unifrac readers stay intentionally permissive — a DOUBLE/DATE sample_id is
+// accepted and simply emitted as VARCHAR, preserving the pre-existing behavior
+// of the ::VARCHAR-cast reader rather than tightening it.
+inline LogicalType ResolveSampleIdOutputType(const LogicalType &input_type) {
+	if (input_type.id() == LogicalTypeId::BIGINT || input_type.id() == LogicalTypeId::UUID) {
+		return input_type;
+	}
+	return LogicalType::VARCHAR;
+}
 
 // Resolve the user-supplied `threads` named parameter into a concrete count
 // that the libssu / scikit-bio-binaries OpenMP regions will run with.

--- a/src/include/unifrac_function_common.hpp
+++ b/src/include/unifrac_function_common.hpp
@@ -58,6 +58,46 @@ std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, con
                                                      const std::string &caller_name,
                                                      LogicalType *sample_id_type = nullptr);
 
+// A dense, symmetric, zero-diagonal fp32 distance matrix materialized from a
+// condensed COO distance relation (`sample_a, sample_b, distance`). This is the
+// metric-agnostic input shape shared by the `pcoa` and `permanova` table
+// functions: any relation with those three columns can be read — the
+// `unifrac_distances` output, a `beta_*` macro result, or a precomputed
+// Bray-Curtis/Jaccard/Euclidean table — so ordination and the omnibus test are
+// decoupled from UniFrac.
+struct DenseDistanceMatrix {
+	std::vector<float> matrix;           // n*n row-major, symmetric, zero diagonal (mat[i*n+j])
+	std::vector<std::string> sample_ids; // distinct ids from both columns, lexicographically sorted
+	uint32_t n_samples = 0;
+	// Output type mirrored from sample_a's input column (BIGINT/UUID → same,
+	// else VARCHAR); see ResolveSampleIdOutputType.
+	LogicalType sample_id_type = LogicalType::VARCHAR;
+};
+
+// Read the user-named condensed distance relation into a dense matrix. The
+// relation must expose `(sample_a, sample_b, distance)`: sample_a/sample_b of
+// any type castable to VARCHAR, distance castable to DOUBLE (mirrors
+// ReadFeatureTable's probe-then-cast approach).
+//
+// Rows with a NULL sample_a/sample_b are skipped entirely (a NULL id has no
+// identity). A row with a valid id pair but a NULL/NaN distance still registers
+// both ids in the dictionary but contributes no distance ("not provided"), so a
+// sample whose every distance is NULL/NaN does NOT silently vanish — it surfaces
+// as a completeness error. Distinct ids are collected from BOTH columns and
+// sorted lexicographically (the build_dictionary convention shared with
+// UnifracSupportBiomView::FromCoo, so sample_a < sample_b holds for VARCHAR ids
+// exactly as for unifrac_distances). The fill + validation (n>=2, completeness,
+// conflicting duplicates, negative/non-finite, nonzero self-distance) is
+// delegated to BuildDenseDistanceMatrix and re-thrown as InvalidInputException
+// prefixed with `caller_name`.
+//
+// sample_a's original SQL type is captured (BIGINT/UUID mirrored, else VARCHAR)
+// into DenseDistanceMatrix::sample_id_type. sample_a and sample_b are merged into
+// one dictionary emitted under that type, so their resolved output types must
+// match (else a BinderException) — sample_a's is mirrored.
+DenseDistanceMatrix ReadDistanceTable(ClientContext &context, const std::string &table_name,
+                                      const std::string &caller_name);
+
 // Resolve the SQL type that a mirrored sample-id output column should carry.
 // BIGINT and UUID are mirrored (so results join back to typed metadata without
 // a cast — parity with align_minimap2); every other input type collapses to

--- a/src/include/unifrac_table_functions.hpp
+++ b/src/include/unifrac_table_functions.hpp
@@ -8,5 +8,7 @@ void RegisterUnifracPcoa(ExtensionLoader &loader);
 void RegisterUnifracPermanova(ExtensionLoader &loader);
 void RegisterUnifracFaithPD(ExtensionLoader &loader);
 void RegisterUnifracDistances(ExtensionLoader &loader);
+void RegisterPcoaFromDistances(ExtensionLoader &loader);
+void RegisterPermanovaFromDistances(ExtensionLoader &loader);
 
 } // namespace duckdb

--- a/src/include/unifrac_table_functions.hpp
+++ b/src/include/unifrac_table_functions.hpp
@@ -7,5 +7,6 @@ namespace duckdb {
 void RegisterUnifracPcoa(ExtensionLoader &loader);
 void RegisterUnifracPermanova(ExtensionLoader &loader);
 void RegisterUnifracFaithPD(ExtensionLoader &loader);
+void RegisterUnifracDistances(ExtensionLoader &loader);
 
 } // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -317,6 +317,7 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterUnifracPcoa(loader);
 	RegisterUnifracPermanova(loader);
 	RegisterUnifracFaithPD(loader);
+	RegisterUnifracDistances(loader);
 #endif
 
 	AlignPairwiseWfa2ScoreFunction::Register(loader);

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -318,6 +318,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	RegisterUnifracPermanova(loader);
 	RegisterUnifracFaithPD(loader);
 	RegisterUnifracDistances(loader);
+	RegisterPcoaFromDistances(loader);
+	RegisterPermanovaFromDistances(loader);
 #endif
 
 	AlignPairwiseWfa2ScoreFunction::Register(loader);

--- a/src/unifrac_distances_function.cpp
+++ b/src/unifrac_distances_function.cpp
@@ -1,0 +1,319 @@
+#include "unifrac_table_functions.hpp"
+
+#include <climits>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "NewickTree.hpp"
+#include "id_column_utils.hpp"
+#include "tree_table_reader.hpp"
+#include "unifrac_bptree.hpp"
+#include "unifrac_condensed.hpp"
+#include "unifrac_distance.hpp"
+#include "unifrac_function_common.hpp"
+#include "unifrac_support_biom.hpp"
+
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/common/vector_size.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/client_context.hpp"
+
+namespace duckdb {
+namespace {
+
+using unifrac_internal::AcceptedVariantList;
+using unifrac_internal::IsValidVariant;
+using unifrac_internal::ReadFeatureTable;
+using unifrac_internal::ResolveThreadsParameter;
+
+// Bind data owns the biom + bptree views for the whole scan. Both view types
+// have self-wiring move ctors, and this struct is heap-allocated (make_uniq)
+// and never moved after construction, so the char** pointers libssu reads stay
+// valid across the Bind → Execute boundary. The distance matrix is deliberately
+// NOT computed here: unifrac_distances streams the upper triangle one iteration
+// at a time (see the global state) rather than materializing all O(n²) rows.
+struct UnifracDistancesData : public TableFunctionData {
+	miint::unifrac::UnifracSupportBiomView biom_view;
+	miint::unifrac::UnifracBptreeView bptree_view;
+	std::string variant_fp32;
+	bool variance_adjust = false;
+	double alpha = 1.0;
+	bool bypass_tips = false;
+	bool normalize_sample_counts = true;
+	uint32_t subsample_depth = 0;
+	bool subsample_with_replacement = false;
+	int32_t n_subsamples = 1;
+	int32_t seed = -1;
+	int n_threads = 1;
+	// Output type for sample_a/sample_b — mirrors the input sample_id type
+	// (BIGINT/UUID) or VARCHAR otherwise. See ResolveSampleIdOutputType.
+	LogicalType sample_id_out_type = LogicalType::VARCHAR;
+
+	UnifracDistancesData(miint::unifrac::UnifracSupportBiomView biom, miint::unifrac::UnifracBptreeView bptree)
+	    : biom_view(std::move(biom)), bptree_view(std::move(bptree)) {
+	}
+};
+
+// Holds the current iteration's distance matrix and a cursor into its upper
+// triangle. Single-threaded (MaxThreads == 1): DuckDB drives one Execute stream
+// which pages the triangle out in STANDARD_VECTOR_SIZE chunks and, when an
+// iteration is exhausted, recomputes the next one in place.
+struct UnifracDistancesGlobalState : public GlobalTableFunctionState {
+	unique_ptr<miint::unifrac::UnifracDistanceMatrix> matrix;
+	miint::unifrac::CondensedCursor cursor;
+	int32_t iteration = 0;
+	bool finished = false;
+
+	idx_t MaxThreads() const override {
+		return 1;
+	}
+};
+
+std::vector<std::string> CollectIds(char **ids, int n) {
+	std::vector<std::string> out;
+	out.reserve(n);
+	for (int i = 0; i < n; ++i) {
+		out.emplace_back(ids[i]);
+	}
+	return out;
+}
+
+// Compute the distance matrix for `iteration` into the global state and reset
+// the cursor to the start of its upper triangle. Subsampling can drop samples
+// below subsample_depth, so each iteration's matrix may have a different
+// n_samples; the cursor is always sized from the matrix that was produced.
+void LoadIteration(const UnifracDistancesData &data, UnifracDistancesGlobalState &gstate, int32_t iteration) {
+	// seed_iter mirrors pcoa/permanova: seed + iteration, with -1 meaning
+	// "unseeded". The seed + n_subsamples overflow is guarded at bind time.
+	const int seed_iter = (data.seed >= 0) ? (data.seed + iteration) : -1;
+	// UnifracDistanceMatrix::Compute throws std::runtime_error on libssu errors;
+	// tree/feature mismatch is already caught at bind by ValidateTreeCoversFeatures,
+	// so anything here is a libssu-internal failure surfaced as InvalidInput.
+	gstate.matrix = make_uniq<miint::unifrac::UnifracDistanceMatrix>([&]() {
+		try {
+			return miint::unifrac::UnifracDistanceMatrix::Compute(
+			    data.biom_view, data.bptree_view, data.variant_fp32, data.variance_adjust, data.alpha, data.bypass_tips,
+			    data.normalize_sample_counts, data.subsample_depth, data.subsample_with_replacement, seed_iter,
+			    data.n_threads);
+		} catch (const std::runtime_error &e) {
+			throw InvalidInputException("unifrac_distances: %s", e.what());
+		}
+	}());
+	gstate.iteration = iteration;
+	gstate.cursor = miint::unifrac::CondensedCursor::Begin(gstate.matrix->n_samples());
+}
+
+unique_ptr<FunctionData> UnifracDistancesBind(ClientContext &context, TableFunctionBindInput &input,
+                                              vector<LogicalType> &return_types, vector<string> &names) {
+	const std::string table_name = input.inputs[0].GetValue<string>();
+	const std::string tree_name = input.inputs[1].GetValue<string>();
+	if (table_name.empty()) {
+		throw BinderException("unifrac_distances: feature-table name must not be empty");
+	}
+	if (tree_name.empty()) {
+		throw BinderException("unifrac_distances: tree name must not be empty");
+	}
+
+	// INTEGER-typed named parameters are read as int32_t to match
+	// LogicalType::INTEGER (align_common.hpp:75 convention).
+	std::string variant = "weighted_normalized";
+	bool variance_adjust = false;
+	double alpha = 1.0;
+	bool bypass_tips = false;
+	bool normalize_sample_counts = true;
+	int32_t subsample_depth = 0;
+	bool subsample_with_replacement = false;
+	int32_t n_subsamples = 1;
+	int32_t seed = -1;
+	int32_t threads = 0; // 0 = follow DuckDB's TaskScheduler::NumberOfThreads()
+	for (const auto &kv : input.named_parameters) {
+		const auto key = StringUtil::Lower(kv.first);
+		if (key == "variant") {
+			variant = kv.second.GetValue<string>();
+		} else if (key == "variance_adjust") {
+			variance_adjust = kv.second.GetValue<bool>();
+		} else if (key == "alpha") {
+			alpha = kv.second.GetValue<double>();
+		} else if (key == "bypass_tips") {
+			bypass_tips = kv.second.GetValue<bool>();
+		} else if (key == "normalize_sample_counts") {
+			normalize_sample_counts = kv.second.GetValue<bool>();
+		} else if (key == "subsample_depth") {
+			subsample_depth = kv.second.GetValue<int32_t>();
+		} else if (key == "subsample_with_replacement") {
+			subsample_with_replacement = kv.second.GetValue<bool>();
+		} else if (key == "n_subsamples") {
+			n_subsamples = kv.second.GetValue<int32_t>();
+		} else if (key == "seed") {
+			seed = kv.second.GetValue<int32_t>();
+		} else if (key == "threads") {
+			threads = kv.second.GetValue<int32_t>();
+		}
+	}
+	const int n_threads = ResolveThreadsParameter(context, threads, "unifrac_distances");
+
+	if (!IsValidVariant(variant)) {
+		throw BinderException("unifrac_distances: variant '%s' is not valid. Accepted variants: %s", variant,
+		                      AcceptedVariantList());
+	}
+	if (n_subsamples < 1) {
+		throw BinderException("unifrac_distances: n_subsamples must be >= 1 (got %d)", n_subsamples);
+	}
+	if (subsample_depth < 0) {
+		throw BinderException("unifrac_distances: subsample_depth must be >= 0 (got %d)", subsample_depth);
+	}
+	if (n_subsamples > 1 && subsample_depth == 0) {
+		throw BinderException("unifrac_distances: n_subsamples > 1 requires subsample_depth > 0 (iterations would "
+		                      "otherwise be identical)");
+	}
+	// Guard the seed_iter = seed + i arithmetic against signed int32 overflow;
+	// libssu's ssu_set_random_seed takes a 32-bit int.
+	if (seed >= 0 &&
+	    static_cast<int64_t>(seed) + static_cast<int64_t>(n_subsamples) - 1 > static_cast<int64_t>(INT_MAX)) {
+		throw BinderException("unifrac_distances: seed (%d) + n_subsamples (%d) - 1 exceeds INT_MAX; pick a smaller "
+		                      "seed or fewer subsamples",
+		                      seed, n_subsamples);
+	}
+
+	LogicalType sample_id_type = LogicalType::VARCHAR;
+	auto coo_rows = ReadFeatureTable(context, table_name, "unifrac_distances", &sample_id_type);
+	if (coo_rows.empty()) {
+		throw InvalidInputException("unifrac_distances: feature-table '%s' is empty after dropping NULL/zero rows",
+		                            table_name);
+	}
+	miint::unifrac::UnifracSupportBiomView biom_view = [&]() {
+		try {
+			return miint::unifrac::UnifracSupportBiomView::FromCoo(std::move(coo_rows));
+		} catch (const std::invalid_argument &e) {
+			throw InvalidInputException("unifrac_distances: %s", e.what());
+		}
+	}();
+
+	const auto *biom_struct = biom_view.support_biom();
+	auto feature_ids = CollectIds(biom_struct->obs_ids, biom_struct->n_obs);
+
+	auto tree_inputs = ReadTreeTable(context, tree_name);
+	auto tree = miint::NewickTree::build(tree_inputs);
+	try {
+		miint::unifrac::ValidateTreeCoversFeatures(tree, feature_ids);
+	} catch (const std::invalid_argument &e) {
+		throw InvalidInputException("unifrac_distances: %s", e.what());
+	}
+	auto bptree_view = miint::unifrac::UnifracBptreeView::FromNewickTree(tree);
+
+	auto data = make_uniq<UnifracDistancesData>(std::move(biom_view), std::move(bptree_view));
+	// libssu accepts both bare and _fp32-suffixed variants; append _fp32 so the
+	// choice is pinned to fp32 regardless of libssu's default (see pcoa).
+	data->variant_fp32 = variant + "_fp32";
+	data->variance_adjust = variance_adjust;
+	data->alpha = alpha;
+	data->bypass_tips = bypass_tips;
+	data->normalize_sample_counts = normalize_sample_counts;
+	data->subsample_depth = static_cast<uint32_t>(subsample_depth);
+	data->subsample_with_replacement = subsample_with_replacement;
+	data->n_subsamples = n_subsamples;
+	data->seed = seed;
+	data->n_threads = n_threads;
+	data->sample_id_out_type = unifrac_internal::ResolveSampleIdOutputType(sample_id_type);
+
+	names.emplace_back("iteration");
+	return_types.emplace_back(LogicalType::INTEGER);
+	names.emplace_back("sample_a");
+	return_types.emplace_back(data->sample_id_out_type);
+	names.emplace_back("sample_b");
+	return_types.emplace_back(data->sample_id_out_type);
+	names.emplace_back("distance");
+	return_types.emplace_back(LogicalType::DOUBLE);
+
+	return std::move(data);
+}
+
+unique_ptr<GlobalTableFunctionState> UnifracDistancesInitGlobal(ClientContext &, TableFunctionInitInput &input) {
+	const auto &data = input.bind_data->Cast<UnifracDistancesData>();
+	auto gstate = make_uniq<UnifracDistancesGlobalState>();
+	LoadIteration(data, *gstate, /*iteration*/ 0);
+	return std::move(gstate);
+}
+
+void UnifracDistancesExecute(ClientContext &, TableFunctionInput &input, DataChunk &output) {
+	const auto &data = input.bind_data->Cast<UnifracDistancesData>();
+	auto &gstate = input.global_state->Cast<UnifracDistancesGlobalState>();
+
+	if (gstate.finished) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	auto iter_data = FlatVector::GetData<int32_t>(output.data[0]);
+	auto &sample_a_vec = output.data[1];
+	auto &sample_b_vec = output.data[2];
+	auto dist_data = FlatVector::GetData<double>(output.data[3]);
+	const LogicalType &id_type = data.sample_id_out_type;
+
+	idx_t out_n = 0;
+	while (out_n < STANDARD_VECTOR_SIZE) {
+		// Skip past exhausted iterations, loading the next matrix until one has a
+		// pair or we run out. An iteration with fewer than 2 samples (including
+		// the base case of a <2-sample table, or subsampling dropping an
+		// iteration below 2) has an empty upper triangle, so it contributes no
+		// rows. Unlike unifrac_pcoa — which errors when too few samples survive
+		// because an ordination is undefined — the condensed form of such a
+		// matrix is legitimately empty, so we emit no rows rather than raising.
+		while (gstate.cursor.done()) {
+			if (gstate.iteration + 1 >= data.n_subsamples) {
+				gstate.finished = true;
+				break;
+			}
+			LoadIteration(data, gstate, gstate.iteration + 1);
+		}
+		if (gstate.finished) {
+			break;
+		}
+
+		// Hoist the matrix handles out of the per-row loop — they only change
+		// when LoadIteration advances to the next iteration's matrix.
+		const float *mat = gstate.matrix->matrix();
+		const uint32_t n = gstate.matrix->n_samples();
+		const auto &ids = gstate.matrix->sample_ids();
+		while (out_n < STANDARD_VECTOR_SIZE && !gstate.cursor.done()) {
+			const uint32_t i = gstate.cursor.i;
+			const uint32_t j = gstate.cursor.j;
+			iter_data[out_n] = gstate.iteration;
+			// EmitIdCell mirrors the id type onto the output. Its ""/"*"→NULL
+			// sentinel branch (SAM-domain) is unreachable here: ReadFeatureTable
+			// drops NULL sample_ids and libssu sample ids are never empty.
+			EmitIdCell(sample_a_vec, out_n, ids[i], id_type);
+			EmitIdCell(sample_b_vec, out_n, ids[j], id_type);
+			dist_data[out_n] = static_cast<double>(mat[static_cast<size_t>(i) * n + j]);
+			++out_n;
+			gstate.cursor.advance();
+		}
+	}
+
+	output.SetCardinality(out_n);
+}
+
+} // namespace
+
+void RegisterUnifracDistances(ExtensionLoader &loader) {
+	TableFunction fn("unifrac_distances", {LogicalType::VARCHAR, LogicalType::VARCHAR}, UnifracDistancesExecute,
+	                 UnifracDistancesBind, UnifracDistancesInitGlobal);
+	fn.named_parameters["variant"] = LogicalType::VARCHAR;
+	fn.named_parameters["variance_adjust"] = LogicalType::BOOLEAN;
+	fn.named_parameters["alpha"] = LogicalType::DOUBLE;
+	fn.named_parameters["bypass_tips"] = LogicalType::BOOLEAN;
+	fn.named_parameters["normalize_sample_counts"] = LogicalType::BOOLEAN;
+	fn.named_parameters["subsample_depth"] = LogicalType::INTEGER;
+	fn.named_parameters["subsample_with_replacement"] = LogicalType::BOOLEAN;
+	fn.named_parameters["n_subsamples"] = LogicalType::INTEGER;
+	fn.named_parameters["seed"] = LogicalType::INTEGER;
+	fn.named_parameters["threads"] = LogicalType::INTEGER;
+	loader.RegisterFunction(fn);
+}
+
+} // namespace duckdb

--- a/src/unifrac_faith_pd_function.cpp
+++ b/src/unifrac_faith_pd_function.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "NewickTree.hpp"
+#include "id_column_utils.hpp"
 #include "tree_table_reader.hpp"
 #include "unifrac_bptree.hpp"
 #include "unifrac_function_common.hpp"
@@ -28,6 +29,7 @@ namespace duckdb {
 namespace {
 
 using unifrac_internal::ReadFeatureTable;
+using unifrac_internal::ResolveSampleIdOutputType;
 using unifrac_internal::ResolveThreadsParameter;
 
 struct FaithPdRow {
@@ -38,11 +40,15 @@ struct FaithPdRow {
 
 struct UnifracFaithPdData : public TableFunctionData {
 	std::vector<FaithPdRow> rows;
+	// Output type for sample_id — mirrors the input sample_id type (BIGINT/UUID)
+	// or VARCHAR otherwise. See ResolveSampleIdOutputType.
+	LogicalType sample_id_type = LogicalType::VARCHAR;
 };
 
 struct UnifracFaithPdGlobalState : public GlobalTableFunctionState {
 	std::vector<FaithPdRow> rows;
 	size_t cursor = 0;
+	LogicalType sample_id_type = LogicalType::VARCHAR;
 	idx_t MaxThreads() const override {
 		return 1;
 	}
@@ -167,7 +173,8 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 		                      seed, n_subsamples);
 	}
 
-	auto coo_rows = ReadFeatureTable(context, table_name, "unifrac_faith_pd");
+	LogicalType sample_id_col_type = LogicalType::VARCHAR;
+	auto coo_rows = ReadFeatureTable(context, table_name, "unifrac_faith_pd", &sample_id_col_type);
 	if (coo_rows.empty()) {
 		throw InvalidInputException("unifrac_faith_pd: feature-table '%s' is empty after dropping NULL/zero rows",
 		                            table_name);
@@ -196,6 +203,7 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 	auto bptree_view = miint::unifrac::UnifracBptreeView::FromNewickTree(tree);
 
 	auto data = make_uniq<UnifracFaithPdData>();
+	data->sample_id_type = ResolveSampleIdOutputType(sample_id_col_type);
 	data->rows.reserve(static_cast<size_t>(n_subsamples) * biom_struct->n_samples);
 
 	if (subsample_depth == 0) {
@@ -223,7 +231,7 @@ unique_ptr<FunctionData> UnifracFaithPdBind(ClientContext &context, TableFunctio
 	names.emplace_back("iteration");
 	return_types.emplace_back(LogicalType::INTEGER);
 	names.emplace_back("sample_id");
-	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(data->sample_id_type);
 	names.emplace_back("faith_pd");
 	return_types.emplace_back(LogicalType::DOUBLE);
 
@@ -234,6 +242,7 @@ unique_ptr<GlobalTableFunctionState> UnifracFaithPdInitGlobal(ClientContext &, T
 	auto &data = input.bind_data->CastNoConst<UnifracFaithPdData>();
 	auto gstate = make_uniq<UnifracFaithPdGlobalState>();
 	gstate->rows = std::move(data.rows);
+	gstate->sample_id_type = data.sample_id_type;
 	return std::move(gstate);
 }
 
@@ -249,13 +258,14 @@ void UnifracFaithPdExecute(ClientContext &, TableFunctionInput &input, DataChunk
 
 	auto iter_data = FlatVector::GetData<int32_t>(output.data[0]);
 	auto &sample_id_vec = output.data[1];
-	auto sample_id_data = FlatVector::GetData<string_t>(sample_id_vec);
 	auto faith_pd_data = FlatVector::GetData<double>(output.data[2]);
 
 	for (idx_t i = 0; i < n; ++i) {
 		const auto &r = gstate.rows[gstate.cursor + i];
 		iter_data[i] = r.iteration;
-		sample_id_data[i] = StringVector::AddString(sample_id_vec, r.sample_id);
+		// EmitIdCell mirrors the id type; its ""/"*"→NULL sentinel branch is
+		// unreachable here (ReadFeatureTable drops NULL sample_ids).
+		EmitIdCell(sample_id_vec, i, r.sample_id, gstate.sample_id_type);
 		faith_pd_data[i] = r.faith_pd;
 	}
 	gstate.cursor += n;

--- a/src/unifrac_function_common.cpp
+++ b/src/unifrac_function_common.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 
+#include "catalog_utils.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -14,7 +15,7 @@
 namespace duckdb::unifrac_internal {
 
 std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, const std::string &table_name,
-                                                     const std::string &caller_name) {
+                                                     const std::string &caller_name, LogicalType *sample_id_type) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
 	const auto qname = KeywordHelper::WriteOptionallyQuoted(table_name);
@@ -26,6 +27,21 @@ std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, con
 		throw InvalidInputException(
 		    "%s: feature-table '%s' must expose (sample_id VARCHAR, feature_id VARCHAR, value DOUBLE): %s", caller_name,
 		    table_name, probe->GetError());
+	}
+
+	// Capture the sample_id column's original SQL type (before the ::VARCHAR cast
+	// above) for callers that mirror the id type onto their output. A catalog
+	// metadata lookup — the same mechanism sequence_table_reader/tree_table_reader
+	// use — rather than a second query; the probe above already proved sample_id
+	// exists and is VARCHAR-castable, so the lookup here always finds it.
+	if (sample_id_type != nullptr) {
+		auto cols = GetTableOrViewColumns(context, table_name, "feature-table");
+		for (idx_t i = 0; i < cols.names.size(); ++i) {
+			if (StringUtil::Lower(cols.names[i]) == "sample_id") {
+				*sample_id_type = cols.types[i];
+				break;
+			}
+		}
 	}
 
 	auto result = conn.Query("SELECT sample_id::VARCHAR, feature_id::VARCHAR, value::DOUBLE FROM " + qname);

--- a/src/unifrac_function_common.cpp
+++ b/src/unifrac_function_common.cpp
@@ -1,8 +1,11 @@
 #include "unifrac_function_common.hpp"
 
+#include <algorithm>
 #include <cmath>
+#include <unordered_map>
 
 #include "catalog_utils.hpp"
+#include "unifrac_dense_distance.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/numeric_utils.hpp"
 #include "duckdb/common/string_util.hpp"
@@ -79,6 +82,143 @@ std::vector<miint::unifrac::CooRow> ReadFeatureTable(ClientContext &context, con
 		}
 	}
 	return rows;
+}
+
+DenseDistanceMatrix ReadDistanceTable(ClientContext &context, const std::string &table_name,
+                                      const std::string &caller_name) {
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+	const auto qname = KeywordHelper::WriteOptionallyQuoted(table_name);
+
+	// Schema probe via LIMIT 0 — surfaces missing columns or unsafe casts as a
+	// binder-time error before we materialize the full relation (mirrors
+	// ReadFeatureTable).
+	auto probe = conn.Query("SELECT sample_a::VARCHAR, sample_b::VARCHAR, distance::DOUBLE FROM " + qname + " LIMIT 0");
+	if (probe->HasError()) {
+		throw InvalidInputException("%s: distance-table '%s' must expose (sample_a, sample_b, distance DOUBLE): %s",
+		                            caller_name, table_name, probe->GetError());
+	}
+
+	// Capture sample_a's and sample_b's original SQL types (before the ::VARCHAR
+	// cast) so the caller can mirror BIGINT/UUID ids onto its output. The probe
+	// above already proved both columns exist and are VARCHAR-castable.
+	LogicalType sample_a_type = LogicalType::VARCHAR;
+	LogicalType sample_b_type = LogicalType::VARCHAR;
+	{
+		auto cols = GetTableOrViewColumns(context, table_name, "distance-table");
+		for (idx_t i = 0; i < cols.names.size(); ++i) {
+			const auto lname = StringUtil::Lower(cols.names[i]);
+			if (lname == "sample_a") {
+				sample_a_type = cols.types[i];
+			} else if (lname == "sample_b") {
+				sample_b_type = cols.types[i];
+			}
+		}
+	}
+	// sample_a and sample_b are merged into ONE id dictionary emitted under a
+	// single output type. If they resolve to different output types (e.g. a
+	// BIGINT sample_a but a VARCHAR sample_b), the mirror would emit sample_b's
+	// ids under sample_a's type — a silent wrong-namespace merge if they happen
+	// to parse, or a confusing deferred EmitIdCell failure if they don't. Reject
+	// at bind instead (fail loud).
+	if (ResolveSampleIdOutputType(sample_a_type) != ResolveSampleIdOutputType(sample_b_type)) {
+		throw BinderException("%s: distance-table '%s' has mismatched sample_a (%s) and sample_b (%s) id types; "
+		                      "both must map to the same output type (BIGINT, UUID, or VARCHAR)",
+		                      caller_name, table_name, sample_a_type.ToString(), sample_b_type.ToString());
+	}
+
+	auto result = conn.Query("SELECT sample_a::VARCHAR, sample_b::VARCHAR, distance::DOUBLE FROM " + qname);
+	if (result->HasError()) {
+		throw InvalidInputException("%s: failed to read distance-table '%s': %s", caller_name, table_name,
+		                            result->GetError());
+	}
+
+	// Collect surviving (a, b, distance) triples and the raw id list. NULL
+	// sample ids or NULL/NaN distances are dropped ("not provided"); an unfilled
+	// pair is caught downstream by the completeness check with a named message.
+	struct RawTriple {
+		std::string a;
+		std::string b;
+		double distance;
+	};
+	std::vector<RawTriple> triples;
+	std::vector<std::string> ids_raw;
+	auto &materialized = result->Cast<MaterializedQueryResult>();
+	while (auto chunk = materialized.Fetch()) {
+		const idx_t rn = chunk->size();
+		if (rn == 0) {
+			break;
+		}
+		UnifiedVectorFormat a_u, b_u, d_u;
+		chunk->data[0].ToUnifiedFormat(rn, a_u);
+		chunk->data[1].ToUnifiedFormat(rn, b_u);
+		chunk->data[2].ToUnifiedFormat(rn, d_u);
+		auto a_data = UnifiedVectorFormat::GetData<string_t>(a_u);
+		auto b_data = UnifiedVectorFormat::GetData<string_t>(b_u);
+		auto d_data = UnifiedVectorFormat::GetData<double>(d_u);
+		for (idx_t i = 0; i < rn; ++i) {
+			const auto ai = a_u.sel->get_index(i);
+			const auto bi = b_u.sel->get_index(i);
+			const auto di = d_u.sel->get_index(i);
+			// A NULL sample id has no identity — skip the row entirely.
+			if (!a_u.validity.RowIsValid(ai) || !b_u.validity.RowIsValid(bi)) {
+				continue;
+			}
+			std::string a = a_data[ai].GetString();
+			std::string b = b_data[bi].GetString();
+			// Record both ids BEFORE gating on the distance: a sample that appears
+			// in the table must enter the dictionary even if this particular
+			// distance is missing, so a sample whose every distance is NULL/NaN
+			// (e.g. a Bray-Curtis all-zero sample, NaN against everything)
+			// surfaces as a completeness error rather than silently vanishing
+			// from the result.
+			ids_raw.push_back(a);
+			ids_raw.push_back(b);
+			if (!d_u.validity.RowIsValid(di)) {
+				continue; // NULL distance → "not provided"
+			}
+			const double dv = d_data[di];
+			if (std::isnan(dv)) {
+				continue; // NaN distance → "not provided"
+			}
+			triples.push_back({std::move(a), std::move(b), dv});
+		}
+	}
+
+	// Stable dictionary: distinct ids from both columns, sorted lexicographically
+	// (matches build_dictionary / UnifracSupportBiomView::FromCoo). ids_raw is
+	// dead after this move.
+	std::vector<std::string> sample_ids = std::move(ids_raw);
+	std::sort(sample_ids.begin(), sample_ids.end());
+	sample_ids.erase(std::unique(sample_ids.begin(), sample_ids.end()), sample_ids.end());
+	const auto n = static_cast<uint32_t>(sample_ids.size());
+	if (n < 2) {
+		throw InvalidInputException(
+		    "%s: distance-table '%s' has %u distinct sample(s) after dropping NULL rows; at least 2 are required",
+		    caller_name, table_name, n);
+	}
+	std::unordered_map<std::string, uint32_t> index;
+	index.reserve(sample_ids.size());
+	for (uint32_t i = 0; i < n; ++i) {
+		index.emplace(sample_ids[i], i);
+	}
+
+	std::vector<miint::unifrac::DistanceEntry> entries;
+	entries.reserve(triples.size());
+	for (const auto &t : triples) {
+		entries.push_back({index.at(t.a), index.at(t.b), t.distance});
+	}
+
+	DenseDistanceMatrix out;
+	try {
+		out.matrix = miint::unifrac::BuildDenseDistanceMatrix(entries, n, sample_ids);
+	} catch (const std::invalid_argument &e) {
+		throw InvalidInputException("%s: %s", caller_name, e.what());
+	}
+	out.sample_ids = std::move(sample_ids);
+	out.n_samples = n;
+	out.sample_id_type = ResolveSampleIdOutputType(sample_a_type);
+	return out;
 }
 
 int ResolveThreadsParameter(ClientContext &context, int32_t user_value, const std::string &caller_name) {

--- a/src/unifrac_pcoa_function.cpp
+++ b/src/unifrac_pcoa_function.cpp
@@ -32,6 +32,7 @@ namespace {
 
 using unifrac_internal::AcceptedVariantList;
 using unifrac_internal::IsValidVariant;
+using unifrac_internal::ReadDistanceTable;
 using unifrac_internal::ReadFeatureTable;
 using unifrac_internal::ResolveSampleIdOutputType;
 using unifrac_internal::ResolveThreadsParameter;
@@ -70,6 +71,76 @@ std::vector<std::string> CollectIds(char **ids, int n) {
 	return out;
 }
 
+// Run randomized PCoA (skbb_pcoa_fsvd_fp32) on a dense fp32 distance matrix and
+// append one PcoaRow per (sample, axis). Shared by unifrac_pcoa (once per
+// subsample iteration, over a freshly computed UniFrac matrix) and the
+// metric-agnostic `pcoa` (a single iteration over any distance table), so the
+// ordination + row-emission path is byte-for-byte identical for both — the
+// property the pcoa/unifrac_pcoa equivalence test pins.
+//
+// `mat` is n×n row-major fp32; `ids` are the matrix's sample ids (size n).
+// `caller_name` prefixes the too-few-samples error. Throws InvalidInputException
+// when n < n_dims + 1 (PCoA loses one dimension to centering).
+void RunPcoaOnMatrix(const float *mat, uint32_t n, const std::vector<std::string> &ids, uint32_t n_dims, int seed,
+                     int n_threads, int32_t iteration_index, const char *caller_name, std::vector<PcoaRow> &out_rows) {
+	if (n < n_dims + 1) {
+		throw InvalidInputException("%s: only %u sample(s) available for ordination; n_dims=%u requires at least %u "
+		                            "samples (PCoA loses one dimension to centering)",
+		                            caller_name, n, n_dims, n_dims + 1);
+	}
+
+	std::vector<float> eigvals(n_dims);
+	std::vector<float> samples(static_cast<size_t>(n) * n_dims);
+	std::vector<float> prop(n_dims);
+
+	// skbb_pcoa_fsvd_fp32 uses its own per-call seed for randomization, but its
+	// `#pragma omp parallel for` regions (principal_coordinate_analysis.cpp)
+	// still need the process-wide OpenMP serialization so concurrent queries
+	// don't race on omp_set_num_threads.
+	{
+		miint::unifrac::OmpThreadScope omp_scope(n_threads);
+		skbb_pcoa_fsvd_fp32(n, mat, n_dims, seed, eigvals.data(), samples.data(), prop.data());
+	}
+
+	// samples is laid out (n × n_dims), sample-major. The header comment in
+	// ordination.h reads "(n_eighs × n_dims)" but the actual implementation
+	// (principal_coordinate_analysis.cpp:574-578 and the preceding
+	// transpose_T(n_dims, n_eighs, ...)) writes `samples + row * n_eighs` with
+	// row iterating over samples, i.e. sample-major.
+	for (uint32_t s = 0; s < n; ++s) {
+		for (uint32_t axis = 0; axis < n_dims; ++axis) {
+			PcoaRow row;
+			row.iteration = iteration_index;
+			row.sample_id = ids[s];
+			row.axis = static_cast<int32_t>(axis);
+			row.coordinate = static_cast<double>(samples[s * n_dims + axis]);
+			row.eigenvalue = static_cast<double>(eigvals[axis]);
+			row.proportion_explained = static_cast<double>(prop[axis]);
+			out_rows.push_back(std::move(row));
+		}
+	}
+}
+
+// Declare the PCoA output schema. Shared by unifrac_pcoa and pcoa so the two
+// functions can never drift apart column-wise — the "identical output schema"
+// invariant is enforced structurally rather than by discipline. `sample_id_type`
+// is the mirrored input id type (see ResolveSampleIdOutputType).
+void DeclarePcoaOutputSchema(const LogicalType &sample_id_type, vector<LogicalType> &return_types,
+                             vector<string> &names) {
+	names.emplace_back("iteration");
+	return_types.emplace_back(LogicalType::INTEGER);
+	names.emplace_back("sample_id");
+	return_types.emplace_back(sample_id_type);
+	names.emplace_back("axis");
+	return_types.emplace_back(LogicalType::INTEGER);
+	names.emplace_back("coordinate");
+	return_types.emplace_back(LogicalType::DOUBLE);
+	names.emplace_back("eigenvalue");
+	return_types.emplace_back(LogicalType::DOUBLE);
+	names.emplace_back("proportion_explained");
+	return_types.emplace_back(LogicalType::DOUBLE);
+}
+
 void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view,
                          const miint::unifrac::UnifracBptreeView &bptree_view, const std::string &variant_fp32,
                          bool variance_adjust, double alpha, bool bypass_tips, bool normalize_sample_counts,
@@ -91,48 +162,12 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
 	}();
 
 	// Subsampling can drop samples whose total counts fall below
-	// subsample_depth, so the distance matrix's n_samples may be smaller
-	// than the input feature-table's n_samples; n_dims must still fit.
-	const uint32_t actual_n_samples = dist.n_samples();
-	if (actual_n_samples < n_dims + 1) {
-		throw InvalidInputException(
-		    "unifrac_pcoa: after subsampling iteration %d only %u sample(s) survive "
-		    "(samples whose total count falls below subsample_depth=%u are dropped); n_dims=%u requires >= %u samples",
-		    iteration_index, actual_n_samples, subsample_depth, n_dims, n_dims + 1);
-	}
-
-	std::vector<float> eigvals(n_dims);
-	std::vector<float> samples(static_cast<size_t>(actual_n_samples) * n_dims);
-	std::vector<float> prop(n_dims);
-
-	// skbb_pcoa_fsvd_fp32 uses its own per-call seed for randomization, but its
-	// `#pragma omp parallel for` regions (principal_coordinate_analysis.cpp)
-	// still need the process-wide OpenMP serialization so concurrent queries
-	// don't race on omp_set_num_threads.
-	{
-		miint::unifrac::OmpThreadScope omp_scope(n_threads);
-		skbb_pcoa_fsvd_fp32(actual_n_samples, dist.matrix(), n_dims, seed_iter, eigvals.data(), samples.data(),
-		                    prop.data());
-	}
-
-	// samples is laid out (actual_n_samples × n_dims), sample-major. The header
-	// comment in ordination.h reads "(n_eighs × n_dims)" but the actual
-	// implementation (principal_coordinate_analysis.cpp:574-578 and the
-	// preceding transpose_T(n_dims, n_eighs, ...)) writes `samples + row *
-	// n_eighs` with row iterating over samples, i.e. sample-major.
-	const auto &sample_ids = dist.sample_ids();
-	for (uint32_t s = 0; s < actual_n_samples; ++s) {
-		for (uint32_t axis = 0; axis < n_dims; ++axis) {
-			PcoaRow row;
-			row.iteration = iteration_index;
-			row.sample_id = sample_ids[s];
-			row.axis = static_cast<int32_t>(axis);
-			row.coordinate = static_cast<double>(samples[s * n_dims + axis]);
-			row.eigenvalue = static_cast<double>(eigvals[axis]);
-			row.proportion_explained = static_cast<double>(prop[axis]);
-			out_rows.push_back(std::move(row));
-		}
-	}
+	// subsample_depth, so the distance matrix's n_samples may be smaller than
+	// the input feature-table's n_samples. RunPcoaOnMatrix guards n vs n_dims
+	// (the same check the bind-time validation applies to the pre-subsample
+	// count) and emits the rows.
+	RunPcoaOnMatrix(dist.matrix(), dist.n_samples(), dist.sample_ids(), n_dims, seed_iter, n_threads, iteration_index,
+	                "unifrac_pcoa", out_rows);
 }
 
 unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBindInput &input,
@@ -272,18 +307,7 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 		                    seed_iter, static_cast<uint32_t>(n_dims), n_threads, i, data->rows);
 	}
 
-	names.emplace_back("iteration");
-	return_types.emplace_back(LogicalType::INTEGER);
-	names.emplace_back("sample_id");
-	return_types.emplace_back(data->sample_id_type);
-	names.emplace_back("axis");
-	return_types.emplace_back(LogicalType::INTEGER);
-	names.emplace_back("coordinate");
-	return_types.emplace_back(LogicalType::DOUBLE);
-	names.emplace_back("eigenvalue");
-	return_types.emplace_back(LogicalType::DOUBLE);
-	names.emplace_back("proportion_explained");
-	return_types.emplace_back(LogicalType::DOUBLE);
+	DeclarePcoaOutputSchema(data->sample_id_type, return_types, names);
 
 	return std::move(data);
 }
@@ -329,6 +353,57 @@ void UnifracPcoaExecute(ClientContext &, TableFunctionInput &input, DataChunk &o
 	output.SetCardinality(n);
 }
 
+// ── pcoa(distances, ...) — metric-agnostic PCoA over a condensed distance table ──
+// Decoupled from UniFrac: reads any `(sample_a, sample_b, distance)` relation
+// (the unifrac_distances output, a beta_* macro result, or a precomputed
+// Bray-Curtis/Jaccard/Euclidean table) into a dense matrix and runs the exact
+// same skbb_pcoa_fsvd_fp32 + emit path as unifrac_pcoa via RunPcoaOnMatrix. It
+// reuses UnifracPcoaData / UnifracPcoaGlobalState / UnifracPcoaExecute /
+// UnifracPcoaInitGlobal unchanged — the output schema is identical, iteration is
+// always 0 (kept for schema parity), and there is no subsampling (a distance
+// table is a fixed matrix).
+unique_ptr<FunctionData> PcoaFromDistancesBind(ClientContext &context, TableFunctionBindInput &input,
+                                               vector<LogicalType> &return_types, vector<string> &names) {
+	const std::string table_name = input.inputs[0].GetValue<string>();
+	if (table_name.empty()) {
+		throw BinderException("pcoa: distance-table name must not be empty");
+	}
+
+	int32_t n_dims = 3;
+	int32_t seed = -1;
+	int32_t threads = 0; // 0 = follow DuckDB's TaskScheduler::NumberOfThreads()
+	for (const auto &kv : input.named_parameters) {
+		const auto key = StringUtil::Lower(kv.first);
+		if (key == "n_dims") {
+			n_dims = kv.second.GetValue<int32_t>();
+		} else if (key == "seed") {
+			seed = kv.second.GetValue<int32_t>();
+		} else if (key == "threads") {
+			threads = kv.second.GetValue<int32_t>();
+		}
+	}
+	const int n_threads = ResolveThreadsParameter(context, threads, "pcoa");
+	if (n_dims < 1) {
+		throw BinderException("pcoa: n_dims must be >= 1 (got %d)", n_dims);
+	}
+
+	auto dist = ReadDistanceTable(context, table_name, "pcoa");
+	if (static_cast<uint32_t>(n_dims) > dist.n_samples - 1) {
+		throw BinderException("pcoa: n_dims (%d) must be <= n_samples - 1 (%u). PCoA loses one dimension to centering.",
+		                      n_dims, dist.n_samples - 1);
+	}
+
+	auto data = make_uniq<UnifracPcoaData>();
+	data->sample_id_type = dist.sample_id_type;
+	data->rows.reserve(static_cast<size_t>(dist.n_samples) * static_cast<size_t>(n_dims));
+	RunPcoaOnMatrix(dist.matrix.data(), dist.n_samples, dist.sample_ids, static_cast<uint32_t>(n_dims), seed, n_threads,
+	                /*iteration_index*/ 0, "pcoa", data->rows);
+
+	DeclarePcoaOutputSchema(data->sample_id_type, return_types, names);
+
+	return std::move(data);
+}
+
 } // namespace
 
 void RegisterUnifracPcoa(ExtensionLoader &loader) {
@@ -343,6 +418,14 @@ void RegisterUnifracPcoa(ExtensionLoader &loader) {
 	fn.named_parameters["subsample_depth"] = LogicalType::INTEGER;
 	fn.named_parameters["subsample_with_replacement"] = LogicalType::BOOLEAN;
 	fn.named_parameters["n_subsamples"] = LogicalType::INTEGER;
+	fn.named_parameters["seed"] = LogicalType::INTEGER;
+	fn.named_parameters["threads"] = LogicalType::INTEGER;
+	loader.RegisterFunction(fn);
+}
+
+void RegisterPcoaFromDistances(ExtensionLoader &loader) {
+	TableFunction fn("pcoa", {LogicalType::VARCHAR}, UnifracPcoaExecute, PcoaFromDistancesBind, UnifracPcoaInitGlobal);
+	fn.named_parameters["n_dims"] = LogicalType::INTEGER;
 	fn.named_parameters["seed"] = LogicalType::INTEGER;
 	fn.named_parameters["threads"] = LogicalType::INTEGER;
 	loader.RegisterFunction(fn);

--- a/src/unifrac_pcoa_function.cpp
+++ b/src/unifrac_pcoa_function.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "NewickTree.hpp"
+#include "id_column_utils.hpp"
 #include "tree_table_reader.hpp"
 #include "unifrac_bptree.hpp"
 #include "unifrac_distance.hpp"
@@ -32,6 +33,7 @@ namespace {
 using unifrac_internal::AcceptedVariantList;
 using unifrac_internal::IsValidVariant;
 using unifrac_internal::ReadFeatureTable;
+using unifrac_internal::ResolveSampleIdOutputType;
 using unifrac_internal::ResolveThreadsParameter;
 
 struct PcoaRow {
@@ -45,11 +47,15 @@ struct PcoaRow {
 
 struct UnifracPcoaData : public TableFunctionData {
 	std::vector<PcoaRow> rows;
+	// Output type for sample_id — mirrors the input sample_id type (BIGINT/UUID)
+	// or VARCHAR otherwise. See ResolveSampleIdOutputType.
+	LogicalType sample_id_type = LogicalType::VARCHAR;
 };
 
 struct UnifracPcoaGlobalState : public GlobalTableFunctionState {
 	std::vector<PcoaRow> rows;
 	size_t cursor = 0;
+	LogicalType sample_id_type = LogicalType::VARCHAR;
 	idx_t MaxThreads() const override {
 		return 1;
 	}
@@ -210,7 +216,8 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 		    seed, n_subsamples);
 	}
 
-	auto coo_rows = ReadFeatureTable(context, table_name, "unifrac_pcoa");
+	LogicalType sample_id_col_type = LogicalType::VARCHAR;
+	auto coo_rows = ReadFeatureTable(context, table_name, "unifrac_pcoa", &sample_id_col_type);
 	if (coo_rows.empty()) {
 		throw InvalidInputException("unifrac_pcoa: feature-table '%s' is empty after dropping NULL/zero rows",
 		                            table_name);
@@ -254,6 +261,7 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 	const std::string variant_fp32 = variant + "_fp32";
 
 	auto data = make_uniq<UnifracPcoaData>();
+	data->sample_id_type = ResolveSampleIdOutputType(sample_id_col_type);
 	const auto rows_per_iter = static_cast<size_t>(n_samples) * static_cast<size_t>(n_dims);
 	data->rows.reserve(static_cast<size_t>(n_subsamples) * rows_per_iter);
 	for (int32_t i = 0; i < n_subsamples; ++i) {
@@ -267,7 +275,7 @@ unique_ptr<FunctionData> UnifracPcoaBind(ClientContext &context, TableFunctionBi
 	names.emplace_back("iteration");
 	return_types.emplace_back(LogicalType::INTEGER);
 	names.emplace_back("sample_id");
-	return_types.emplace_back(LogicalType::VARCHAR);
+	return_types.emplace_back(data->sample_id_type);
 	names.emplace_back("axis");
 	return_types.emplace_back(LogicalType::INTEGER);
 	names.emplace_back("coordinate");
@@ -284,6 +292,7 @@ unique_ptr<GlobalTableFunctionState> UnifracPcoaInitGlobal(ClientContext &, Tabl
 	auto &data = input.bind_data->CastNoConst<UnifracPcoaData>();
 	auto gstate = make_uniq<UnifracPcoaGlobalState>();
 	gstate->rows = std::move(data.rows);
+	gstate->sample_id_type = data.sample_id_type;
 	return std::move(gstate);
 }
 
@@ -299,7 +308,6 @@ void UnifracPcoaExecute(ClientContext &, TableFunctionInput &input, DataChunk &o
 
 	auto iter_data = FlatVector::GetData<int32_t>(output.data[0]);
 	auto &sample_id_vec = output.data[1];
-	auto sample_id_data = FlatVector::GetData<string_t>(sample_id_vec);
 	auto axis_data = FlatVector::GetData<int32_t>(output.data[2]);
 	auto coord_data = FlatVector::GetData<double>(output.data[3]);
 	auto eig_data = FlatVector::GetData<double>(output.data[4]);
@@ -308,7 +316,9 @@ void UnifracPcoaExecute(ClientContext &, TableFunctionInput &input, DataChunk &o
 	for (idx_t i = 0; i < n; ++i) {
 		const auto &r = gstate.rows[gstate.cursor + i];
 		iter_data[i] = r.iteration;
-		sample_id_data[i] = StringVector::AddString(sample_id_vec, r.sample_id);
+		// EmitIdCell mirrors the id type; its ""/"*"→NULL sentinel branch is
+		// unreachable here (ReadFeatureTable drops NULL sample_ids).
+		EmitIdCell(sample_id_vec, i, r.sample_id, gstate.sample_id_type);
 		axis_data[i] = r.axis;
 		coord_data[i] = r.coordinate;
 		eig_data[i] = r.eigenvalue;

--- a/src/unifrac_permanova_function.cpp
+++ b/src/unifrac_permanova_function.cpp
@@ -36,6 +36,7 @@ namespace {
 
 using unifrac_internal::AcceptedVariantList;
 using unifrac_internal::IsValidVariant;
+using unifrac_internal::ReadDistanceTable;
 using unifrac_internal::ReadFeatureTable;
 using unifrac_internal::ResolveThreadsParameter;
 
@@ -69,16 +70,18 @@ struct WideMetadata {
 // (case-insensitive); every other column is a variable whose values are
 // cast to VARCHAR. `requested_variables` empty → use all non-sample_id
 // columns in original column order. Non-empty → exact-match lookup
-// (case-insensitive), preserving user-supplied order.
+// (case-insensitive), preserving user-supplied order. `caller_name` prefixes
+// every error message so it names the SQL function the user actually called
+// (e.g. "permanova" vs "unifrac_permanova").
 WideMetadata ReadWideMetadata(ClientContext &context, const std::string &table_name,
-                              const std::vector<std::string> &requested_variables) {
+                              const std::vector<std::string> &requested_variables, const std::string &caller_name) {
 	auto &db = DatabaseInstance::GetDatabase(context);
 	Connection conn(db);
 	const auto qname = KeywordHelper::WriteOptionallyQuoted(table_name);
 
 	auto probe = conn.Query("SELECT * FROM " + qname + " LIMIT 0");
 	if (probe->HasError()) {
-		throw InvalidInputException("unifrac_permanova: failed to read metadata relation '%s': %s", table_name,
+		throw InvalidInputException("%s: failed to read metadata relation '%s': %s", caller_name, table_name,
 		                            probe->GetError());
 	}
 	auto &probe_mat = probe->Cast<MaterializedQueryResult>();
@@ -90,7 +93,7 @@ WideMetadata ReadWideMetadata(ClientContext &context, const std::string &table_n
 	for (idx_t i = 0; i < all_names.size(); ++i) {
 		if (StringUtil::Lower(all_names[i]) == "sample_id") {
 			if (sample_id_col != DConstants::INVALID_INDEX) {
-				throw BinderException("unifrac_permanova: metadata '%s' has multiple 'sample_id' columns", table_name);
+				throw BinderException("%s: metadata '%s' has multiple 'sample_id' columns", caller_name, table_name);
 			}
 			sample_id_col = i;
 		} else {
@@ -99,7 +102,7 @@ WideMetadata ReadWideMetadata(ClientContext &context, const std::string &table_n
 		}
 	}
 	if (sample_id_col == DConstants::INVALID_INDEX) {
-		throw BinderException("unifrac_permanova: metadata '%s' must have a 'sample_id' column", table_name);
+		throw BinderException("%s: metadata '%s' must have a 'sample_id' column", caller_name, table_name);
 	}
 
 	std::vector<std::string> chosen_variables;
@@ -121,9 +124,8 @@ WideMetadata ReadWideMetadata(ClientContext &context, const std::string &table_n
 		for (const auto &v : requested_variables) {
 			auto it = lookup.find(StringUtil::Lower(v));
 			if (it == lookup.end()) {
-				throw BinderException(
-				    "unifrac_permanova: variable '%s' not found in metadata '%s' (sample_id column is reserved)", v,
-				    table_name);
+				throw BinderException("%s: variable '%s' not found in metadata '%s' (sample_id column is reserved)",
+				                      caller_name, v, table_name);
 			}
 			chosen_variables.push_back(non_sample_cols[it->second]);
 			chosen_indices.push_back(non_sample_indices[it->second]);
@@ -138,9 +140,8 @@ WideMetadata ReadWideMetadata(ClientContext &context, const std::string &table_n
 
 	auto result = conn.Query(sql);
 	if (result->HasError()) {
-		throw InvalidInputException(
-		    "unifrac_permanova: failed to read metadata variables from '%s': %s\nGenerated SQL: %s", table_name,
-		    result->GetError(), sql);
+		throw InvalidInputException("%s: failed to read metadata variables from '%s': %s\nGenerated SQL: %s",
+		                            caller_name, table_name, result->GetError(), sql);
 	}
 
 	WideMetadata out;
@@ -181,6 +182,70 @@ WideMetadata ReadWideMetadata(ClientContext &context, const std::string &table_n
 	return out;
 }
 
+// Run PERMANOVA (skbb_permanova_fp32) on a dense fp32 distance matrix for every
+// grouping the metadata factorizes into, appending one PermanovaRow per
+// grouping. Shared by unifrac_permanova (once per subsample iteration, over a
+// freshly computed UniFrac matrix) and the metric-agnostic `permanova` (a single
+// iteration over any distance table), so the grouping + skbb path is identical
+// for both — the property the permanova/unifrac_permanova equivalence test pins.
+//
+// `mat` is n×n row-major fp32; `ids` are the matrix's sample ids (size n, the
+// order BuildGroupings aligns groupings to). `seed` is used across all
+// variables in the call, guaranteeing the Rule-7 invariant: identical groupings
+// under the same distance matrix produce identical pseudo-F. `caller_name`
+// prefixes the BuildGroupings error (missing sample / unknown variable).
+void RunPermanovaOnMatrix(const float *mat, uint32_t n, const std::vector<std::string> &ids,
+                          const std::vector<miint::unifrac::MetadataRow> &metadata_rows,
+                          const std::vector<std::string> &requested_variables, uint32_t n_permutations, int seed,
+                          int n_threads, int32_t iteration_index, const char *caller_name,
+                          std::vector<PermanovaRow> &out_rows) {
+	std::vector<miint::unifrac::NamedGrouping> groupings;
+	try {
+		groupings = miint::unifrac::BuildGroupings(metadata_rows, ids, requested_variables);
+	} catch (const std::invalid_argument &e) {
+		throw InvalidInputException("%s: %s", caller_name, e.what());
+	}
+
+	for (const auto &grouping : groupings) {
+		// skbb_permanova_fp32 takes its own per-call seed for randomization, but
+		// its `#pragma omp parallel for` regions (permanova.cpp) still need the
+		// process-wide OpenMP serialization so concurrent queries don't race on
+		// omp_set_num_threads.
+		float f_stat = 0.0f;
+		float p_value = 0.0f;
+		{
+			miint::unifrac::OmpThreadScope omp_scope(n_threads);
+			skbb_permanova_fp32(n, mat, grouping.labels.data(), n_permutations, seed, &f_stat, &p_value);
+		}
+		PermanovaRow row;
+		row.iteration = iteration_index;
+		row.variable = grouping.variable;
+		row.n_groups = static_cast<int32_t>(grouping.n_groups);
+		row.f_stat = static_cast<double>(f_stat);
+		row.p_value = static_cast<double>(p_value);
+		row.n_permutations = static_cast<int32_t>(n_permutations);
+		out_rows.push_back(std::move(row));
+	}
+}
+
+// Declare the PERMANOVA output schema. Shared by unifrac_permanova and permanova
+// so the two functions can never drift apart column-wise — the "identical output
+// schema" invariant is enforced structurally rather than by discipline.
+void DeclarePermanovaOutputSchema(vector<LogicalType> &return_types, vector<string> &names) {
+	names.emplace_back("iteration");
+	return_types.emplace_back(LogicalType::INTEGER);
+	names.emplace_back("variable");
+	return_types.emplace_back(LogicalType::VARCHAR);
+	names.emplace_back("n_groups");
+	return_types.emplace_back(LogicalType::INTEGER);
+	names.emplace_back("f_stat");
+	return_types.emplace_back(LogicalType::DOUBLE);
+	names.emplace_back("p_value");
+	return_types.emplace_back(LogicalType::DOUBLE);
+	names.emplace_back("n_permutations");
+	return_types.emplace_back(LogicalType::INTEGER);
+}
+
 void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view,
                          const miint::unifrac::UnifracBptreeView &bptree_view, const std::string &variant_fp32,
                          bool variance_adjust, double alpha, bool bypass_tips, bool normalize_sample_counts,
@@ -202,38 +267,8 @@ void ComputeOneIteration(const miint::unifrac::UnifracSupportBiomView &biom_view
 		}
 	}();
 
-	std::vector<miint::unifrac::NamedGrouping> groupings;
-	try {
-		groupings = miint::unifrac::BuildGroupings(metadata_rows, dist.sample_ids(), requested_variables);
-	} catch (const std::invalid_argument &e) {
-		throw InvalidInputException("unifrac_permanova: %s", e.what());
-	}
-
-	const uint32_t n_samples = dist.n_samples();
-	for (const auto &grouping : groupings) {
-		// skbb_permanova_fp32 takes its own per-call seed for randomization,
-		// but its `#pragma omp parallel for` regions (permanova.cpp) still
-		// need the process-wide OpenMP serialization so concurrent queries
-		// don't race on omp_set_num_threads. Using seed_iter across all
-		// variables in an iteration guarantees the Rule-7 invariant:
-		// identical groupings under the same distance matrix produce
-		// identical pseudo-F.
-		float f_stat = 0.0f;
-		float p_value = 0.0f;
-		{
-			miint::unifrac::OmpThreadScope omp_scope(n_threads);
-			skbb_permanova_fp32(n_samples, dist.matrix(), grouping.labels.data(), n_permutations, seed_iter, &f_stat,
-			                    &p_value);
-		}
-		PermanovaRow row;
-		row.iteration = iteration_index;
-		row.variable = grouping.variable;
-		row.n_groups = static_cast<int32_t>(grouping.n_groups);
-		row.f_stat = static_cast<double>(f_stat);
-		row.p_value = static_cast<double>(p_value);
-		row.n_permutations = static_cast<int32_t>(n_permutations);
-		out_rows.push_back(std::move(row));
-	}
+	RunPermanovaOnMatrix(dist.matrix(), dist.n_samples(), dist.sample_ids(), metadata_rows, requested_variables,
+	                     n_permutations, seed_iter, n_threads, iteration_index, "unifrac_permanova", out_rows);
 }
 
 unique_ptr<FunctionData> UnifracPermanovaBind(ClientContext &context, TableFunctionBindInput &input,
@@ -354,7 +389,7 @@ unique_ptr<FunctionData> UnifracPermanovaBind(ClientContext &context, TableFunct
 	}
 	auto bptree_view = miint::unifrac::UnifracBptreeView::FromNewickTree(tree);
 
-	auto metadata = ReadWideMetadata(context, metadata_name, requested_variables);
+	auto metadata = ReadWideMetadata(context, metadata_name, requested_variables, "unifrac_permanova");
 	if (metadata.column_names.empty()) {
 		throw BinderException("unifrac_permanova: metadata '%s' has no variable columns (only 'sample_id' present)",
 		                      metadata_name);
@@ -373,18 +408,7 @@ unique_ptr<FunctionData> UnifracPermanovaBind(ClientContext &context, TableFunct
 		                    n_threads, i, data->rows);
 	}
 
-	names.emplace_back("iteration");
-	return_types.emplace_back(LogicalType::INTEGER);
-	names.emplace_back("variable");
-	return_types.emplace_back(LogicalType::VARCHAR);
-	names.emplace_back("n_groups");
-	return_types.emplace_back(LogicalType::INTEGER);
-	names.emplace_back("f_stat");
-	return_types.emplace_back(LogicalType::DOUBLE);
-	names.emplace_back("p_value");
-	return_types.emplace_back(LogicalType::DOUBLE);
-	names.emplace_back("n_permutations");
-	return_types.emplace_back(LogicalType::INTEGER);
+	DeclarePermanovaOutputSchema(return_types, names);
 
 	return std::move(data);
 }
@@ -427,6 +451,66 @@ void UnifracPermanovaExecute(ClientContext &, TableFunctionInput &input, DataChu
 	output.SetCardinality(n);
 }
 
+// ── permanova(distances, metadata, ...) — metric-agnostic PERMANOVA ───────────
+// Decoupled from UniFrac: reads any `(sample_a, sample_b, distance)` relation
+// (the unifrac_distances output, a beta_* macro result, or a precomputed
+// Bray-Curtis/Jaccard/Euclidean table) into a dense matrix and runs the exact
+// same BuildGroupings + skbb_permanova_fp32 path as unifrac_permanova via
+// RunPermanovaOnMatrix. Reuses UnifracPermanovaData / UnifracPermanovaGlobalState
+// / UnifracPermanovaExecute / UnifracPermanovaInitGlobal and ReadWideMetadata
+// unchanged — the output schema is identical, iteration is always 0 (kept for
+// parity), and there is no subsampling (a distance table is a fixed matrix).
+unique_ptr<FunctionData> PermanovaFromDistancesBind(ClientContext &context, TableFunctionBindInput &input,
+                                                    vector<LogicalType> &return_types, vector<string> &names) {
+	const std::string table_name = input.inputs[0].GetValue<string>();
+	const std::string metadata_name = input.inputs[1].GetValue<string>();
+	if (table_name.empty() || metadata_name.empty()) {
+		throw BinderException("permanova: both positional arguments (distances, metadata) must be non-empty");
+	}
+
+	int32_t n_permutations = 999;
+	std::vector<std::string> requested_variables;
+	int32_t seed = -1;
+	int32_t threads = 0; // 0 = follow DuckDB's TaskScheduler::NumberOfThreads()
+	for (const auto &kv : input.named_parameters) {
+		const auto key = StringUtil::Lower(kv.first);
+		if (key == "n_permutations") {
+			n_permutations = kv.second.GetValue<int32_t>();
+		} else if (key == "variables") {
+			auto &list_children = ListValue::GetChildren(kv.second);
+			requested_variables.reserve(list_children.size());
+			for (const auto &child : list_children) {
+				requested_variables.push_back(child.GetValue<string>());
+			}
+		} else if (key == "seed") {
+			seed = kv.second.GetValue<int32_t>();
+		} else if (key == "threads") {
+			threads = kv.second.GetValue<int32_t>();
+		}
+	}
+	const int n_threads = ResolveThreadsParameter(context, threads, "permanova");
+	if (n_permutations < 1) {
+		throw BinderException("permanova: n_permutations must be >= 1 (got %d)", n_permutations);
+	}
+
+	auto dist = ReadDistanceTable(context, table_name, "permanova");
+	auto metadata = ReadWideMetadata(context, metadata_name, requested_variables, "permanova");
+	if (metadata.column_names.empty()) {
+		throw BinderException("permanova: metadata '%s' has no variable columns (only 'sample_id' present)",
+		                      metadata_name);
+	}
+
+	auto data = make_uniq<UnifracPermanovaData>();
+	data->rows.reserve(metadata.column_names.size());
+	RunPermanovaOnMatrix(dist.matrix.data(), dist.n_samples, dist.sample_ids, metadata.rows, metadata.column_names,
+	                     static_cast<uint32_t>(n_permutations), seed, n_threads, /*iteration_index*/ 0, "permanova",
+	                     data->rows);
+
+	DeclarePermanovaOutputSchema(return_types, names);
+
+	return std::move(data);
+}
+
 } // namespace
 
 void RegisterUnifracPermanova(ExtensionLoader &loader) {
@@ -442,6 +526,16 @@ void RegisterUnifracPermanova(ExtensionLoader &loader) {
 	fn.named_parameters["subsample_depth"] = LogicalType::INTEGER;
 	fn.named_parameters["subsample_with_replacement"] = LogicalType::BOOLEAN;
 	fn.named_parameters["n_subsamples"] = LogicalType::INTEGER;
+	fn.named_parameters["seed"] = LogicalType::INTEGER;
+	fn.named_parameters["threads"] = LogicalType::INTEGER;
+	loader.RegisterFunction(fn);
+}
+
+void RegisterPermanovaFromDistances(ExtensionLoader &loader) {
+	TableFunction fn("permanova", {LogicalType::VARCHAR, LogicalType::VARCHAR}, UnifracPermanovaExecute,
+	                 PermanovaFromDistancesBind, UnifracPermanovaInitGlobal);
+	fn.named_parameters["n_permutations"] = LogicalType::INTEGER;
+	fn.named_parameters["variables"] = LogicalType::LIST(LogicalType::VARCHAR);
 	fn.named_parameters["seed"] = LogicalType::INTEGER;
 	fn.named_parameters["threads"] = LogicalType::INTEGER;
 	loader.RegisterFunction(fn);

--- a/test/cpp/test_UnifracCondensed.cpp
+++ b/test/cpp/test_UnifracCondensed.cpp
@@ -1,0 +1,83 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "unifrac_condensed.hpp"
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+using miint::unifrac::CondensedCursor;
+
+namespace {
+
+// Drive a cursor to exhaustion, collecting every (i, j) it yields.
+std::vector<std::pair<uint32_t, uint32_t>> Drain(uint32_t n) {
+	std::vector<std::pair<uint32_t, uint32_t>> pairs;
+	auto c = CondensedCursor::Begin(n);
+	while (!c.done()) {
+		pairs.emplace_back(c.i, c.j);
+		c.advance();
+	}
+	return pairs;
+}
+
+// Independent reference: the strict upper triangle in row-major order.
+std::vector<std::pair<uint32_t, uint32_t>> Reference(uint32_t n) {
+	std::vector<std::pair<uint32_t, uint32_t>> pairs;
+	for (uint32_t i = 0; i + 1 < n; ++i) {
+		for (uint32_t j = i + 1; j < n; ++j) {
+			pairs.emplace_back(i, j);
+		}
+	}
+	return pairs;
+}
+
+} // namespace
+
+TEST_CASE("CondensedCursor yields nothing for n < 2", "[unifrac][condensed]") {
+	// A distance "matrix" with 0 or 1 samples has no unordered pairs. done()
+	// must be true from the start so the streaming loop emits an empty result
+	// rather than underflowing on n - 1.
+	REQUIRE(CondensedCursor::Begin(0).done());
+	REQUIRE(CondensedCursor::Begin(1).done());
+	REQUIRE(Drain(0).empty());
+	REQUIRE(Drain(1).empty());
+}
+
+TEST_CASE("CondensedCursor enumerates the strict upper triangle in order", "[unifrac][condensed]") {
+	// The emitted sequence is exactly (0,1),(0,2),...,(0,n-1),(1,2),... — one
+	// unordered pair each, diagonal excluded — which is what makes sample_a <
+	// sample_b hold for lexicographically sorted ids.
+	for (uint32_t n : {2u, 3u, 5u, 10u}) {
+		const auto got = Drain(n);
+		const auto want = Reference(n);
+		REQUIRE(got == want);
+		// n*(n-1)/2 pairs, all with i < j.
+		REQUIRE(got.size() == static_cast<size_t>(n) * (n - 1) / 2);
+		for (const auto &p : got) {
+			REQUIRE(p.first < p.second);
+		}
+	}
+}
+
+TEST_CASE("CondensedCursor is resumable across a boundary by copying", "[unifrac][condensed]") {
+	// The execute path snapshots the cursor between output chunks. Copying the
+	// value type mid-stream and continuing must produce the identical tail —
+	// this is the invariant that keeps multi-chunk streaming correct.
+	const uint32_t n = 12; // 66 pairs
+	auto full = Drain(n);
+
+	auto c = CondensedCursor::Begin(n);
+	std::vector<std::pair<uint32_t, uint32_t>> rejoined;
+	// Emit 20 pairs, snapshot, then resume from the copy.
+	for (int k = 0; k < 20 && !c.done(); ++k) {
+		rejoined.emplace_back(c.i, c.j);
+		c.advance();
+	}
+	CondensedCursor snapshot = c; // copy
+	while (!snapshot.done()) {
+		rejoined.emplace_back(snapshot.i, snapshot.j);
+		snapshot.advance();
+	}
+	REQUIRE(rejoined == full);
+}

--- a/test/cpp/test_UnifracDenseDistance.cpp
+++ b/test/cpp/test_UnifracDenseDistance.cpp
@@ -1,0 +1,145 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "unifrac_dense_distance.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using miint::unifrac::BuildDenseDistanceMatrix;
+using miint::unifrac::DistanceEntry;
+
+namespace {
+
+// Canonical 3-sample id vector for the fixtures below.
+const std::vector<std::string> kIds3 = {"A", "B", "C"};
+
+} // namespace
+
+TEST_CASE("BuildDenseDistanceMatrix fills a symmetric zero-diagonal matrix", "[unifrac][dense_distance]") {
+	// Full upper triangle of a 3-sample matrix: (A,B), (A,C), (B,C).
+	std::vector<DistanceEntry> entries = {{0, 1, 0.5}, {0, 2, 0.25}, {1, 2, 0.75}};
+	auto m = BuildDenseDistanceMatrix(entries, 3, kIds3);
+	REQUIRE(m.size() == 9);
+	// Diagonal is definitionally zero.
+	REQUIRE(m[0 * 3 + 0] == 0.0f);
+	REQUIRE(m[1 * 3 + 1] == 0.0f);
+	REQUIRE(m[2 * 3 + 2] == 0.0f);
+	// Symmetric off-diagonal.
+	REQUIRE(m[0 * 3 + 1] == 0.5f);
+	REQUIRE(m[1 * 3 + 0] == 0.5f);
+	REQUIRE(m[0 * 3 + 2] == 0.25f);
+	REQUIRE(m[2 * 3 + 0] == 0.25f);
+	REQUIRE(m[1 * 3 + 2] == 0.75f);
+	REQUIRE(m[2 * 3 + 1] == 0.75f);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix accepts a distance of exactly zero", "[unifrac][dense_distance]") {
+	// A genuine off-diagonal zero (identical composition) must be distinguished
+	// from an unfilled cell — the completeness check must still pass.
+	std::vector<DistanceEntry> entries = {{0, 1, 0.0}, {0, 2, 0.25}, {1, 2, 0.75}};
+	auto m = BuildDenseDistanceMatrix(entries, 3, kIds3);
+	REQUIRE(m[0 * 3 + 1] == 0.0f);
+	REQUIRE(m[1 * 3 + 0] == 0.0f);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix ignores self-pairs", "[unifrac][dense_distance]") {
+	// (A,A) is the diagonal — definitionally zero — and must not count toward
+	// completeness nor overwrite anything.
+	std::vector<DistanceEntry> entries = {{0, 0, 0.0}, {0, 1, 0.5}, {0, 2, 0.25}, {1, 2, 0.75}, {2, 2, 0.0}};
+	auto m = BuildDenseDistanceMatrix(entries, 3, kIds3);
+	REQUIRE(m[0 * 3 + 1] == 0.5f);
+	REQUIRE(m[0 * 3 + 0] == 0.0f);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix tolerates identical duplicates and (b,a) mirrors", "[unifrac][dense_distance]") {
+	// The same unordered pair given twice with the same value — including the
+	// reversed (b,a) orientation — is a no-op, not a conflict.
+	std::vector<DistanceEntry> entries = {{0, 1, 0.5}, {1, 0, 0.5}, {0, 2, 0.25}, {1, 2, 0.75}, {2, 1, 0.75}};
+	auto m = BuildDenseDistanceMatrix(entries, 3, kIds3);
+	REQUIRE(m[0 * 3 + 1] == 0.5f);
+	REQUIRE(m[1 * 3 + 2] == 0.75f);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects conflicting duplicates", "[unifrac][dense_distance]") {
+	// Same unordered pair, two different values → the input is ambiguous and we
+	// must fail loud rather than silently keep one.
+	std::vector<DistanceEntry> entries = {{0, 1, 0.5}, {0, 1, 0.6}, {0, 2, 0.25}, {1, 2, 0.75}};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(entries, 3, kIds3), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects a conflicting (b,a) mirror", "[unifrac][dense_distance]") {
+	std::vector<DistanceEntry> entries = {{0, 1, 0.5}, {1, 0, 0.6}, {0, 2, 0.25}, {1, 2, 0.75}};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(entries, 3, kIds3), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects negative distances", "[unifrac][dense_distance]") {
+	std::vector<DistanceEntry> entries = {{0, 1, -0.1}, {0, 2, 0.25}, {1, 2, 0.75}};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(entries, 3, kIds3), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix names the FIRST gap in row-major order", "[unifrac][dense_distance]") {
+	// n=4 with three gaps — (A,B), (A,C), (A,D) all missing — and three present
+	// pairs (B,C), (B,D), (C,D). The contract is to name the first missing pair
+	// in row-major upper-triangle order, which is (A,B). A weaker test with a
+	// single gap could not tell "finds the first gap" from "finds any gap", so a
+	// scan-order regression (column-major, unordered map) would slip through.
+	const std::vector<std::string> ids4 = {"A", "B", "C", "D"};
+	std::vector<DistanceEntry> entries = {{1, 2, 0.5}, {1, 3, 0.25}, {2, 3, 0.75}};
+	try {
+		BuildDenseDistanceMatrix(entries, 4, ids4);
+		FAIL("expected std::invalid_argument");
+	} catch (const std::invalid_argument &e) {
+		const std::string msg = e.what();
+		REQUIRE(msg.find("'A'") != std::string::npos);
+		REQUIRE(msg.find("'B'") != std::string::npos);
+		// The first gap is (A,B); C and D must not appear in the message.
+		REQUIRE(msg.find("'C'") == std::string::npos);
+		REQUIRE(msg.find("'D'") == std::string::npos);
+	}
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects non-finite distances", "[unifrac][dense_distance]") {
+	// NaN/Inf would silently poison skbb_pcoa_fsvd_fp32 / skbb_permanova_fp32,
+	// and NaN specifically breaks the identical-duplicate check (NaN != NaN), so
+	// it must be rejected up front rather than stored.
+	const double nan_v = std::numeric_limits<double>::quiet_NaN();
+	const double inf_v = std::numeric_limits<double>::infinity();
+	std::vector<DistanceEntry> with_nan = {{0, 1, nan_v}, {0, 2, 0.25}, {1, 2, 0.75}};
+	std::vector<DistanceEntry> with_inf = {{0, 1, inf_v}, {0, 2, 0.25}, {1, 2, 0.75}};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(with_nan, 3, kIds3), std::invalid_argument);
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(with_inf, 3, kIds3), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects a nonzero self-distance", "[unifrac][dense_distance]") {
+	// A zero self-pair is the (ignored) diagonal; a nonzero one is contradictory
+	// input (the diagonal is definitionally zero) and must fail loud, not be
+	// silently discarded.
+	std::vector<DistanceEntry> entries = {{0, 0, 3.7}, {0, 1, 0.5}, {0, 2, 0.25}, {1, 2, 0.75}};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(entries, 3, kIds3), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects out-of-range indices", "[unifrac][dense_distance]") {
+	// An index >= n must throw cleanly rather than read/write out of bounds —
+	// this header is DuckDB-free and callable directly.
+	std::vector<DistanceEntry> entries = {{0, 3, 0.5}, {0, 2, 0.25}, {1, 2, 0.75}};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(entries, 3, kIds3), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix rejects an ids/n size mismatch", "[unifrac][dense_distance]") {
+	// ids must describe exactly n samples; a mismatch is a caller-contract bug
+	// that would otherwise index ids out of bounds in an error message.
+	std::vector<DistanceEntry> entries = {{0, 1, 0.5}, {0, 2, 0.25}, {1, 2, 0.75}};
+	const std::vector<std::string> ids2 = {"A", "B"};
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(entries, 3, ids2), std::invalid_argument);
+}
+
+TEST_CASE("BuildDenseDistanceMatrix requires at least two samples", "[unifrac][dense_distance]") {
+	// A 0- or 1-sample matrix has no unordered pairs; ordination and PERMANOVA
+	// are both undefined, so this is an error rather than an empty result.
+	std::vector<DistanceEntry> none;
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(none, 0, {}), std::invalid_argument);
+	REQUIRE_THROWS_AS(BuildDenseDistanceMatrix(none, 1, {"A"}), std::invalid_argument);
+}

--- a/test/sql/beta_distance_macros.test
+++ b/test/sql/beta_distance_macros.test
@@ -1,0 +1,108 @@
+# name: test/sql/beta_distance_macros.test
+# description: beta-distance SQL macros over a condensed distance table — within/between grouping and k-NN.
+# group: [sql]
+
+require miint
+
+# Macros are registered at extension load, so no require-env gate is needed.
+
+statement ok
+PRAGMA enable_verification;
+
+# A tiny condensed distance table (upper triangle, as unifrac_distances emits).
+statement ok
+CREATE TABLE dist AS SELECT sample_a, sample_b, distance::DOUBLE AS distance FROM (VALUES
+    ('a', 'b', 0.1), ('a', 'c', 0.5), ('b', 'c', 0.4)
+) t(sample_a, sample_b, distance);
+
+# A (sample_id, grouping) reduction of some metadata.
+statement ok
+CREATE TABLE grp AS SELECT * FROM (VALUES
+    ('a', 'gut'), ('b', 'gut'), ('c', 'skin')
+) t(sample_id, grouping);
+
+# All three macros are registered.
+query I
+SELECT COUNT(DISTINCT function_name) FROM duckdb_functions()
+WHERE function_name IN ('beta_group_distances', 'beta_knn', 'beta_knn_from_sample');
+----
+3
+
+# ── beta_group_distances: label each pair within/between ──────────────────────
+query TTTT
+SELECT sample_a, sample_b, comparison, group_a || '|' || group_b AS groups
+FROM beta_group_distances(dist, grp)
+ORDER BY sample_a, sample_b;
+----
+a	b	within	gut|gut
+a	c	between	gut|skin
+b	c	between	gut|skin
+
+# The #158 use case: aggregated within/between distance distribution.
+query TIR
+SELECT comparison, count(*) AS n, round(avg(distance), 4) AS mean
+FROM beta_group_distances(dist, grp)
+GROUP BY comparison ORDER BY comparison;
+----
+between	2	0.45
+within	1	0.1
+
+# ── beta_knn: k nearest neighbors per sample, both orientations, with distance ─
+# k=1: each sample's single nearest neighbor. a↔b are mutual nearest (0.1);
+# c's nearest is b (0.4 < 0.5).
+query TTR
+SELECT sample_id, neighbor, distance FROM beta_knn(dist, 1) ORDER BY sample_id;
+----
+a	b	0.1
+b	a	0.1
+c	b	0.4
+
+# k=2 returns every directed neighbor (3 samples × 2 = 6).
+query I
+SELECT COUNT(*) FROM beta_knn(dist, 2);
+----
+6
+
+# rank is exposed and starts at 1.
+query I
+SELECT COUNT(*) FROM beta_knn(dist, 2) WHERE rank NOT IN (1, 2);
+----
+0
+
+# ── beta_knn_from_sample: nearest neighbors of one source, with distance ──────
+query TR
+SELECT neighbor, distance FROM beta_knn_from_sample(dist, 2, 'a') ORDER BY distance, neighbor;
+----
+b	0.1
+c	0.5
+
+# c appears only as sample_b in dist; the macro still finds both orientations.
+query TR
+SELECT neighbor, distance FROM beta_knn_from_sample(dist, 1, 'c');
+----
+b	0.4
+
+# 'b' appears on BOTH sides (sample_b of (a,b), sample_a of (b,c)) — both UNION
+# branches must fire and merge for its neighbor list to be complete.
+query TR
+SELECT neighbor, distance FROM beta_knn_from_sample(dist, 2, 'b') ORDER BY distance, neighbor;
+----
+a	0.1
+c	0.4
+
+# Absent source → empty result (not an error).
+query I
+SELECT COUNT(*) FROM beta_knn_from_sample(dist, 5, 'nonexistent');
+----
+0
+
+# k <= 0 yields no rows for either k-NN macro (locks the boundary behavior).
+query I
+SELECT COUNT(*) FROM beta_knn(dist, 0);
+----
+0
+
+query I
+SELECT COUNT(*) FROM beta_knn_from_sample(dist, 0, 'a');
+----
+0

--- a/test/sql/pcoa.test
+++ b/test/sql/pcoa.test
@@ -1,0 +1,260 @@
+# name: test/sql/pcoa.test
+# description: pcoa table function — metric-agnostic PCoA over a condensed (sample_a, sample_b, distance) distance table.
+# group: [sql]
+
+require miint
+
+require-env UNIFRAC_AVAILABLE
+
+# ── Inline distance table: 4 samples, complete upper triangle (6 pairs) ───────
+statement ok
+CREATE TABLE dist AS SELECT * FROM (VALUES
+    ('A', 'B', 0.50),
+    ('A', 'C', 0.60),
+    ('A', 'D', 0.70),
+    ('B', 'C', 0.30),
+    ('B', 'D', 0.40),
+    ('C', 'D', 0.20)
+) AS t(sample_a, sample_b, distance);
+
+# Default n_dims=3 over 4 samples → 4 * 3 = 12 rows.
+query I
+SELECT COUNT(*) FROM pcoa('dist', seed := 42);
+----
+12
+
+# n_dims is honoured: 4 samples * 2 dims = 8 rows, exactly 2 distinct axes.
+query I
+SELECT COUNT(*) FROM pcoa('dist', n_dims := 2, seed := 42);
+----
+8
+
+query I
+SELECT COUNT(DISTINCT axis) FROM pcoa('dist', n_dims := 2, seed := 42);
+----
+2
+
+# iteration is always 0 (kept for schema parity with unifrac_pcoa); every sample
+# appears once per axis.
+query I
+SELECT COUNT(DISTINCT iteration) FROM pcoa('dist', n_dims := 3, seed := 42);
+----
+1
+
+query I
+SELECT COUNT(DISTINCT sample_id) FROM pcoa('dist', n_dims := 3, seed := 42);
+----
+4
+
+# Output schema + column types are stable (VARCHAR ids stay VARCHAR).
+query ITIIII
+SELECT iteration, typeof(sample_id), axis, coordinate IS NOT NULL,
+       eigenvalue IS NOT NULL, proportion_explained IS NOT NULL
+FROM pcoa('dist', n_dims := 3, seed := 42)
+WHERE sample_id = 'A' AND axis = 0;
+----
+0	VARCHAR	0	true	true	true
+
+# Eigenvalues are non-increasing across axes (axis 0 is the largest).
+query I
+WITH per_axis AS (
+    SELECT DISTINCT axis, eigenvalue FROM pcoa('dist', n_dims := 3, seed := 42)
+), lagged AS (
+    SELECT axis, eigenvalue, LAG(eigenvalue) OVER (ORDER BY axis) AS prev_eigenvalue
+    FROM per_axis
+)
+SELECT bool_and(prev_eigenvalue IS NULL OR prev_eigenvalue >= eigenvalue) FROM lagged;
+----
+true
+
+# ── Seed reproducibility (tolerance-based; see the fp32 note in unifrac_pcoa.test) ──
+query I
+WITH a AS (SELECT * FROM pcoa('dist', n_dims := 3, seed := 42)),
+     b AS (SELECT * FROM pcoa('dist', n_dims := 3, seed := 42))
+SELECT COUNT(*) FROM a
+JOIN b USING (iteration, sample_id, axis)
+WHERE abs(a.coordinate - b.coordinate) < 1e-5
+  AND abs(a.eigenvalue - b.eigenvalue) < 1e-5
+  AND abs(a.proportion_explained - b.proportion_explained) < 1e-5;
+----
+12
+
+# ── Sample-ID type parity (BIGINT / UUID mirrored onto the output) ────────────
+statement ok
+CREATE TABLE dist_bigint AS
+    SELECT (ascii(sample_a) - 64)::BIGINT AS sample_a,
+           (ascii(sample_b) - 64)::BIGINT AS sample_b, distance FROM dist;
+
+query T
+SELECT DISTINCT typeof(sample_id) FROM pcoa('dist_bigint', n_dims := 3, seed := 42);
+----
+BIGINT
+
+query I
+SELECT COUNT(DISTINCT sample_id) FROM pcoa('dist_bigint', n_dims := 3, seed := 42);
+----
+4
+
+statement ok
+CREATE TABLE dist_uuid AS
+    SELECT ma.uid AS sample_a, mb.uid AS sample_b, d.distance
+    FROM dist d
+    JOIN (VALUES
+        ('A', '11111111-1111-1111-1111-111111111111'::UUID),
+        ('B', '22222222-2222-2222-2222-222222222222'::UUID),
+        ('C', '33333333-3333-3333-3333-333333333333'::UUID),
+        ('D', '44444444-4444-4444-4444-444444444444'::UUID)
+    ) ma(orig, uid) ON d.sample_a = ma.orig
+    JOIN (VALUES
+        ('A', '11111111-1111-1111-1111-111111111111'::UUID),
+        ('B', '22222222-2222-2222-2222-222222222222'::UUID),
+        ('C', '33333333-3333-3333-3333-333333333333'::UUID),
+        ('D', '44444444-4444-4444-4444-444444444444'::UUID)
+    ) mb(orig, uid) ON d.sample_b = mb.orig;
+
+query T
+SELECT DISTINCT typeof(sample_id) FROM pcoa('dist_uuid', n_dims := 3, seed := 42);
+----
+UUID
+
+# ── Bind-time / read errors ──────────────────────────────────────────────────
+
+# n_dims > n_samples - 1 → Binder error (PCoA loses one dim to centering).
+# 4 samples → max allowed n_dims is 3.
+statement error
+SELECT * FROM pcoa('dist', n_dims := 4);
+----
+n_dims
+
+# n_dims must be >= 1.
+statement error
+SELECT * FROM pcoa('dist', n_dims := 0);
+----
+n_dims
+
+# Incomplete matrix (a pair is missing) → error naming the first missing pair.
+statement ok
+CREATE TABLE dist_incomplete AS SELECT * FROM dist WHERE NOT (sample_a = 'A' AND sample_b = 'C');
+
+statement error
+SELECT * FROM pcoa('dist_incomplete', n_dims := 2);
+----
+incomplete distance matrix
+
+# Negative distance → error.
+statement ok
+CREATE TABLE dist_negative AS SELECT * FROM (VALUES
+    ('A', 'B', -0.50), ('A', 'C', 0.60), ('B', 'C', 0.30)
+) AS t(sample_a, sample_b, distance);
+
+statement error
+SELECT * FROM pcoa('dist_negative', n_dims := 2);
+----
+negative distance
+
+# Conflicting duplicate (same pair, two different values) → error.
+statement ok
+CREATE TABLE dist_conflict AS SELECT * FROM (VALUES
+    ('A', 'B', 0.50), ('A', 'B', 0.60), ('A', 'C', 0.60), ('B', 'C', 0.30)
+) AS t(sample_a, sample_b, distance);
+
+statement error
+SELECT * FROM pcoa('dist_conflict', n_dims := 2);
+----
+conflicting distances
+
+# Fewer than 2 distinct samples → error (a single self-pair yields 1 id).
+statement ok
+CREATE TABLE dist_one AS SELECT * FROM (VALUES ('A', 'A', 0.0)) AS t(sample_a, sample_b, distance);
+
+statement error
+SELECT * FROM pcoa('dist_one', n_dims := 1);
+----
+at least 2 are required
+
+# Mismatched sample_a / sample_b id types → Binder error (they merge into one
+# output column, so both must resolve to the same output type).
+statement ok
+CREATE TABLE dist_mixed_types AS
+    SELECT sample_a, (ascii(sample_b) - 64)::BIGINT AS sample_b, distance FROM dist;
+
+statement error
+SELECT * FROM pcoa('dist_mixed_types', n_dims := 2);
+----
+mismatched
+
+# ── Order-independence: ids are collected from BOTH columns ───────────────────
+# Swapping sample_a<->sample_b (so sample_a > sample_b for every row, and 'A'
+# now appears only in sample_b) must yield the identical ordination. A reader
+# that only read sample_a would lose sample 'A' entirely.
+statement ok
+CREATE TABLE dist_swapped AS SELECT sample_b AS sample_a, sample_a AS sample_b, distance FROM dist;
+
+query I
+SELECT COUNT(DISTINCT sample_id) FROM pcoa('dist_swapped', n_dims := 3, seed := 42);
+----
+4
+
+query I
+WITH a AS (SELECT sample_id, axis, abs(coordinate) AS c FROM pcoa('dist', n_dims := 3, seed := 42)),
+     b AS (SELECT sample_id, axis, abs(coordinate) AS c FROM pcoa('dist_swapped', n_dims := 3, seed := 42))
+SELECT COUNT(*) FROM a JOIN b USING (sample_id, axis) WHERE abs(a.c - b.c) < 1e-5;
+----
+12
+
+# ── A sample whose every distance is NaN must not silently vanish ─────────────
+# 'D' appears in three rows, all with NaN distance. Its ids are still recorded,
+# so it enters the dictionary and the missing (·, D) pairs surface as an
+# incompleteness error — rather than pcoa silently ordinating only {A,B,C} and
+# returning a smaller result than the user's table implies.
+statement ok
+CREATE TABLE dist_nan_sample AS SELECT * FROM (VALUES
+    ('A', 'B', 0.50),
+    ('A', 'C', 0.60),
+    ('B', 'C', 0.30),
+    ('A', 'D', 'nan'::DOUBLE),
+    ('B', 'D', 'nan'::DOUBLE),
+    ('C', 'D', 'nan'::DOUBLE)
+) AS t(sample_a, sample_b, distance);
+
+statement error
+SELECT * FROM pcoa('dist_nan_sample', n_dims := 2);
+----
+incomplete distance matrix
+
+# ── Equivalence (killer test): pcoa over unifrac_distances ≈ unifrac_pcoa ─────
+# Same distance matrix + same skbb_pcoa_fsvd_fp32 + same seed ⇒ identical
+# coordinates (up to axis sign, so compare |coordinate|) within fp32 tolerance.
+statement ok
+CREATE TABLE observations AS SELECT * FROM read_biom('data/biom/test.biom');
+
+statement ok
+CREATE TABLE tree AS SELECT * FROM read_newick('data/unifrac/gg_otu_tree.nwk');
+
+statement ok
+CREATE TABLE ud AS SELECT sample_a, sample_b, distance
+FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized');
+
+# Independent cardinality check before the join: guards against a dedup bug that
+# could fan the join out and coincidentally still land on 18 matched rows.
+query I
+SELECT COUNT(*) FROM pcoa('ud', n_dims := 3, seed := 42);
+----
+18
+
+# 6 samples × 3 dims = 18 rows match within tolerance (join on sample_id, axis).
+query I
+WITH viadist AS (
+    SELECT sample_id, axis, abs(coordinate) AS c, eigenvalue AS e
+    FROM pcoa('ud', n_dims := 3, seed := 42)
+),
+     direct AS (
+    SELECT sample_id, axis, abs(coordinate) AS c, eigenvalue AS e
+    FROM unifrac_pcoa('observations', 'tree', variant := 'weighted_normalized', n_dims := 3, seed := 42)
+)
+SELECT COUNT(*) FROM viadist
+JOIN direct USING (sample_id, axis)
+WHERE abs(viadist.c - direct.c) < 1e-5
+  AND abs(viadist.e - direct.e) < 1e-5;
+----
+18

--- a/test/sql/permanova.test
+++ b/test/sql/permanova.test
@@ -1,0 +1,181 @@
+# name: test/sql/permanova.test
+# description: permanova table function — metric-agnostic PERMANOVA over a condensed (sample_a, sample_b, distance) distance table + wide metadata.
+# group: [sql]
+
+require miint
+
+require-env UNIFRAC_AVAILABLE
+
+# ── Inline distance table: 4 samples, complete upper triangle (6 pairs) ───────
+# A,B close and C,D close; A,B far from C,D — a clear two-group structure.
+statement ok
+CREATE TABLE dist AS SELECT * FROM (VALUES
+    ('A', 'B', 0.10),
+    ('A', 'C', 0.90),
+    ('A', 'D', 0.85),
+    ('B', 'C', 0.88),
+    ('B', 'D', 0.92),
+    ('C', 'D', 0.15)
+) AS t(sample_a, sample_b, distance);
+
+statement ok
+CREATE TABLE metadata AS SELECT * FROM (VALUES
+    ('A', 'left',  'x'),
+    ('B', 'left',  'x'),
+    ('C', 'right', 'x'),
+    ('D', 'right', 'x')
+) AS t(sample_id, grp, single_group);
+
+# ── Single-variable happy path ───────────────────────────────────────────────
+query I
+SELECT COUNT(*) FROM permanova('dist', 'metadata', variables := ['grp'],
+    n_permutations := 99, seed := 42);
+----
+1
+
+# Output schema: iteration, variable, n_groups, f_stat, p_value, n_permutations.
+query IIIIII
+SELECT iteration, variable, n_groups,
+       f_stat IS NOT NULL, p_value IS NOT NULL, n_permutations
+FROM permanova('dist', 'metadata', variables := ['grp'], n_permutations := 99, seed := 42);
+----
+0	grp	2	true	true	99
+
+# p_value in [0, 1]; f_stat finite for a real two-group split.
+query I
+SELECT COUNT(*) FROM permanova('dist', 'metadata', variables := ['grp'],
+    n_permutations := 99, seed := 42)
+WHERE p_value < 0 OR p_value > 1 OR NOT isfinite(f_stat);
+----
+0
+
+# n_groups matches the count of distinct values per requested variable.
+query II
+SELECT variable, n_groups FROM permanova('dist', 'metadata',
+    variables := ['grp', 'single_group'], n_permutations := 99, seed := 42)
+ORDER BY variable;
+----
+grp	2
+single_group	1
+
+# Default variables: empty list selects every non-sample_id column → 2 rows.
+query I
+SELECT COUNT(*) FROM permanova('dist', 'metadata', n_permutations := 99, seed := 42);
+----
+2
+
+# ── Seed reproducibility ─────────────────────────────────────────────────────
+# Same seed ⇒ identical p_value (byte-identical: same permutations) and f_stat.
+query I
+WITH a AS (SELECT * FROM permanova('dist', 'metadata', variables := ['grp'],
+              n_permutations := 99, seed := 42)),
+     b AS (SELECT * FROM permanova('dist', 'metadata', variables := ['grp'],
+              n_permutations := 99, seed := 42))
+SELECT COUNT(*) FROM a JOIN b USING (iteration, variable)
+WHERE a.p_value = b.p_value AND abs(a.f_stat - b.f_stat) < 1e-5 AND a.n_groups = b.n_groups;
+----
+1
+
+# ── Read / bind errors ───────────────────────────────────────────────────────
+
+# Metadata missing a sample present in the distance matrix → error naming it.
+statement ok
+CREATE TABLE metadata_missing AS SELECT sample_id, grp FROM metadata WHERE sample_id <> 'C';
+
+statement error
+SELECT * FROM permanova('dist', 'metadata_missing', variables := ['grp']);
+----
+C
+
+# Unknown variable → Binder error naming it.
+statement error
+SELECT * FROM permanova('dist', 'metadata', variables := ['nonexistent_column']);
+----
+nonexistent_column
+
+# n_permutations must be >= 1.
+statement error
+SELECT * FROM permanova('dist', 'metadata', n_permutations := 0);
+----
+n_permutations
+
+# Metadata without a sample_id column → Binder error.
+statement ok
+CREATE TABLE metadata_no_sid AS SELECT grp, single_group FROM metadata;
+
+statement error
+SELECT * FROM permanova('dist', 'metadata_no_sid');
+----
+sample_id
+
+# Incomplete distance matrix → error naming the first missing pair.
+statement ok
+CREATE TABLE dist_incomplete AS SELECT * FROM dist WHERE NOT (sample_a = 'A' AND sample_b = 'C');
+
+statement error
+SELECT * FROM permanova('dist_incomplete', 'metadata', variables := ['grp']);
+----
+incomplete distance matrix
+
+# ── Sample-ID type parity: BIGINT distance-table ids join to BIGINT metadata ──
+statement ok
+CREATE TABLE dist_bigint AS
+    SELECT (ascii(sample_a) - 64)::BIGINT AS sample_a,
+           (ascii(sample_b) - 64)::BIGINT AS sample_b, distance FROM dist;
+
+statement ok
+CREATE TABLE metadata_bigint AS
+    SELECT (ascii(sample_id) - 64)::BIGINT AS sample_id, grp FROM metadata;
+
+query II
+SELECT variable, n_groups FROM permanova('dist_bigint', 'metadata_bigint',
+    variables := ['grp'], n_permutations := 99, seed := 42);
+----
+grp	2
+
+# Same underlying data + same seed ⇒ the BIGINT-keyed result matches the
+# VARCHAR baseline exactly (sample matching is value-based, not positional).
+query I
+WITH v AS (SELECT variable, n_groups, f_stat, p_value FROM permanova('dist', 'metadata',
+              variables := ['grp'], n_permutations := 99, seed := 42)),
+     b AS (SELECT variable, n_groups, f_stat, p_value FROM permanova('dist_bigint', 'metadata_bigint',
+              variables := ['grp'], n_permutations := 99, seed := 42))
+SELECT COUNT(*) FROM v JOIN b USING (variable)
+WHERE v.n_groups = b.n_groups AND v.p_value = b.p_value AND abs(v.f_stat - b.f_stat) < 1e-5;
+----
+1
+
+# ── Equivalence (killer test): permanova over unifrac_distances ≈ unifrac_permanova ──
+# Same distance matrix + same groupings + same skbb_permanova_fp32 + same seed ⇒
+# p_value byte-identical and f_stat within fp32 tolerance.
+statement ok
+CREATE TABLE observations AS SELECT * FROM read_biom('data/biom/test.biom');
+
+statement ok
+CREATE TABLE tree AS SELECT * FROM read_newick('data/unifrac/gg_otu_tree.nwk');
+
+statement ok
+CREATE TABLE ud AS SELECT sample_a, sample_b, distance
+FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized');
+
+statement ok
+CREATE TABLE meta6 AS SELECT * FROM (VALUES
+    ('Sample1', 'gut'),  ('Sample2', 'gut'),  ('Sample3', 'gut'),
+    ('Sample4', 'skin'), ('Sample5', 'skin'), ('Sample6', 'skin')
+) AS t(sample_id, body_site);
+
+query I
+WITH viadist AS (
+    SELECT variable, n_groups, f_stat, p_value FROM permanova('ud', 'meta6',
+        variables := ['body_site'], n_permutations := 99, seed := 42)
+),
+     direct AS (
+    SELECT variable, n_groups, f_stat, p_value FROM unifrac_permanova('observations', 'tree', 'meta6',
+        variant := 'weighted_normalized', variables := ['body_site'], n_permutations := 99, seed := 42)
+)
+SELECT COUNT(*) FROM viadist JOIN direct USING (variable)
+WHERE viadist.n_groups = direct.n_groups
+  AND viadist.p_value = direct.p_value
+  AND abs(viadist.f_stat - direct.f_stat) < 1e-5;
+----
+1

--- a/test/sql/unifrac_available.test
+++ b/test/sql/unifrac_available.test
@@ -25,6 +25,12 @@ WHERE function_name = 'unifrac_faith_pd' AND function_type = 'table';
 ----
 1
 
+query I
+SELECT COUNT(*) FROM duckdb_functions()
+WHERE function_name = 'unifrac_distances' AND function_type = 'table';
+----
+1
+
 # Both embedded libraries report a version string (git describe output).
 query I
 SELECT COUNT(*) FROM miint_versions()

--- a/test/sql/unifrac_available.test
+++ b/test/sql/unifrac_available.test
@@ -31,6 +31,19 @@ WHERE function_name = 'unifrac_distances' AND function_type = 'table';
 ----
 1
 
+# Metric-agnostic distance-table analytics (decoupled from UniFrac).
+query I
+SELECT COUNT(*) FROM duckdb_functions()
+WHERE function_name = 'pcoa' AND function_type = 'table';
+----
+1
+
+query I
+SELECT COUNT(*) FROM duckdb_functions()
+WHERE function_name = 'permanova' AND function_type = 'table';
+----
+1
+
 # Both embedded libraries report a version string (git describe output).
 query I
 SELECT COUNT(*) FROM miint_versions()

--- a/test/sql/unifrac_distances.test
+++ b/test/sql/unifrac_distances.test
@@ -1,0 +1,348 @@
+# name: test/sql/unifrac_distances.test
+# description: unifrac_distances table function — condensed (upper-triangle) UniFrac distances in COO long form.
+# group: [sql]
+
+require miint
+
+require-env UNIFRAC_AVAILABLE
+
+# 6 samples × 5 features; tips of gg_otu_tree.nwk are GG_OTU_1..GG_OTU_5.
+statement ok
+CREATE TABLE observations AS SELECT * FROM read_biom('data/biom/test.biom');
+
+statement ok
+CREATE TABLE tree AS SELECT * FROM read_newick('data/unifrac/gg_otu_tree.nwk');
+
+# ── Completeness / shape ─────────────────────────────────────────────────────
+# Condensed upper triangle of a 6-sample matrix = 6*5/2 = 15 pairs, one iteration.
+query I
+SELECT COUNT(*) FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized');
+----
+15
+
+# Every emitted pair is unique (no duplicates, no diagonal).
+query I
+SELECT COUNT(*) = COUNT(DISTINCT (sample_a, sample_b)) AND COUNT(*) = 15
+FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized');
+----
+true
+
+# Canonical ordering: sample_a is strictly less than sample_b for every row
+# (upper triangle over lexicographically sorted sample ids). No self-pairs.
+query I
+SELECT COUNT(*) FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized')
+WHERE sample_a >= sample_b;
+----
+0
+
+# Single iteration by default → iteration is 0 for every row.
+query I
+SELECT COUNT(DISTINCT iteration) FROM unifrac_distances('observations', 'tree',
+    variant := 'weighted_normalized');
+----
+1
+
+# Output schema column types are stable.
+query ITTI
+SELECT iteration, typeof(sample_a), typeof(sample_b), distance IS NOT NULL
+FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized')
+ORDER BY sample_a, sample_b
+LIMIT 1;
+----
+0	VARCHAR	VARCHAR	true
+
+# ── Value bounds ─────────────────────────────────────────────────────────────
+# Normalized variants produce distances in [0, 1]; all distances are >= 0.
+query I
+SELECT COUNT(*) FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized')
+WHERE distance < 0 OR distance > 1;
+----
+0
+
+# ── Exact hand-computed values (unweighted UniFrac) ──────────────────────────
+# Tree ((A:0.1,B:0.2):0.3,C:0.4): internal edge int=0.3 is the parent of A,B.
+# Unweighted UniFrac = (branch length unique to one sample) / (branch length in
+# either sample). Hand-derived for each pair below:
+#   {A} vs {B}      : unique A(0.1)+B(0.2)=0.3, union 0.6                  → 0.5
+#   {A} vs {C}      : unique 0.1+0.3+0.4=0.8,   union 0.8                  → 1.0
+#   {B} vs {C}      : unique 0.2+0.3+0.4=0.9,   union 0.9                  → 1.0
+#   {A} vs {A,B,C}  : unique B(0.2)+C(0.4)=0.6, union 1.0                  → 0.6
+#   {B} vs {A,B,C}  : unique A(0.1)+C(0.4)=0.5, union 1.0                  → 0.5
+#   {C} vs {A,B,C}  : unique A(0.1)+B(0.2)+int(0.3)=0.6, union 1.0         → 0.6
+# Lexicographic sample order is S1, S2, S3, Sall (('1' < 'a')).
+statement ok
+CREATE TABLE simple_tree AS SELECT * FROM read_newick('data/newick/simple.nwk');
+
+statement ok
+CREATE TABLE simple_obs AS SELECT * FROM (VALUES
+    ('S1', 'A', 1.0), ('S2', 'B', 1.0), ('S3', 'C', 1.0),
+    ('Sall', 'A', 1.0), ('Sall', 'B', 1.0), ('Sall', 'C', 1.0)
+) t(sample_id, feature_id, value);
+
+# 4 samples → 6 pairs; assert every pair matches its hand-computed value.
+query I
+WITH d AS (SELECT * FROM unifrac_distances('simple_obs', 'simple_tree', variant := 'unweighted'))
+SELECT COUNT(*) FROM d WHERE
+    (sample_a = 'S1' AND sample_b = 'S2'   AND abs(distance - 0.5) < 1e-5) OR
+    (sample_a = 'S1' AND sample_b = 'S3'   AND abs(distance - 1.0) < 1e-5) OR
+    (sample_a = 'S1' AND sample_b = 'Sall' AND abs(distance - 0.6) < 1e-5) OR
+    (sample_a = 'S2' AND sample_b = 'S3'   AND abs(distance - 1.0) < 1e-5) OR
+    (sample_a = 'S2' AND sample_b = 'Sall' AND abs(distance - 0.5) < 1e-5) OR
+    (sample_a = 'S3' AND sample_b = 'Sall' AND abs(distance - 0.6) < 1e-5);
+----
+6
+
+# ── Streaming across chunk boundaries ────────────────────────────────────────
+# 70 samples → 70*69/2 = 2415 pairs > STANDARD_VECTOR_SIZE (2048), so the
+# execute cursor must span multiple output chunks. Distances vary by sample.
+statement ok
+CREATE TABLE big_obs AS
+SELECT 'S' || i AS sample_id, f.feature_id, (1 + (i % 3))::DOUBLE AS value
+FROM range(70) t(i)
+CROSS JOIN (VALUES ('GG_OTU_1'), ('GG_OTU_2'), ('GG_OTU_3')) f(feature_id);
+
+query I
+SELECT COUNT(*) = 2415 AND COUNT(*) = COUNT(DISTINCT (sample_a, sample_b))
+FROM unifrac_distances('big_obs', 'tree', variant := 'weighted_normalized');
+----
+true
+
+# Multi-iteration AND multi-chunk together: 70 samples survive depth=3, so
+# 2415 pairs × 2 iterations = 4830 rows spanning 3 output chunks. The iteration
+# boundary (row 2415) lands mid-chunk, forcing LoadIteration between chunks and
+# carrying iteration state across an Execute() boundary. COUNT(DISTINCT (...))
+# catches any pair duplicated or dropped at either boundary.
+query I
+WITH d AS (SELECT * FROM unifrac_distances('big_obs', 'tree',
+              variant := 'weighted_normalized', subsample_depth := 3, n_subsamples := 2, seed := 11))
+SELECT COUNT(*) = 4830
+   AND COUNT(*) = COUNT(DISTINCT (iteration, sample_a, sample_b))
+   AND COUNT(DISTINCT iteration) = 2
+FROM d;
+----
+true
+
+# ── Multi-iteration with subsampling ─────────────────────────────────────────
+# depth=3 keeps all 6 samples every iteration → 15 pairs × 5 iterations = 75 rows.
+query I
+SELECT COUNT(*) FROM unifrac_distances('observations', 'tree',
+    variant := 'weighted_normalized', subsample_depth := 3, n_subsamples := 5, seed := 7);
+----
+75
+
+query I
+SELECT COUNT(DISTINCT iteration) FROM unifrac_distances('observations', 'tree',
+    variant := 'weighted_normalized', subsample_depth := 3, n_subsamples := 5, seed := 7);
+----
+5
+
+# Seed reproducibility: two identical invocations agree pair-for-pair.
+query I
+WITH a AS (SELECT * FROM unifrac_distances('observations', 'tree',
+              variant := 'weighted_normalized', subsample_depth := 3, n_subsamples := 5, seed := 7)),
+     b AS (SELECT * FROM unifrac_distances('observations', 'tree',
+              variant := 'weighted_normalized', subsample_depth := 3, n_subsamples := 5, seed := 7))
+SELECT COUNT(*) FROM a
+JOIN b USING (iteration, sample_a, sample_b)
+WHERE abs(a.distance - b.distance) < 1e-5;
+----
+75
+
+# ── Subsampling that drops samples changes the per-iteration triangle size ───
+# S1 has total count 1, so at subsample_depth=2 it is dropped (a sample whose
+# total falls below the depth can't be rarefied); the remaining 3 samples give
+# 3*2/2 = 3 pairs, and S1 appears in no pair. Guards the "cursor is re-sized
+# from each iteration's matrix, not the input table" contract.
+statement ok
+CREATE TABLE dropped_obs AS SELECT * FROM (VALUES
+    ('S1', 'GG_OTU_1', 1.0),
+    ('S2', 'GG_OTU_1', 1.0), ('S2', 'GG_OTU_2', 1.0),
+    ('S3', 'GG_OTU_1', 1.0), ('S3', 'GG_OTU_3', 1.0),
+    ('S4', 'GG_OTU_2', 1.0), ('S4', 'GG_OTU_3', 1.0)
+) t(sample_id, feature_id, value);
+
+query I
+SELECT COUNT(*) FROM unifrac_distances('dropped_obs', 'tree',
+    variant := 'weighted_normalized', subsample_depth := 2);
+----
+3
+
+query I
+SELECT COUNT(*) FROM unifrac_distances('dropped_obs', 'tree',
+    variant := 'weighted_normalized', subsample_depth := 2)
+WHERE sample_a = 'S1' OR sample_b = 'S1';
+----
+0
+
+# ── Fewer than two samples → empty result (not an error) ─────────────────────
+# The condensed form of a <2-sample matrix has no pairs. Unlike unifrac_pcoa
+# (undefined for <2 samples → error), a distance dump legitimately returns 0
+# rows. Documented behavior, tested in both the base and subsampling cases.
+statement ok
+CREATE TABLE one_sample_obs AS SELECT * FROM (VALUES
+    ('Solo', 'GG_OTU_1', 1.0), ('Solo', 'GG_OTU_2', 1.0)
+) t(sample_id, feature_id, value);
+
+query I
+SELECT COUNT(*) FROM unifrac_distances('one_sample_obs', 'tree', variant := 'weighted_normalized');
+----
+0
+
+# ── Bind-time errors ─────────────────────────────────────────────────────────
+
+# Tree missing a feature_id → error naming the missing tip.
+statement ok
+CREATE TABLE observations_extra_feature AS
+    SELECT * FROM observations
+    UNION ALL SELECT 'Sample1' AS sample_id, 'MISSING_OTU' AS feature_id, 1.0::DOUBLE AS value;
+
+statement error
+SELECT * FROM unifrac_distances('observations_extra_feature', 'tree', variant := 'weighted_normalized');
+----
+MISSING_OTU
+
+# Bad variant → Binder error listing the accepted set.
+statement error
+SELECT * FROM unifrac_distances('observations', 'tree', variant := 'made_up_metric');
+----
+variant
+
+# Empty feature table → InvalidInput error.
+statement ok
+CREATE TABLE empty_obs AS SELECT * FROM observations WHERE false;
+
+statement error
+SELECT * FROM unifrac_distances('empty_obs', 'tree', variant := 'weighted_normalized');
+----
+empty
+
+# n_subsamples > 1 with subsample_depth = 0 → Binder error (iterations identical).
+statement error
+SELECT * FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized', n_subsamples := 5);
+----
+subsample_depth
+
+# n_subsamples must be >= 1.
+statement error
+SELECT * FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized', n_subsamples := 0);
+----
+n_subsamples
+
+# ── Sample-ID type parity (BIGINT / UUID mirrored onto the output) ────────────
+# Parity with align_minimap2: sample_a/sample_b are emitted with the input
+# sample_id's type so results join back to metadata without a cast. Pairs are
+# still emitted once each (ordered by the canonical lexical id form), so numeric
+# sample_a < sample_b need not hold for BIGINT — uniqueness is what we assert.
+statement ok
+CREATE TABLE obs_bigint AS
+    SELECT replace(sample_id, 'Sample', '')::BIGINT AS sample_id, feature_id, value FROM observations;
+
+query T
+SELECT DISTINCT typeof(sample_a) FROM unifrac_distances('obs_bigint', 'tree');
+----
+BIGINT
+
+query T
+SELECT DISTINCT typeof(sample_b) FROM unifrac_distances('obs_bigint', 'tree');
+----
+BIGINT
+
+# 15 unique pairs; all six ids (1..6) round-trip through the output.
+query I
+SELECT COUNT(*) = 15 AND COUNT(*) = COUNT(DISTINCT (sample_a, sample_b))
+FROM unifrac_distances('obs_bigint', 'tree');
+----
+true
+
+query I
+SELECT COUNT(DISTINCT s) FROM (
+    SELECT sample_a AS s FROM unifrac_distances('obs_bigint', 'tree')
+    UNION ALL SELECT sample_b FROM unifrac_distances('obs_bigint', 'tree'));
+----
+6
+
+# Joins back to a BIGINT metadata key with no cast (the parity payoff).
+statement ok
+CREATE TABLE md_bigint AS SELECT DISTINCT replace(sample_id, 'Sample', '')::BIGINT AS sample_id FROM observations;
+
+query I
+SELECT COUNT(*) FROM unifrac_distances('obs_bigint', 'tree') d
+JOIN md_bigint m ON d.sample_a = m.sample_id;
+----
+15
+
+# UUIDs carry hex letters (a-f), so the round-trip exercises real hex conversion,
+# not just an all-digits degenerate case.
+statement ok
+CREATE TABLE obs_uuid AS
+    SELECT m.uid AS sample_id, o.feature_id, o.value
+    FROM observations o JOIN (VALUES
+        ('Sample1', 'aaaaaaaa-1111-4222-8333-444444444444'::UUID),
+        ('Sample2', 'bbbbbbbb-1111-4222-8333-444444444444'::UUID),
+        ('Sample3', 'cccccccc-1111-4222-8333-444444444444'::UUID),
+        ('Sample4', 'dddddddd-1111-4222-8333-444444444444'::UUID),
+        ('Sample5', 'eeeeeeee-1111-4222-8333-444444444444'::UUID),
+        ('Sample6', 'ffffffff-1111-4222-8333-444444444444'::UUID)
+    ) m(orig, uid) ON o.sample_id = m.orig;
+
+query T
+SELECT DISTINCT typeof(sample_a) FROM unifrac_distances('obs_uuid', 'tree');
+----
+UUID
+
+query I
+SELECT COUNT(*) FROM unifrac_distances('obs_uuid', 'tree');
+----
+15
+
+query I
+SELECT COUNT(DISTINCT s) FROM (
+    SELECT sample_a AS s FROM unifrac_distances('obs_uuid', 'tree')
+    UNION ALL SELECT sample_b FROM unifrac_distances('obs_uuid', 'tree'));
+----
+6
+
+# VARCHAR input stays VARCHAR (non-regression).
+query T
+SELECT DISTINCT typeof(sample_a) FROM unifrac_distances('observations', 'tree');
+----
+VARCHAR
+
+# Negative and INT64-extreme BIGINT ids survive the ::VARCHAR-cast → lexical-sort
+# → re-parse egress path losslessly. Lexically "-5" < "9223..." ('-' < '9'), so
+# that is the emitted (sample_a, sample_b) order for this 2-sample table.
+statement ok
+CREATE TABLE obs_neg AS SELECT * FROM (VALUES
+    ((-5)::BIGINT, 'GG_OTU_1', 1.0), ((-5)::BIGINT, 'GG_OTU_2', 1.0),
+    (9223372036854775807::BIGINT, 'GG_OTU_1', 1.0), (9223372036854775807::BIGINT, 'GG_OTU_3', 1.0)
+) t(sample_id, feature_id, value);
+
+query II
+SELECT sample_a, sample_b FROM unifrac_distances('obs_neg', 'tree');
+----
+-5	9223372036854775807
+
+# ── Composition with the beta-distance macros (end-to-end) ───────────────────
+# The #158 within/between use case, straight off the primitive's output.
+statement ok
+CREATE TABLE dm AS SELECT * FROM unifrac_distances('observations', 'tree', variant := 'weighted_normalized');
+
+statement ok
+CREATE TABLE md_groups AS SELECT * FROM (VALUES
+    ('Sample1', 'gut'), ('Sample2', 'gut'), ('Sample3', 'gut'),
+    ('Sample4', 'skin'), ('Sample5', 'skin'), ('Sample6', 'skin')
+) t(sample_id, grouping);
+
+# 3 gut × 3 skin = 9 between; 2×C(3,2) = 6 within.
+query TI
+SELECT comparison, count(*) AS n FROM beta_group_distances('dm', 'md_groups')
+GROUP BY comparison ORDER BY comparison;
+----
+between	9
+within	6
+
+# k-NN over the same distances: 6 samples × 2 neighbors = 12 rows.
+query I
+SELECT COUNT(*) FROM beta_knn('dm', 2);
+----
+12

--- a/test/sql/unifrac_faith_pd.test
+++ b/test/sql/unifrac_faith_pd.test
@@ -128,3 +128,40 @@ statement error
 SELECT * FROM unifrac_faith_pd('observations', 'tree', subsample_depth := -1);
 ----
 subsample_depth
+
+# ── Sample-ID type parity (BIGINT / UUID mirrored onto the output) ────────────
+# The sample_id output column mirrors the input feature-table's sample_id type,
+# so PD values join back to typed metadata without a cast (align_minimap2 parity).
+statement ok
+CREATE TABLE obs_bigint AS
+    SELECT replace(sample_id, 'Sample', '')::BIGINT AS sample_id, feature_id, value FROM observations;
+
+query T
+SELECT DISTINCT typeof(sample_id) FROM unifrac_faith_pd('obs_bigint', 'tree');
+----
+BIGINT
+
+# Values are unchanged by the type change; id 5 == Sample5 → PD 0.5.
+query IR
+SELECT sample_id, faith_pd FROM unifrac_faith_pd('obs_bigint', 'tree') WHERE sample_id = 5;
+----
+5	0.5
+
+statement ok
+CREATE TABLE obs_uuid AS
+    SELECT m.uid AS sample_id, o.feature_id, o.value
+    FROM observations o JOIN (VALUES
+        ('Sample1', '11111111-1111-1111-1111-111111111111'::UUID),
+        ('Sample5', '55555555-5555-5555-5555-555555555555'::UUID)
+    ) m(orig, uid) ON o.sample_id = m.orig;
+
+query T
+SELECT DISTINCT typeof(sample_id) FROM unifrac_faith_pd('obs_uuid', 'tree');
+----
+UUID
+
+# VARCHAR input stays VARCHAR (non-regression).
+query T
+SELECT DISTINCT typeof(sample_id) FROM unifrac_faith_pd('observations', 'tree');
+----
+VARCHAR

--- a/test/sql/unifrac_pcoa.test
+++ b/test/sql/unifrac_pcoa.test
@@ -203,3 +203,48 @@ SELECT * FROM unifrac_pcoa('observations', 'tree',
     variant := 'weighted_normalized', n_dims := 3, n_subsamples := 0);
 ----
 n_subsamples
+
+# ── Sample-ID type parity (BIGINT / UUID mirrored onto the output) ────────────
+# The sample_id output column mirrors the input feature-table's sample_id type,
+# so coordinates join back to typed metadata without a cast (align_minimap2 parity).
+statement ok
+CREATE TABLE obs_bigint AS
+    SELECT replace(sample_id, 'Sample', '')::BIGINT AS sample_id, feature_id, value FROM observations;
+
+query T
+SELECT DISTINCT typeof(sample_id) FROM unifrac_pcoa('obs_bigint', 'tree', n_dims := 3, seed := 42);
+----
+BIGINT
+
+query I
+SELECT COUNT(DISTINCT sample_id) FROM unifrac_pcoa('obs_bigint', 'tree', n_dims := 3, seed := 42);
+----
+6
+
+statement ok
+CREATE TABLE obs_uuid AS
+    SELECT m.uid AS sample_id, o.feature_id, o.value
+    FROM observations o JOIN (VALUES
+        ('Sample1', '11111111-1111-1111-1111-111111111111'::UUID),
+        ('Sample2', '22222222-2222-2222-2222-222222222222'::UUID),
+        ('Sample3', '33333333-3333-3333-3333-333333333333'::UUID),
+        ('Sample4', '44444444-4444-4444-4444-444444444444'::UUID),
+        ('Sample5', '55555555-5555-5555-5555-555555555555'::UUID),
+        ('Sample6', '66666666-6666-6666-6666-666666666666'::UUID)
+    ) m(orig, uid) ON o.sample_id = m.orig;
+
+query T
+SELECT DISTINCT typeof(sample_id) FROM unifrac_pcoa('obs_uuid', 'tree', n_dims := 3, seed := 42);
+----
+UUID
+
+query I
+SELECT COUNT(DISTINCT sample_id) FROM unifrac_pcoa('obs_uuid', 'tree', n_dims := 3, seed := 42);
+----
+6
+
+# VARCHAR input stays VARCHAR (non-regression).
+query T
+SELECT DISTINCT typeof(sample_id) FROM unifrac_pcoa('observations', 'tree', n_dims := 3, seed := 42);
+----
+VARCHAR


### PR DESCRIPTION
## Summary

Implements #158 by exposing the **primitive** — the condensed (upper-triangle) UniFrac distance matrix — as `unifrac_distances(feature_table, tree, ...)` returning `(iteration, sample_a, sample_b, distance)`. Within/between-group distributions, k-NN, and Mantel-r then fall out of ordinary SQL rather than a bespoke group-distances function.

## What's included

- **`unifrac_distances`** table function. Streams the upper triangle from one N×N fp32 matrix at a time (deliberately unlike `unifrac_pcoa`'s materialize-at-bind), so the O(n²) *result rows* are never all held in memory. Fewer than two samples → empty result (the condensed form of a <2-sample matrix has no pairs), unlike `unifrac_pcoa` which errors.
- **Sample-ID type parity.** `unifrac_distances`, `unifrac_pcoa`, and `unifrac_faith_pd` now mirror the input `sample_id` type (BIGINT/UUID → same, else VARCHAR) onto their output, so results join back to typed metadata without a cast — parity with `align_minimap2`. `unifrac_permanova` emits no sample ids and is unchanged.
- **SQL macros** over any condensed distance table: `beta_group_distances` (within/between labeling), `beta_knn`, `beta_knn_from_sample`.
- **Docs.** New `docs/diversity.md` sections plus within/between, per-group-vs-rest, k-NN, and Mantel-r recipes.

## Testing

- New `test/sql/unifrac_distances.test` (54 assertions): completeness/uniqueness, hand-computed exact unweighted values, multi-chunk streaming, multi-iteration × multi-chunk, subsampling that drops samples, <2-sample empty, BIGINT/UUID round-trips (incl. negative / INT64_MAX and hex UUIDs), error paths, and end-to-end macro composition.
- New `test/cpp/test_UnifracCondensed.cpp` (cursor unit tests) and `test/sql/beta_distance_macros.test` (46 assertions).
- Parity tests added to `unifrac_pcoa.test` / `unifrac_faith_pd.test`; existing VARCHAR expectations unchanged.
- Full C++ suite 13267/13267; every documented SQL example was executed against the built extension.

No new library dependency (reuses the embedded `unifrac-binaries` / `scikit-bio-binaries`), so `miint_versions()` is unchanged.

## Deferred (separate issues)

- Mantel permutation test — #160 (the r-statistic is already free via `corr()` over two condensed tables).
- Procrustes / partial Procrustes — #161.

Developed red/green/refactor with a self-triggered code review at each phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
