### PR TITLE
feat(phylogeny): phylo_independent_contrasts + tree_resolve_multifurcations (#159)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1181,6 +1181,8 @@ set(EXTENSION_SOURCES
     src/tree_table_reader.cpp
     src/tree_resolve_placement.cpp
     src/shear_tree.cpp
+    src/tree_resolve_multifurcations.cpp
+    src/phylo_independent_contrasts.cpp
     src/copy_newick.cpp
     src/Minimap2Aligner.cpp
     src/sequence_table_reader.cpp
@@ -1669,6 +1671,8 @@ set(TEST_SOURCES
     test/cpp/test_NewickParser.cpp
     test/cpp/test_InsertFullyResolved.cpp
     test/cpp/test_ShearTree.cpp
+    test/cpp/test_ResolveMultifurcations.cpp
+    test/cpp/test_IndependentContrasts.cpp
     src/Minimap2Aligner.cpp
     test/cpp/test_Minimap2Aligner.cpp
     test/cpp/test_AlignBowtie2Sharded.cpp

--- a/docs/phylogeny.md
+++ b/docs/phylogeny.md
@@ -5,8 +5,10 @@ Methods for estimating and operating on phylogenies.
 ## Table of Contents
 
 - [Shear (subset to tips)](#shear-subset-to-tips) - Prune a tree down to a set of tips.
+- [Resolve multifurcations](#resolve-multifurcations) - Resolve polytomies into a strictly bifurcating tree.
 - [Resolve placements](#resolve-placements) - Fully resolve sequence placements against a backbone.
 - [FastTree](#fasttree) - Estimate a phylogeny from a MSA with FastTree.
+- [Independent contrasts (PIC)](#independent-contrasts-pic) - Felsenstein (1985) phylogenetic independent contrasts.
 
 ### Shear (subset to tips)
 
@@ -81,6 +83,51 @@ LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2 duckdb   # or python, etc.
 This applies to any allocation-heavy miint workload (large `read_newick`
 builds, `tree_resolve_placement`, QC), not just `shear_tree`. It does not reduce
 peak memory materially — it is a speed optimization.
+
+### Resolve multifurcations
+
+Resolve every multifurcation (a node with more than two children — a "polytomy") in a tree into a series of bifurcations, producing a strictly bifurcating tree. This is the operation you want before running a method that requires a binary tree — notably [`phylo_independent_contrasts`](#independent-contrasts-pic) — on a tree that contains polytomies (e.g. an unrooted tree whose root is a trifurcation, as `phylogeny_fasttree` emits, or a tree flattened from a taxonomy).
+
+**Function signature**:
+
+`tree_resolve_multifurcations(tree_table)`
+
+**Parameters:**
+- `tree_table` (VARCHAR): Name of a table or view containing tree data in [`read_newick`](reading.md#newick) schema (requires `node_index` and `parent_index`; `name`, `branch_length`, `edge_id` optional).
+
+**Output schema:** Same as [`read_newick`](reading.md#newick) (without filepath), reindexed 0-based: `node_index`, `name`, `branch_length`, `edge_id`, `parent_index`, `is_tip`. The schema is `UNION ALL`-compatible with `read_newick`, can be written back out with `COPY ... (FORMAT NEWICK)`, and feeds directly into `phylo_independent_contrasts`.
+
+**Behavior / semantics:**
+- A node with `m ≥ 3` children `c0, c1, …, c(m-1)` (in `node_index` order) is resolved into a **deterministic left-comb**: the node keeps `c0` and a new internal node `N1`; `N1` keeps `c1` and `N2`; … ; `N(m-2)` keeps `c(m-2)` and `c(m-1)`. This inserts `m-2` new internal nodes.
+- New connector nodes are **unnamed**, have **branch length `0`**, and no `edge_id`. Because the connectors are zero-length, the original edge lengths and all root-to-tip distances are unchanged.
+- Nodes with two or fewer children are left untouched. **Single-child unifurcations are not collapsed** — that is a different operation; use [`shear_tree`](#shear-subset-to-tips) with `collapse := true` for that.
+- A multifurcating root is resolved as well.
+- Child order follows `node_index` (the canonical order `read_newick` assigns, encoding the original Newick left-to-right order); the reader sorts input rows by `node_index`, so the result is reproducible regardless of how the tree relation is physically stored.
+
+**Important — the resolution is statistically arbitrary.** A polytomy carries no information about the order in which its lineages diverged, so any bifurcating resolution is as valid as any other. When the resolved tree feeds a downstream analysis such as independent contrasts, each artificially-created dichotomy contributes a contrast that is not real independent information; the effective degrees of freedom should be reduced accordingly. Resolving is a pragmatic step to satisfy a binary-tree requirement, not a reconstruction of unknown branching order.
+
+**Examples:**
+```sql
+-- A tree with a trifurcating (unrooted) root, e.g. from phylogeny_fasttree.
+CREATE TABLE ref_tree AS SELECT * FROM read_newick('unrooted.nwk');
+
+-- Resolve polytomies into bifurcations (zero-length connectors).
+SELECT * FROM tree_resolve_multifurcations('ref_tree');
+
+-- Prep a tree for PIC: resolve, persist, then run independent contrasts.
+CREATE TABLE binary_tree AS SELECT * FROM tree_resolve_multifurcations('ref_tree');
+SELECT * FROM phylo_independent_contrasts('binary_tree', 'traits');
+
+-- Write the resolved tree back out.
+COPY (
+    SELECT node_index, name, branch_length, edge_id, parent_index
+    FROM tree_resolve_multifurcations('ref_tree')
+) TO 'binary.nwk' (FORMAT NEWICK);
+```
+
+**Error conditions:**
+- `tree_table` does not exist.
+- `tree_table` missing required `node_index` / `parent_index` columns.
 
 ### Resolve placements
 
@@ -323,3 +370,72 @@ SELECT * FROM tree_resolve_placement('ref_tree', 'placements');
 - Daemon process exits non-zero or returns a non-OK protocol response (exit message includes the daemon's stderr)
 
 **Reproducibility:** With `threads=1` and a fixed `seed`, the tree is bit-deterministic across runs of the same `gpl-boundary` build. With `threads>1`, FastTree's parallel sections produce floating-point variation in branch lengths and (rarely) topology — pin `threads=1` for deterministic output.
+
+### Independent contrasts (PIC)
+
+Compute Felsenstein's (1985) **phylogenetic independent contrasts** for one or more numeric per-tip traits over a tree. Per-tip traits are not statistically independent — related tips share evolutionary history — so naively correlating two traits across tips is biased. Independent contrasts is the standard correction: it transforms the correlated tip values into `n-1` contrasts that are independent and identically distributed under a Brownian-motion model, which can then be correlated or regressed (through the origin) in downstream SQL.
+
+Reference: Felsenstein, J. (1985) "Phylogenies and the Comparative Method." *The American Naturalist* 125(1):1–15.
+
+**Function signature**:
+
+`phylo_independent_contrasts(tree_table, traits_table)`
+
+**Parameters:**
+- `tree_table` (VARCHAR): Name of a table or view containing tree data in [`read_newick`](reading.md#newick) schema (requires `node_index` and `parent_index`; `name` and `branch_length` are needed for a meaningful contrast; `edge_id` optional). The tree must be **strictly bifurcating** with **finite, non-negative branch lengths** (see requirements below).
+- `traits_table` (VARCHAR): Name of a table or view in **long form** with columns `name`, `trait`, `value`:
+  - `name`: the tip identifier, matched to the tree's tip labels. Type-flexible — `VARCHAR`, `UUID`, and `BIGINT` are all accepted and matched to tip labels by their canonical text form (the same posture as `read_id` elsewhere), so a numeric or UUID feature key works directly.
+  - `trait` (VARCHAR): the trait name; one trait is computed per distinct value.
+  - `value` (DOUBLE): the numeric trait value for that tip.
+
+  Every trait must cover **exactly** the tree's tip set — no missing tips, no extra names, no `NULL` values. To analyze a subset of tips, [`shear_tree`](#shear-subset-to-tips) the tree to those tips first: pruning re-sums branch lengths, which changes the contrasts, so it cannot be skipped by simply omitting tips from the traits.
+
+**Output schema:** long form, one row per (internal node, trait):
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `node_index` | BIGINT | The input tree's `node_index` for the internal node at which the contrast is computed |
+| `trait` | VARCHAR | The trait name |
+| `contrast` | DOUBLE | The standardized independent contrast `(X_i − X_j) / sqrt(v_i + v_j)` |
+| `ancestral_estimate` | DOUBLE | The reconstructed (inverse-variance-weighted) trait value at the node |
+| `contrast_variance` | DOUBLE | `v_i + v_j`, the contrast's expected variance (a property of the tree, identical across traits) |
+
+For a rooted bifurcating tree with `n` tips there are `n-1` internal nodes and thus `n-1` contrasts per trait.
+
+**Behavior / semantics:**
+- Computed by Felsenstein's post-order pruning. At each internal node with children `i`, `j` and variance-extended branch lengths `v_i`, `v_j`: `contrast = (X_i − X_j)/sqrt(v_i+v_j)`; the ancestral estimate is the inverse-variance-weighted mean `(X_i·v_j + X_j·v_i)/(v_i+v_j)`; and the node's branch length is extended by `(v_i·v_j)/(v_i+v_j)` for use higher in the tree.
+- **The sign of a contrast is arbitrary** — it depends on which child is `i` vs `j` (here, `node_index` order). This is why the standard two-trait analysis is a regression *through the origin* over the paired contrasts (or a correlation after fixing one axis's sign). Results are reproducible: child order follows `node_index`.
+- `contrast_variance` is identical across traits for a given node, which is what makes multi-trait computation cheap (the tree is validated and its variances precomputed once).
+- The two-trait correlation / regression is intentionally **not** built in — layer it in SQL over the per-node output (example below).
+
+**Requirements and error conditions:**
+- **Strictly bifurcating.** Every internal node must have exactly two children. A polytomy (`> 2` children) errors and points to [`tree_resolve_multifurcations`](#resolve-multifurcations); a unifurcation (`1` child) errors and points to [`shear_tree`](#shear-subset-to-tips). Common gotcha: an *unrooted* Newick tree has a trifurcating root and must be resolved (or rooted) first.
+- **Finite, non-negative branch lengths on every non-root edge.** PIC divides by `v_i + v_j`, so an unspecified (`NULL`/NaN) or infinite length errors, and a negative length errors. The root's own branch length is unused. Zero-length internal edges are allowed (e.g. the connectors from `tree_resolve_multifurcations`); only a contrast whose variance `v_i + v_j` is exactly zero (both children zero-length) errors.
+- **Trait coverage.** A tip with no trait value, a trait value for a name that is not a tip, a duplicate `(name, trait)` pair, or a `NULL` `value` all error.
+- Tip names must be unique (they key the traits); `tree_table` / `traits_table` must exist and have the required columns.
+
+**Examples:**
+```sql
+-- Tree (must be bifurcating) and per-tip traits in long form.
+CREATE TABLE tree AS SELECT * FROM read_newick('tree.nwk');
+CREATE TABLE traits AS SELECT * FROM (VALUES
+    ('sp1', 'body_mass', 3.2), ('sp2', 'body_mass', 1.1), ('sp3', 'body_mass', 2.7),
+    ('sp1', 'metabolic_rate', 0.9), ('sp2', 'metabolic_rate', 0.4), ('sp3', 'metabolic_rate', 0.7)
+) AS v(name, trait, value);
+
+-- Contrasts for every trait.
+SELECT * FROM phylo_independent_contrasts('tree', 'traits') ORDER BY trait, node_index;
+
+-- Two-trait association via regression THROUGH THE ORIGIN over paired contrasts
+-- (through the origin because each contrast's sign is arbitrary).
+WITH c AS (SELECT * FROM phylo_independent_contrasts('tree', 'traits'))
+SELECT sum(x.contrast * y.contrast) / sum(x.contrast * x.contrast) AS pic_slope
+FROM c AS x JOIN c AS y USING (node_index)
+WHERE x.trait = 'body_mass' AND y.trait = 'metabolic_rate';
+
+-- If the tree has polytomies, resolve first (see the arbitrariness caveat there).
+CREATE TABLE binary_tree AS SELECT * FROM tree_resolve_multifurcations('tree');
+SELECT * FROM phylo_independent_contrasts('binary_tree', 'traits');
+```
+
+**Cleanroom note:** this is a from-scratch implementation of the algorithm as published in Felsenstein (1985); it does not derive from any GPL comparative-methods package.

--- a/docs/table_of_contents.md
+++ b/docs/table_of_contents.md
@@ -31,7 +31,7 @@ MIINT provides a range of bioinformatic capabilities. The materials included her
 
 ## Phylogeny & diversity
 
-- [Phylogeny estimation](phylogeny.md) - Methods for phylogenetic estimation.
+- [Phylogeny estimation](phylogeny.md) - Phylogenetic estimation, tree manipulation (shear, resolve multifurcations/placements), and comparative methods (independent contrasts).
 - [Alpha and beta diversity](diversity.md) - Methods to compute and analyze alpha and beta diversity.
 
 ## Mass spectrometry

--- a/src/NewickTree.cpp
+++ b/src/NewickTree.cpp
@@ -1140,8 +1140,18 @@ struct ContrastScaffold {
 	std::unordered_map<std::string_view, uint32_t> tip_by_name; // for trait-completeness checks
 };
 
-std::string node_label(const NewickTree &t, uint32_t i) {
-	return t.name(i).empty() ? ("node " + std::to_string(i)) : ("node '" + t.name(i) + "'");
+// Human-readable node identifier for error messages. Prefers the node's name;
+// for unnamed nodes, reports the caller-facing id from `node_ids` when available
+// (so messages reference the source table's node_index, not the internal dense
+// index), else the dense index.
+std::string node_label(const NewickTree &t, uint32_t i, const std::vector<int64_t> *node_ids) {
+	if (!t.name(i).empty()) {
+		return "node '" + t.name(i) + "'";
+	}
+	if (node_ids && i < node_ids->size()) {
+		return "node " + std::to_string((*node_ids)[i]);
+	}
+	return "node " + std::to_string(i);
 }
 
 std::string join_names(std::vector<std::string> &v) {
@@ -1163,7 +1173,7 @@ std::string join_names(std::vector<std::string> &v) {
 // Validate structure + branch lengths (all trait-independent) and precompute the
 // variance-extended branch lengths and per-node contrast variances in one
 // post-order pass. Throws on any structural / branch-length violation.
-ContrastScaffold build_contrast_scaffold(const NewickTree &t) {
+ContrastScaffold build_contrast_scaffold(const NewickTree &t, const std::vector<int64_t> *node_ids) {
 	const uint32_t n = static_cast<uint32_t>(t.num_nodes());
 	ContrastScaffold s;
 	s.extended_length.assign(n, 0.0);
@@ -1180,12 +1190,12 @@ ContrastScaffold build_contrast_scaffold(const NewickTree &t) {
 			}
 		} else if (nc > 2) {
 			throw std::runtime_error(
-			    "independent_contrasts: " + node_label(t, i) + " has " + std::to_string(nc) +
+			    "independent_contrasts: " + node_label(t, i, node_ids) + " has " + std::to_string(nc) +
 			    " children; requires a strictly bifurcating tree — use tree_resolve_multifurcations to resolve "
 			    "polytomies");
 		} else if (nc == 1) {
 			throw std::runtime_error(
-			    "independent_contrasts: " + node_label(t, i) +
+			    "independent_contrasts: " + node_label(t, i, node_ids) +
 			    " has 1 child; requires a strictly bifurcating tree — use shear_tree (collapse) to remove "
 			    "unifurcations");
 		}
@@ -1204,13 +1214,13 @@ ContrastScaffold build_contrast_scaffold(const NewickTree &t) {
 		}
 		double bl = t.branch_length(i);
 		if (!std::isfinite(bl)) {
-			throw std::runtime_error("independent_contrasts: " + node_label(t, i) +
+			throw std::runtime_error("independent_contrasts: " + node_label(t, i, node_ids) +
 			                         " has a non-finite (NaN or infinite) branch length; PIC requires a finite branch "
 			                         "length on every non-root edge");
 		}
 		if (bl < 0.0) {
-			throw std::runtime_error("independent_contrasts: " + node_label(t, i) + " has a negative branch length (" +
-			                         std::to_string(bl) + ")");
+			throw std::runtime_error("independent_contrasts: " + node_label(t, i, node_ids) +
+			                         " has a negative branch length (" + std::to_string(bl) + ")");
 		}
 	}
 
@@ -1228,7 +1238,7 @@ ContrastScaffold build_contrast_scaffold(const NewickTree &t) {
 		double vj = s.extended_length[j];
 		double denom = vi + vj;
 		if (!(denom > 0.0)) {
-			throw std::runtime_error("independent_contrasts: " + node_label(t, node) +
+			throw std::runtime_error("independent_contrasts: " + node_label(t, node, node_ids) +
 			                         " has two children with zero total branch length (contrast variance is zero)");
 		}
 		s.contrast_variance[node] = denom;
@@ -1297,17 +1307,19 @@ std::vector<IndependentContrast> contrasts_for_trait(const NewickTree &t, const 
 } // namespace
 
 std::vector<IndependentContrast>
-NewickTree::independent_contrasts(const std::unordered_map<std::string, double> &trait_values) const {
-	ContrastScaffold scaffold = build_contrast_scaffold(*this);
+NewickTree::independent_contrasts(const std::unordered_map<std::string, double> &trait_values,
+                                  const std::vector<int64_t> *node_ids) const {
+	ContrastScaffold scaffold = build_contrast_scaffold(*this, node_ids);
 	std::vector<double> x_workspace(num_nodes());
 	return contrasts_for_trait(*this, scaffold, trait_values, x_workspace);
 }
 
 std::vector<std::vector<IndependentContrast>>
-NewickTree::independent_contrasts(const std::vector<std::unordered_map<std::string, double>> &trait_values_list) const {
+NewickTree::independent_contrasts(const std::vector<std::unordered_map<std::string, double>> &trait_values_list,
+                                  const std::vector<int64_t> *node_ids) const {
 	// Trait-independent validation + variances computed once, reused per trait; the
 	// tree-sized ancestral-value scratch buffer is allocated once and reused too.
-	ContrastScaffold scaffold = build_contrast_scaffold(*this);
+	ContrastScaffold scaffold = build_contrast_scaffold(*this, node_ids);
 	std::vector<double> x_workspace(num_nodes());
 	std::vector<std::vector<IndependentContrast>> results;
 	results.reserve(trait_values_list.size());

--- a/src/NewickTree.cpp
+++ b/src/NewickTree.cpp
@@ -1082,6 +1082,241 @@ NewickTree NewickTree::shear(const std::unordered_set<std::string> &keep_names, 
 	return result;
 }
 
+NewickTree NewickTree::resolve_multifurcations() const {
+	const uint32_t n = static_cast<uint32_t>(nodes_.size());
+
+	NewickTree result;
+
+	// Pass 1: copy every original node in ascending index order, preserving
+	// name / branch length / edge id. Because nodes are added in order, original
+	// index i maps to result index i; new connector nodes are appended after, so
+	// original edges and node identities are untouched.
+	for (uint32_t i = 0; i < n; ++i) {
+		result.add_node(nodes_[i].name, nodes_[i].branch_length, nodes_[i].edge_id);
+	}
+	// build()/parse() always yield >= 1 node with a valid root, so root_ is a real
+	// index here; an empty source would copy NO_PARENT through, matching an empty
+	// result, so no separate guard is needed (cf. shear()'s explicit check).
+	result.root_ = root_;
+
+	// Pass 2: wire children. A node with <= 2 children is attached directly in
+	// its original order (bifurcations and single-child unifurcations pass
+	// through unchanged). A node with m >= 3 children is resolved into a
+	// deterministic left-comb: c0 stays on the node and each further child hangs
+	// off a fresh zero-length connector, so c0,c1,...,c(m-1) become successive
+	// "left" children and the final connector holds the last two.
+	for (uint32_t i = 0; i < n; ++i) {
+		const auto &ch = nodes_[i].children;
+		const size_t m = ch.size();
+		if (m <= 2) {
+			for (uint32_t c : ch) {
+				result.set_parent(c, i);
+			}
+			continue;
+		}
+		uint32_t current = i;
+		for (size_t k = 0; k < m; ++k) {
+			result.set_parent(ch[k], current);
+			if (k < m - 2) {
+				uint32_t connector = result.add_node("", 0.0, std::nullopt);
+				result.set_parent(connector, current);
+				current = connector;
+			}
+		}
+	}
+
+	return result;
+}
+
+namespace {
+
+// Trait-independent scaffold for Felsenstein independent contrasts: the validated
+// tree plus per-node variance-extended branch lengths and per-internal-node
+// contrast variances. Built once, reused across every trait over the same tree.
+struct ContrastScaffold {
+	std::vector<uint32_t> postorder;                            // children-before-parents
+	std::vector<double> extended_length;                        // v' per node (raw branch length at tips)
+	std::vector<double> contrast_variance;                      // v_i + v_j per internal node (unused at tips)
+	std::unordered_map<std::string_view, uint32_t> tip_by_name; // for trait-completeness checks
+};
+
+std::string node_label(const NewickTree &t, uint32_t i) {
+	return t.name(i).empty() ? ("node " + std::to_string(i)) : ("node '" + t.name(i) + "'");
+}
+
+std::string join_names(std::vector<std::string> &v) {
+	std::sort(v.begin(), v.end());
+	std::string s;
+	constexpr size_t cap = 10;
+	for (size_t i = 0; i < v.size() && i < cap; ++i) {
+		if (i) {
+			s += ", ";
+		}
+		s += "'" + v[i] + "'";
+	}
+	if (v.size() > cap) {
+		s += ", ... (" + std::to_string(v.size() - cap) + " more)";
+	}
+	return s;
+}
+
+// Validate structure + branch lengths (all trait-independent) and precompute the
+// variance-extended branch lengths and per-node contrast variances in one
+// post-order pass. Throws on any structural / branch-length violation.
+ContrastScaffold build_contrast_scaffold(const NewickTree &t) {
+	const uint32_t n = static_cast<uint32_t>(t.num_nodes());
+	ContrastScaffold s;
+	s.extended_length.assign(n, 0.0);
+	s.contrast_variance.assign(n, 0.0);
+
+	// Bifurcation + unique tip names.
+	for (uint32_t i = 0; i < n; ++i) {
+		const size_t nc = t.children(i).size();
+		if (nc == 0) {
+			bool inserted = s.tip_by_name.emplace(t.name(i), i).second;
+			if (!inserted) {
+				throw std::runtime_error("independent_contrasts: duplicate tip name '" + t.name(i) +
+				                         "' (tip names must be unique to key traits)");
+			}
+		} else if (nc > 2) {
+			throw std::runtime_error(
+			    "independent_contrasts: " + node_label(t, i) + " has " + std::to_string(nc) +
+			    " children; requires a strictly bifurcating tree — use tree_resolve_multifurcations to resolve "
+			    "polytomies");
+		} else if (nc == 1) {
+			throw std::runtime_error(
+			    "independent_contrasts: " + node_label(t, i) +
+			    " has 1 child; requires a strictly bifurcating tree — use shear_tree (collapse) to remove "
+			    "unifurcations");
+		}
+	}
+
+	// Finite, non-negative branch length on every non-root edge. (The root's own
+	// branch length is never used.) A non-finite length (NaN from an unspecified
+	// edge, or ±Inf from a literal 'inf'/'infinity') would poison sqrt()/the
+	// weighting and silently emit 0 / NaN contrasts, so reject both; a negative
+	// length is biologically meaningless even if a sibling masks it in the sum.
+	// Zero is allowed here — only a zero contrast *variance* is fatal, checked
+	// below, so resolver-inserted zero-length internal edges pass.
+	for (uint32_t i = 0; i < n; ++i) {
+		if (i == t.root()) {
+			continue;
+		}
+		double bl = t.branch_length(i);
+		if (!std::isfinite(bl)) {
+			throw std::runtime_error("independent_contrasts: " + node_label(t, i) +
+			                         " has a non-finite (NaN or infinite) branch length; PIC requires a finite branch "
+			                         "length on every non-root edge");
+		}
+		if (bl < 0.0) {
+			throw std::runtime_error("independent_contrasts: " + node_label(t, i) + " has a negative branch length (" +
+			                         std::to_string(bl) + ")");
+		}
+	}
+
+	// Variance-extended branch lengths + per-node contrast variances in one
+	// post-order pass (none of this depends on the trait values).
+	s.postorder = t.postorder();
+	for (uint32_t node : s.postorder) {
+		if (t.is_tip(node)) {
+			s.extended_length[node] = t.branch_length(node);
+			continue;
+		}
+		uint32_t i = t.children(node)[0];
+		uint32_t j = t.children(node)[1];
+		double vi = s.extended_length[i];
+		double vj = s.extended_length[j];
+		double denom = vi + vj;
+		if (!(denom > 0.0)) {
+			throw std::runtime_error("independent_contrasts: " + node_label(t, node) +
+			                         " has two children with zero total branch length (contrast variance is zero)");
+		}
+		s.contrast_variance[node] = denom;
+		// The root has no incoming edge, so only the variance-adjustment term
+		// applies; every other node adds its own branch length.
+		double own_bl = (node == t.root()) ? 0.0 : t.branch_length(node);
+		s.extended_length[node] = own_bl + (vi * vj) / denom;
+	}
+
+	return s;
+}
+
+// Per-trait pass: validate completeness against the scaffold's tip set, then a
+// single post-order computing ancestral values + standardized contrasts using the
+// precomputed variances (Felsenstein 1985).
+// `x_workspace` is a caller-owned scratch buffer sized to num_nodes; every entry
+// is overwritten during the post-order (each node is written before any ancestor
+// reads it), so it needs no re-initialization and can be reused across traits.
+std::vector<IndependentContrast> contrasts_for_trait(const NewickTree &t, const ContrastScaffold &s,
+                                                     const std::unordered_map<std::string, double> &trait_values,
+                                                     std::vector<double> &x_workspace) {
+	// Trait completeness: exactly the tip set (no missing tips, no extras).
+	std::vector<std::string> missing;
+	for (const auto &entry : s.tip_by_name) {
+		if (trait_values.find(std::string(entry.first)) == trait_values.end()) {
+			missing.emplace_back(entry.first);
+		}
+	}
+	if (!missing.empty()) {
+		throw std::runtime_error("independent_contrasts: no trait value for tip(s): " + join_names(missing));
+	}
+	if (trait_values.size() != s.tip_by_name.size()) {
+		std::vector<std::string> extra;
+		for (const auto &[name, val] : trait_values) {
+			if (s.tip_by_name.find(name) == s.tip_by_name.end()) {
+				extra.push_back(name);
+			}
+		}
+		throw std::runtime_error("independent_contrasts: trait value(s) for name(s) that are not a tip in the tree: " +
+		                         join_names(extra));
+	}
+
+	std::vector<double> &X = x_workspace; // reconstructed ancestral value (tip trait value at leaves)
+	std::vector<IndependentContrast> result;
+	result.reserve(s.tip_by_name.empty() ? 0 : s.tip_by_name.size() - 1);
+
+	for (uint32_t node : s.postorder) {
+		if (t.is_tip(node)) {
+			X[node] = trait_values.at(t.name(node)); // present (validated above)
+			continue;
+		}
+		uint32_t i = t.children(node)[0];
+		uint32_t j = t.children(node)[1];
+		double vi = s.extended_length[i];
+		double vj = s.extended_length[j];
+		double denom = s.contrast_variance[node]; // precomputed, guaranteed > 0
+		double contrast = (X[i] - X[j]) / std::sqrt(denom);
+		double anc = (X[i] * vj + X[j] * vi) / denom;
+		X[node] = anc;
+		result.push_back(IndependentContrast {node, contrast, anc, denom});
+	}
+
+	return result;
+}
+
+} // namespace
+
+std::vector<IndependentContrast>
+NewickTree::independent_contrasts(const std::unordered_map<std::string, double> &trait_values) const {
+	ContrastScaffold scaffold = build_contrast_scaffold(*this);
+	std::vector<double> x_workspace(num_nodes());
+	return contrasts_for_trait(*this, scaffold, trait_values, x_workspace);
+}
+
+std::vector<std::vector<IndependentContrast>>
+NewickTree::independent_contrasts(const std::vector<std::unordered_map<std::string, double>> &trait_values_list) const {
+	// Trait-independent validation + variances computed once, reused per trait; the
+	// tree-sized ancestral-value scratch buffer is allocated once and reused too.
+	ContrastScaffold scaffold = build_contrast_scaffold(*this);
+	std::vector<double> x_workspace(num_nodes());
+	std::vector<std::vector<IndependentContrast>> results;
+	results.reserve(trait_values_list.size());
+	for (const auto &trait_values : trait_values_list) {
+		results.push_back(contrasts_for_trait(*this, scaffold, trait_values, x_workspace));
+	}
+	return results;
+}
+
 uint32_t NewickTree::add_node(const std::string &name, double branch_length, std::optional<int64_t> edge_id) {
 	if (nodes_.size() >= MAX_NODES) {
 		throw std::runtime_error("Tree too large: exceeds maximum of " + std::to_string(MAX_NODES) + " nodes");

--- a/src/include/NewickTree.hpp
+++ b/src/include/NewickTree.hpp
@@ -261,16 +261,23 @@ public:
 	// Zero-length internal edges are allowed. Throws std::runtime_error /
 	// std::invalid_argument describing the first violation. The root's own branch
 	// length is unused.
-	std::vector<IndependentContrast>
-	independent_contrasts(const std::unordered_map<std::string, double> &trait_values) const;
+	//
+	// `node_ids` (optional) maps this tree's dense node index to a caller-facing
+	// identifier (e.g. the original node_index of the source table); when supplied,
+	// error messages for unnamed nodes report that identifier instead of the
+	// internal dense index. Pass nullptr to use the dense index.
+	std::vector<IndependentContrast> independent_contrasts(const std::unordered_map<std::string, double> &trait_values,
+	                                                       const std::vector<int64_t> *node_ids = nullptr) const;
 
 	// Batch overload for many traits over the same tree: the trait-independent work
 	// (structural + branch-length validation, variance-extended branch lengths, and
 	// per-node contrast variances) is done once and reused across every trait.
 	// Returns one contrast vector per input trait, in the same order. Per-trait
-	// completeness is still validated; the same exceptions are thrown.
+	// completeness is still validated; the same exceptions are thrown. `node_ids` is
+	// as above (used only for error-message identifiers).
 	std::vector<std::vector<IndependentContrast>>
-	independent_contrasts(const std::vector<std::unordered_map<std::string, double>> &trait_values_list) const;
+	independent_contrasts(const std::vector<std::unordered_map<std::string, double>> &trait_values_list,
+	                      const std::vector<int64_t> *node_ids = nullptr) const;
 
 	// ========================================================================
 	// Modification (for insert_fully_resolved)

--- a/src/include/NewickTree.hpp
+++ b/src/include/NewickTree.hpp
@@ -50,6 +50,15 @@ struct NodeInput {
 	std::optional<int64_t> edge_id;   // Edge identifier (nullopt if not specified)
 };
 
+// One standardized phylogenetic independent contrast (Felsenstein 1985) at an
+// internal node, for a single trait.
+struct IndependentContrast {
+	uint32_t node;             // Internal node index (this tree's index)
+	double contrast;           // Standardized contrast (X_i - X_j) / sqrt(v_i + v_j)
+	double ancestral_estimate; // Reconstructed trait value X_k at the node
+	double contrast_variance;  // v_i + v_j (the contrast's expected variance)
+};
+
 class NewickTree {
 public:
 	// Constants
@@ -216,6 +225,52 @@ public:
 	//
 	// The returned tree's node indices are reassigned 0-based (as with build()).
 	NewickTree shear(const std::unordered_set<std::string> &keep_names, bool collapse, bool ignore_missing) const;
+
+	// ========================================================================
+	// Resolution (make multifurcations bifurcating)
+	// ========================================================================
+
+	// Return a new tree in which every node with more than two children is
+	// resolved into a series of bifurcations. For a node with children
+	// c0,c1,...,c(m-1) (m >= 3) in their existing order, the resolution is a
+	// deterministic left-comb: the node keeps c0 and a new internal node N1;
+	// N1 keeps c1 and N2; ...; N(m-2) keeps c(m-2) and c(m-1). The m-2 new
+	// internal nodes are unnamed, have branch length 0, and no edge id, so tip
+	// counts and every original edge length are preserved and root-to-tip
+	// distances are unchanged.
+	//
+	// Nodes with two or fewer children are left untouched, including
+	// single-child unifurcations (this resolves polytomies only; use shear() to
+	// collapse unifurcations). The returned tree's node indices are reassigned
+	// 0-based (original nodes keep their index; new nodes follow).
+	NewickTree resolve_multifurcations() const;
+
+	// ========================================================================
+	// Comparative methods
+	// ========================================================================
+
+	// Compute Felsenstein (1985) phylogenetic independent contrasts for one
+	// numeric per-tip trait, keyed by tip name. Returns one contrast per internal
+	// node (n-1 for a rooted bifurcating tree with n tips).
+	//
+	// Requires a strictly bifurcating tree (every internal node has exactly two
+	// children) with unique tip names, a trait value for exactly the set of tips
+	// (no missing tips, no extra names), and finite non-negative branch lengths on
+	// every non-root edge; each contrast's variance (v_i + v_j) must be > 0
+	// (so at most one of a node's two children may have zero effective length).
+	// Zero-length internal edges are allowed. Throws std::runtime_error /
+	// std::invalid_argument describing the first violation. The root's own branch
+	// length is unused.
+	std::vector<IndependentContrast>
+	independent_contrasts(const std::unordered_map<std::string, double> &trait_values) const;
+
+	// Batch overload for many traits over the same tree: the trait-independent work
+	// (structural + branch-length validation, variance-extended branch lengths, and
+	// per-node contrast variances) is done once and reused across every trait.
+	// Returns one contrast vector per input trait, in the same order. Per-trait
+	// completeness is still validated; the same exceptions are thrown.
+	std::vector<std::vector<IndependentContrast>>
+	independent_contrasts(const std::vector<std::unordered_map<std::string, double>> &trait_values_list) const;
 
 	// ========================================================================
 	// Modification (for insert_fully_resolved)

--- a/src/include/phylo_independent_contrasts.hpp
+++ b/src/include/phylo_independent_contrasts.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+#include <string>
+#include <vector>
+
+namespace duckdb {
+
+// phylo_independent_contrasts(tree_table, traits_table)
+//
+// Felsenstein (1985) phylogenetic independent contrasts over a strictly
+// bifurcating tree (read_newick schema) and one or more numeric per-tip traits.
+//
+// traits_table is long form (name, trait, value): `name` is type-flexible
+// (VARCHAR/UUID/BIGINT, matched to tip labels by canonical text), `trait` is a
+// VARCHAR label, `value` is DOUBLE. Every trait must cover exactly the tree's
+// tip set (no missing tips, no extra names, no NULLs). Output is long form, one
+// row per (internal node, trait): node_index (the input tree's node_index),
+// trait, contrast, ancestral_estimate, contrast_variance.
+class PhyloIndependentContrastsTableFunction {
+public:
+	struct ContrastRow {
+		int64_t node_index;
+		std::string trait;
+		double contrast;
+		double ancestral_estimate;
+		double contrast_variance;
+	};
+
+	struct Data : public TableFunctionData {
+		std::string tree_table_name;
+		std::string traits_table_name;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		Data(std::string tree_table, std::string traits_table);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		std::vector<ContrastRow> rows;
+		size_t current_row_idx = 0;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/include/tree_resolve_multifurcations.hpp
+++ b/src/include/tree_resolve_multifurcations.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "read_newick.hpp"
+#include "duckdb/function/table_function.hpp"
+#include "duckdb/main/extension/extension_loader.hpp"
+
+namespace duckdb {
+
+// tree_resolve_multifurcations(tree_table)
+//
+// Resolve every node with more than two children in a tree (in read_newick
+// schema) into a series of bifurcations by inserting unnamed zero-length
+// internal connector nodes (a deterministic left-comb). Nodes with two or fewer
+// children are unchanged; single-child unifurcations are NOT collapsed (use
+// shear_tree for that). Output schema matches read_newick (without filepath), so
+// the result round-trips into phylo_independent_contrasts and read_newick.
+class TreeResolveMultifurcationsTableFunction {
+public:
+	struct Data : public TableFunctionData {
+		std::string tree_table_name;
+
+		std::vector<std::string> names;
+		std::vector<LogicalType> types;
+
+		explicit Data(std::string tree_table);
+	};
+
+	struct GlobalState : public GlobalTableFunctionState {
+		std::vector<ReadNewickTableFunction::NodeRow> rows;
+		size_t current_row_idx = 0;
+
+		idx_t MaxThreads() const override {
+			return 1;
+		}
+	};
+
+	static unique_ptr<FunctionData> Bind(ClientContext &context, TableFunctionBindInput &input,
+	                                     vector<LogicalType> &return_types, vector<std::string> &names);
+
+	static unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFunctionInitInput &input);
+
+	static void Execute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output);
+
+	static TableFunction GetFunction();
+	static void Register(ExtensionLoader &loader);
+};
+
+} // namespace duckdb

--- a/src/miint_extension.cpp
+++ b/src/miint_extension.cpp
@@ -15,7 +15,9 @@
 #include <copy_ubam.hpp>
 #include <read_jplace_newick.hpp>
 #include <read_newick.hpp>
+#include <phylo_independent_contrasts.hpp>
 #include <shear_tree.hpp>
+#include <tree_resolve_multifurcations.hpp>
 #include <tree_resolve_placement.hpp>
 #include <kseq++/seqio.hpp>
 #include <read_fastx.hpp>
@@ -266,6 +268,8 @@ static void LoadInternal(ExtensionLoader &loader) {
 	ReadJplaceNewickTableFunction::Register(loader);
 	TreeResolvePlacementTableFunction::Register(loader);
 	ShearTreeTableFunction::Register(loader);
+	TreeResolveMultifurcationsTableFunction::Register(loader);
+	PhyloIndependentContrastsTableFunction::Register(loader);
 	AlignMinimap2TableFunction::Register(loader);
 	AlignMinimap2ShardedTableFunction::Register(loader);
 	SaveMinimap2IndexTableFunction::Register(loader);

--- a/src/phylo_independent_contrasts.cpp
+++ b/src/phylo_independent_contrasts.cpp
@@ -1,0 +1,233 @@
+#include "phylo_independent_contrasts.hpp"
+#include "tree_table_reader.hpp"
+#include "catalog_utils.hpp"
+#include "NewickTree.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/database.hpp"
+#include "duckdb/main/query_result.hpp"
+#include "duckdb/parser/keyword_helper.hpp"
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace duckdb {
+
+namespace {
+
+// Validate that the traits table/view has the required long-form columns.
+void ValidateTraitsTableSchema(ClientContext &context, const std::string &table_name) {
+	auto info = GetTableOrViewColumns(context, table_name, "Traits table");
+	for (const char *required : {"name", "trait", "value"}) {
+		if (!HasColumn(info, required)) {
+			throw BinderException("Traits table '%s' missing required column '%s'", table_name, required);
+		}
+	}
+}
+
+// Read long-form traits into trait -> (tip name -> value). Uses a separate
+// Connection (see docs/internals/reading-tables-views.md). `name` is cast to
+// VARCHAR so UUID/BIGINT/VARCHAR tip keys all match tip labels by canonical
+// text. A std::map keeps trait order stable (deterministic output). NULLs and
+// duplicate (name, trait) pairs are hard errors.
+std::map<std::string, std::unordered_map<std::string, double>> ReadTraits(ClientContext &context,
+                                                                          const std::string &table_name) {
+	std::map<std::string, std::unordered_map<std::string, double>> traits;
+
+	auto &db = DatabaseInstance::GetDatabase(context);
+	Connection conn(db);
+
+	std::string query =
+	    "SELECT name::VARCHAR, trait::VARCHAR, value::DOUBLE FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
+	auto query_result = conn.Query(query);
+	if (query_result->HasError()) {
+		throw InvalidInputException("Failed to read from traits table '%s': %s", table_name, query_result->GetError());
+	}
+
+	auto &materialized = query_result->Cast<MaterializedQueryResult>();
+	while (true) {
+		auto chunk = materialized.Fetch();
+		if (!chunk || chunk->size() == 0) {
+			break;
+		}
+		UnifiedVectorFormat name_data, trait_data, value_data;
+		chunk->data[0].ToUnifiedFormat(chunk->size(), name_data);
+		chunk->data[1].ToUnifiedFormat(chunk->size(), trait_data);
+		chunk->data[2].ToUnifiedFormat(chunk->size(), value_data);
+		auto names = UnifiedVectorFormat::GetData<string_t>(name_data);
+		auto trait_names = UnifiedVectorFormat::GetData<string_t>(trait_data);
+		auto values = UnifiedVectorFormat::GetData<double>(value_data);
+
+		for (idx_t i = 0; i < chunk->size(); i++) {
+			auto ni = name_data.sel->get_index(i);
+			auto ti = trait_data.sel->get_index(i);
+			auto vi = value_data.sel->get_index(i);
+
+			if (!name_data.validity.RowIsValid(ni)) {
+				throw InvalidInputException("NULL name in traits table '%s'", table_name);
+			}
+			if (!trait_data.validity.RowIsValid(ti)) {
+				throw InvalidInputException("NULL trait in traits table '%s'", table_name);
+			}
+			std::string nm = names[ni].GetString();
+			std::string tr = trait_names[ti].GetString();
+			if (!value_data.validity.RowIsValid(vi)) {
+				throw InvalidInputException("NULL value for tip '%s' trait '%s' in traits table '%s'", nm, tr,
+				                            table_name);
+			}
+
+			auto [it, inserted] = traits[tr].emplace(std::move(nm), values[vi]);
+			if (!inserted) {
+				throw InvalidInputException("Duplicate trait value for tip '%s' trait '%s' in traits table '%s'",
+				                            it->first, tr, table_name);
+			}
+		}
+	}
+
+	if (traits.empty()) {
+		throw InvalidInputException("Traits table '%s' is empty", table_name);
+	}
+
+	return traits;
+}
+
+} // namespace
+
+PhyloIndependentContrastsTableFunction::Data::Data(std::string tree_table, std::string traits_table)
+    : tree_table_name(std::move(tree_table)), traits_table_name(std::move(traits_table)) {
+	names = {"node_index", "trait", "contrast", "ancestral_estimate", "contrast_variance"};
+	types = {LogicalType::BIGINT, LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::DOUBLE, LogicalType::DOUBLE};
+}
+
+unique_ptr<FunctionData> PhyloIndependentContrastsTableFunction::Bind(ClientContext &context,
+                                                                      TableFunctionBindInput &input,
+                                                                      vector<LogicalType> &return_types,
+                                                                      vector<std::string> &names) {
+	auto tree_table_name = input.inputs[0].ToString();
+	auto traits_table_name = input.inputs[1].ToString();
+
+	// Validate schemas at bind time for early error detection.
+	ValidateTreeTableSchema(context, tree_table_name);
+	ValidateTraitsTableSchema(context, traits_table_name);
+
+	auto data = duckdb::make_uniq<Data>(std::move(tree_table_name), std::move(traits_table_name));
+
+	for (const auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (const auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+unique_ptr<GlobalTableFunctionState> PhyloIndependentContrastsTableFunction::InitGlobal(ClientContext &context,
+                                                                                        TableFunctionInitInput &input) {
+	auto &bind_data = input.bind_data->Cast<Data>();
+	auto gstate = duckdb::make_uniq<GlobalState>();
+
+	auto node_inputs = ReadTreeTable(context, bind_data.tree_table_name);
+
+	// build() preserves input order for node indices, and ReadTreeTable sorts by
+	// node_index, so tree dense index i corresponds to node_inputs[i]. Capture the
+	// original node_index up front so contrasts are reported against the caller's
+	// node_index (a stable join key), not the internal dense index.
+	std::vector<int64_t> tree_index_to_node_id;
+	tree_index_to_node_id.reserve(node_inputs.size());
+	for (const auto &ni : node_inputs) {
+		tree_index_to_node_id.push_back(ni.node_id);
+	}
+
+	miint::NewickTree tree;
+	try {
+		tree = miint::NewickTree::build(node_inputs);
+	} catch (const std::exception &e) {
+		throw InvalidInputException("Failed to build tree from '%s': %s", bind_data.tree_table_name, e.what());
+	}
+	node_inputs = {};
+
+	auto traits = ReadTraits(context, bind_data.traits_table_name);
+
+	// Flatten to parallel name/map vectors (traits is sorted, so output is stable)
+	// and compute all traits in one batch: the tree validation and variance
+	// precompute happen once, then each trait is a cheap post-order pass.
+	std::vector<std::string> trait_names;
+	std::vector<std::unordered_map<std::string, double>> trait_maps;
+	trait_names.reserve(traits.size());
+	trait_maps.reserve(traits.size());
+	for (auto &entry : traits) {
+		trait_names.push_back(entry.first);
+		trait_maps.push_back(std::move(entry.second));
+	}
+
+	std::vector<std::vector<miint::IndependentContrast>> per_trait;
+	try {
+		per_trait = tree.independent_contrasts(trait_maps);
+	} catch (const std::exception &e) {
+		// Cold path: re-run per trait to attribute a completeness failure to the
+		// specific trait for a precise message (structural/branch errors are
+		// trait-independent and surface on the first trait).
+		for (size_t t = 0; t < trait_maps.size(); t++) {
+			try {
+				tree.independent_contrasts(trait_maps[t]);
+			} catch (const std::exception &inner) {
+				throw InvalidInputException("phylo_independent_contrasts failed for trait '%s': %s", trait_names[t],
+				                            inner.what());
+			}
+		}
+		throw InvalidInputException("phylo_independent_contrasts failed: %s", e.what());
+	}
+
+	for (size_t t = 0; t < trait_names.size(); t++) {
+		for (const auto &c : per_trait[t]) {
+			gstate->rows.push_back(ContrastRow {tree_index_to_node_id[c.node], trait_names[t], c.contrast,
+			                                    c.ancestral_estimate, c.contrast_variance});
+		}
+	}
+
+	return gstate;
+}
+
+void PhyloIndependentContrastsTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p,
+                                                     DataChunk &output) {
+	auto &gstate = data_p.global_state->Cast<GlobalState>();
+
+	if (gstate.current_row_idx >= gstate.rows.size()) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	size_t count = std::min<size_t>(STANDARD_VECTOR_SIZE, gstate.rows.size() - gstate.current_row_idx);
+
+	auto node_index_data = FlatVector::GetData<int64_t>(output.data[0]);
+	auto trait_data = FlatVector::GetData<string_t>(output.data[1]);
+	auto contrast_data = FlatVector::GetData<double>(output.data[2]);
+	auto anc_data = FlatVector::GetData<double>(output.data[3]);
+	auto var_data = FlatVector::GetData<double>(output.data[4]);
+
+	for (size_t k = 0; k < count; k++) {
+		const auto &row = gstate.rows[gstate.current_row_idx + k];
+		node_index_data[k] = row.node_index;
+		trait_data[k] = StringVector::AddString(output.data[1], row.trait);
+		contrast_data[k] = row.contrast;
+		anc_data[k] = row.ancestral_estimate;
+		var_data[k] = row.contrast_variance;
+	}
+
+	gstate.current_row_idx += count;
+	output.SetCardinality(count);
+}
+
+TableFunction PhyloIndependentContrastsTableFunction::GetFunction() {
+	return TableFunction("phylo_independent_contrasts", {LogicalType::VARCHAR, LogicalType::VARCHAR}, Execute, Bind,
+	                     InitGlobal);
+}
+
+void PhyloIndependentContrastsTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/phylo_independent_contrasts.cpp
+++ b/src/phylo_independent_contrasts.cpp
@@ -165,14 +165,14 @@ unique_ptr<GlobalTableFunctionState> PhyloIndependentContrastsTableFunction::Ini
 
 	std::vector<std::vector<miint::IndependentContrast>> per_trait;
 	try {
-		per_trait = tree.independent_contrasts(trait_maps);
+		per_trait = tree.independent_contrasts(trait_maps, &tree_index_to_node_id);
 	} catch (const std::exception &e) {
 		// Cold path: re-run per trait to attribute a completeness failure to the
 		// specific trait for a precise message (structural/branch errors are
 		// trait-independent and surface on the first trait).
 		for (size_t t = 0; t < trait_maps.size(); t++) {
 			try {
-				tree.independent_contrasts(trait_maps[t]);
+				tree.independent_contrasts(trait_maps[t], &tree_index_to_node_id);
 			} catch (const std::exception &inner) {
 				throw InvalidInputException("phylo_independent_contrasts failed for trait '%s': %s", trait_names[t],
 				                            inner.what());

--- a/src/tree_resolve_multifurcations.cpp
+++ b/src/tree_resolve_multifurcations.cpp
@@ -1,0 +1,90 @@
+#include "tree_resolve_multifurcations.hpp"
+#include "tree_table_reader.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/types/data_chunk.hpp"
+
+namespace duckdb {
+
+TreeResolveMultifurcationsTableFunction::Data::Data(std::string tree_table) : tree_table_name(std::move(tree_table)) {
+	ReadNewickTableFunction::GetSchema(names, types, false);
+}
+
+unique_ptr<FunctionData> TreeResolveMultifurcationsTableFunction::Bind(ClientContext &context,
+                                                                       TableFunctionBindInput &input,
+                                                                       vector<LogicalType> &return_types,
+                                                                       vector<std::string> &names) {
+	auto tree_table_name = input.inputs[0].ToString();
+
+	// Validate schema at bind time for early error detection.
+	ValidateTreeTableSchema(context, tree_table_name);
+
+	auto data = duckdb::make_uniq<Data>(std::move(tree_table_name));
+
+	for (const auto &name : data->names) {
+		names.emplace_back(name);
+	}
+	for (const auto &type : data->types) {
+		return_types.emplace_back(type);
+	}
+
+	return data;
+}
+
+unique_ptr<GlobalTableFunctionState>
+TreeResolveMultifurcationsTableFunction::InitGlobal(ClientContext &context, TableFunctionInitInput &input) {
+	auto &bind_data = input.bind_data->Cast<Data>();
+	auto gstate = duckdb::make_uniq<GlobalState>();
+
+	auto node_inputs = ReadTreeTable(context, bind_data.tree_table_name);
+
+	miint::NewickTree tree;
+	try {
+		tree = miint::NewickTree::build(node_inputs);
+	} catch (const std::exception &e) {
+		throw InvalidInputException("Failed to build tree from '%s': %s", bind_data.tree_table_name, e.what());
+	}
+
+	// Release the NodeInput vector before resolving to trim transient peak
+	// memory (see shear_tree.cpp for the same rationale).
+	node_inputs = {};
+
+	miint::NewickTree resolved;
+	try {
+		resolved = tree.resolve_multifurcations();
+	} catch (const std::exception &e) {
+		throw InvalidInputException("tree_resolve_multifurcations failed: %s", e.what());
+	}
+
+	gstate->rows = ReadNewickTableFunction::TreeToRows(resolved);
+
+	return gstate;
+}
+
+void TreeResolveMultifurcationsTableFunction::Execute(ClientContext &context, TableFunctionInput &data_p,
+                                                      DataChunk &output) {
+	auto &global_state = data_p.global_state->Cast<GlobalState>();
+
+	if (global_state.current_row_idx >= global_state.rows.size()) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	size_t rows_to_output =
+	    std::min<size_t>(STANDARD_VECTOR_SIZE, global_state.rows.size() - global_state.current_row_idx);
+
+	ReadNewickTableFunction::EmitNodeRows(global_state.rows, global_state.current_row_idx, rows_to_output, output, 0,
+	                                      false, "");
+
+	global_state.current_row_idx += rows_to_output;
+	output.SetCardinality(rows_to_output);
+}
+
+TableFunction TreeResolveMultifurcationsTableFunction::GetFunction() {
+	return TableFunction("tree_resolve_multifurcations", {LogicalType::VARCHAR}, Execute, Bind, InitGlobal);
+}
+
+void TreeResolveMultifurcationsTableFunction::Register(ExtensionLoader &loader) {
+	loader.RegisterFunction(GetFunction());
+}
+
+} // namespace duckdb

--- a/src/tree_table_reader.cpp
+++ b/src/tree_table_reader.cpp
@@ -40,8 +40,17 @@ std::vector<miint::NodeInput> ReadTreeTable(ClientContext &context, const std::s
 	std::string bl_proj = HasColumn(info, "branch_length") ? "branch_length::DOUBLE" : "CAST(NULL AS DOUBLE)";
 	std::string edge_proj = HasColumn(info, "edge_id") ? "edge_id::BIGINT" : "CAST(NULL AS BIGINT)";
 
+	// ORDER BY node_index: build() assigns node-array positions (and therefore
+	// each node's slot in its parent's children list) by the row order this query
+	// returns. Without an explicit order, that follows scan order, which is not
+	// guaranteed to match node_index for views/joins, Parquet-backed tables,
+	// parallel scans, or preserve_insertion_order=false. node_index is the
+	// canonical child order (it encodes read_newick's original left-to-right
+	// order), so ordering by it makes order-sensitive consumers
+	// (tree_resolve_multifurcations) reproducible regardless of storage.
 	std::string query = "SELECT node_index::BIGINT, parent_index::BIGINT, " + name_proj + ", " + bl_proj + ", " +
-	                    edge_proj + " FROM " + KeywordHelper::WriteOptionallyQuoted(table_name);
+	                    edge_proj + " FROM " + KeywordHelper::WriteOptionallyQuoted(table_name) +
+	                    " ORDER BY node_index";
 
 	auto query_result = conn.Query(query);
 

--- a/test/cpp/test_IndependentContrasts.cpp
+++ b/test/cpp/test_IndependentContrasts.cpp
@@ -179,6 +179,25 @@ TEST_CASE("independent_contrasts rejects a polytomy, naming the resolver", "[New
 	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("tree_resolve_multifurcations"));
 }
 
+TEST_CASE("independent_contrasts error reports the caller's node_index for unnamed nodes", "[NewickTree][pic]") {
+	// Unnamed root (caller node_index 77) with three children. Built in node_index
+	// order, so its dense index is 3 — but with a node_ids map the error must name
+	// 77 (what the user can join on), not the internal index 3.
+	std::vector<miint::NodeInput> in = {
+	    {10, std::optional<int64_t>(77), "A", 1.0, std::nullopt},
+	    {20, std::optional<int64_t>(77), "B", 1.0, std::nullopt},
+	    {30, std::optional<int64_t>(77), "C", 1.0, std::nullopt},
+	    {77, std::nullopt, "", std::numeric_limits<double>::quiet_NaN(), std::nullopt},
+	};
+	auto tree = miint::NewickTree::build(in);
+	std::vector<int64_t> node_ids = {10, 20, 30, 77}; // dense index -> caller node_index
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}});
+
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t, &node_ids), ContainsSubstring("node 77"));
+	// Without the map it falls back to the dense index (3).
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("node 3"));
+}
+
 TEST_CASE("independent_contrasts rejects a unifurcation, naming shear_tree", "[NewickTree][pic]") {
 	// root has a single child X: not bifurcating, but the remedy is collapsing the
 	// unifurcation (shear_tree), not resolving a polytomy.

--- a/test/cpp/test_IndependentContrasts.cpp
+++ b/test/cpp/test_IndependentContrasts.cpp
@@ -1,0 +1,242 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <limits>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "NewickTree.hpp"
+
+using Catch::Matchers::ContainsSubstring;
+
+namespace {
+
+uint32_t idx(const miint::NewickTree &tree, const std::string &name) {
+	auto found = tree.find_node_by_name(name);
+	REQUIRE(found.has_value());
+	return found.value();
+}
+
+// The contrast computed at a given internal node (fails if none).
+miint::IndependentContrast at(const std::vector<miint::IndependentContrast> &cs, uint32_t node) {
+	for (const auto &c : cs) {
+		if (c.node == node) {
+			return c;
+		}
+	}
+	FAIL("no contrast at node " << node);
+	return {}; // unreachable
+}
+
+// Hand-derived golden tree (Felsenstein 1985 recurrence, computed by hand):
+//
+//              root
+//             /    \
+//         E:2       C:4
+//        /   \
+//      A:1   B:3
+//
+// The internal edge E carries branch length 2; the asymmetric tip lengths
+// (A:1, B:3) make the ancestral-value WEIGHTING observable: X_A is weighted by
+// v_B and X_B by v_A, so a swapped weighting would be caught.
+const char *kGolden = "((A:1,B:3)E:2,C:4)root;";
+
+} // namespace
+
+// ============================================================================
+// Golden values (Felsenstein 1985), derived by hand from the recurrence:
+//   contrast_k       = (X_i - X_j) / sqrt(v_i + v_j)
+//   ancestral X_k    = (X_i*v_j + X_j*v_i) / (v_i + v_j)
+//   extended v_k'    = v_k + (v_i*v_j)/(v_i + v_j)
+//   contrast_var     = v_i + v_j
+// ============================================================================
+
+TEST_CASE("independent_contrasts matches the hand-derived golden", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse(kGolden);
+
+	// Trait X: A=2, B=6, C=1
+	// E: contrast = (2-6)/sqrt(1+3) = -4/2       = -2.0
+	//    X_E      = (2*3 + 6*1)/4  = 12/4        =  3.0
+	//    var      = 1+3                          =  4.0
+	//    v_E'     = 2 + (1*3)/4    = 2 + 0.75    =  2.75
+	// root: contrast = (3-1)/sqrt(2.75+4) = 2/sqrt(6.75) = 0.769800359...
+	//       X_root   = (3*4 + 1*2.75)/6.75 = 14.75/6.75  = 2.185185185...
+	//       var      = 6.75
+	std::unordered_map<std::string, double> x({{"A", 2.0}, {"B", 6.0}, {"C", 1.0}});
+	auto cs = tree.independent_contrasts(x);
+
+	// n=3 tips -> exactly n-1 = 2 contrasts (one per internal node).
+	REQUIRE(cs.size() == 2);
+
+	auto e = at(cs, idx(tree, "E"));
+	REQUIRE(e.contrast == Catch::Approx(-2.0).margin(1e-9));
+	REQUIRE(e.ancestral_estimate == Catch::Approx(3.0).margin(1e-9));
+	REQUIRE(e.contrast_variance == Catch::Approx(4.0).margin(1e-9));
+
+	auto r = at(cs, idx(tree, "root"));
+	REQUIRE(r.contrast == Catch::Approx(0.769800359).margin(1e-9));
+	REQUIRE(r.ancestral_estimate == Catch::Approx(2.185185185).margin(1e-9));
+	REQUIRE(r.contrast_variance == Catch::Approx(6.75).margin(1e-9));
+}
+
+TEST_CASE("independent_contrasts: contrast_variance is trait-independent", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse(kGolden);
+
+	// Trait Y: A=5, B=1, C=0
+	// E:   contrast = (5-1)/2 = 2.0 ; X_E = (5*3+1*1)/4 = 4.0 ; var = 4.0
+	// root:contrast = (4-0)/sqrt(6.75) = 1.539600718... ; X = 16/6.75 = 2.370370370 ; var = 6.75
+	std::unordered_map<std::string, double> y({{"A", 5.0}, {"B", 1.0}, {"C", 0.0}});
+	auto cs = tree.independent_contrasts(y);
+
+	auto e = at(cs, idx(tree, "E"));
+	auto r = at(cs, idx(tree, "root"));
+
+	REQUIRE(e.contrast == Catch::Approx(2.0).margin(1e-9));
+	REQUIRE(e.ancestral_estimate == Catch::Approx(4.0).margin(1e-9));
+	REQUIRE(r.contrast == Catch::Approx(1.539600718).margin(1e-9));
+	REQUIRE(r.ancestral_estimate == Catch::Approx(2.370370370).margin(1e-9));
+
+	// WHY: variance depends only on the tree, not the trait. E stays 4.0 and root
+	// stays 6.75 exactly as for trait X — this is what lets it be precomputed once.
+	REQUIRE(e.contrast_variance == Catch::Approx(4.0).margin(1e-9));
+	REQUIRE(r.contrast_variance == Catch::Approx(6.75).margin(1e-9));
+}
+
+TEST_CASE("independent_contrasts sign follows child order (deterministic)", "[NewickTree][pic]") {
+	// A is the first child of E, so the contrast is X_A - X_B (negative here), not
+	// the reverse. The sign is arbitrary in theory but must be stable in practice.
+	auto tree = miint::NewickTree::parse(kGolden);
+	std::unordered_map<std::string, double> x({{"A", 2.0}, {"B", 6.0}, {"C", 1.0}});
+	auto cs = tree.independent_contrasts(x);
+	REQUIRE(at(cs, idx(tree, "E")).contrast < 0.0);
+}
+
+TEST_CASE("independent_contrasts count is n-1 for a larger bifurcating tree", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse("(((A:1,B:1)F:1,C:1)G:1,(D:1,E:1)H:1)root;");
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}, {"D", 4.0}, {"E", 5.0}});
+	auto cs = tree.independent_contrasts(t);
+	REQUIRE(cs.size() == 4); // 5 tips -> 4 contrasts
+}
+
+TEST_CASE("independent_contrasts batch matches per-trait single calls", "[NewickTree][pic]") {
+	// The batch overload hoists the trait-independent work but must produce exactly
+	// the same numbers as calling the single-trait method once per trait.
+	auto tree = miint::NewickTree::parse(kGolden);
+	std::unordered_map<std::string, double> x({{"A", 2.0}, {"B", 6.0}, {"C", 1.0}});
+	std::unordered_map<std::string, double> y({{"A", 5.0}, {"B", 1.0}, {"C", 0.0}});
+
+	auto batch = tree.independent_contrasts(std::vector<std::unordered_map<std::string, double>> {x, y});
+	REQUIRE(batch.size() == 2);
+
+	auto same = [](const std::vector<miint::IndependentContrast> &a, const std::vector<miint::IndependentContrast> &b) {
+		REQUIRE(a.size() == b.size());
+		for (size_t i = 0; i < a.size(); i++) {
+			REQUIRE(a[i].node == b[i].node);
+			REQUIRE(a[i].contrast == Catch::Approx(b[i].contrast).margin(1e-12));
+			REQUIRE(a[i].ancestral_estimate == Catch::Approx(b[i].ancestral_estimate).margin(1e-12));
+			REQUIRE(a[i].contrast_variance == Catch::Approx(b[i].contrast_variance).margin(1e-12));
+		}
+	};
+	same(batch[0], tree.independent_contrasts(x));
+	same(batch[1], tree.independent_contrasts(y));
+}
+
+TEST_CASE("independent_contrasts batch validates each trait's completeness", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse(kGolden);
+	std::unordered_map<std::string, double> ok({{"A", 2.0}, {"B", 6.0}, {"C", 1.0}});
+	std::unordered_map<std::string, double> bad({{"A", 2.0}, {"B", 6.0}}); // C missing
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(std::vector<std::unordered_map<std::string, double>> {ok, bad}),
+	                    ContainsSubstring("C"));
+}
+
+// ============================================================================
+// Zero-length internal edges are allowed (the tree_resolve_multifurcations
+// output must feed PIC). Only a zero *contrast variance* is an error.
+// ============================================================================
+
+TEST_CASE("independent_contrasts accepts a zero-length internal edge", "[NewickTree][pic]") {
+	// E's own edge is 0 (as a resolver connector would be). Its children still
+	// have positive lengths, so v_E' = 0 + (1*3)/4 = 0.75 and the root variance
+	// 0.75+4 = 4.75 > 0 — valid.
+	auto tree = miint::NewickTree::parse("((A:1,B:3)E:0,C:4)root;");
+	std::unordered_map<std::string, double> x({{"A", 2.0}, {"B", 6.0}, {"C", 1.0}});
+
+	std::vector<miint::IndependentContrast> cs;
+	REQUIRE_NOTHROW(cs = tree.independent_contrasts(x));
+	REQUIRE(cs.size() == 2);
+	REQUIRE(at(cs, idx(tree, "E")).contrast == Catch::Approx(-2.0).margin(1e-9));
+	// The zero internal edge was actually used: root variance = 0.75 + 4 = 4.75.
+	REQUIRE(at(cs, idx(tree, "root")).contrast_variance == Catch::Approx(4.75).margin(1e-9));
+}
+
+// ============================================================================
+// Error paths (fail loud)
+// ============================================================================
+
+TEST_CASE("independent_contrasts rejects a polytomy, naming the resolver", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse("(A:1,B:2,C:3)root;");
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("tree_resolve_multifurcations"));
+}
+
+TEST_CASE("independent_contrasts rejects a unifurcation, naming shear_tree", "[NewickTree][pic]") {
+	// root has a single child X: not bifurcating, but the remedy is collapsing the
+	// unifurcation (shear_tree), not resolving a polytomy.
+	auto tree = miint::NewickTree::parse("((A:1,B:2)X:3)root;");
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("shear_tree"));
+}
+
+TEST_CASE("independent_contrasts rejects a missing trait value", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse(kGolden);
+	std::unordered_map<std::string, double> t({{"A", 2.0}, {"B", 6.0}}); // C missing
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("C"));
+}
+
+TEST_CASE("independent_contrasts rejects a trait value for a non-tip name", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse(kGolden);
+	std::unordered_map<std::string, double> t({{"A", 2.0}, {"B", 6.0}, {"C", 1.0}, {"Z", 9.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("not a tip"));
+}
+
+TEST_CASE("independent_contrasts rejects duplicate tip names", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse("((A:1,A:2)E:3,C:4)root;");
+	std::unordered_map<std::string, double> t({{"A", 2.0}, {"C", 1.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("duplicate"));
+}
+
+TEST_CASE("independent_contrasts rejects NaN (unspecified) branch lengths", "[NewickTree][pic]") {
+	// A cladogram has no branch lengths — PIC is undefined.
+	auto tree = miint::NewickTree::parse("((A,B)E,C)root;");
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("branch length"));
+}
+
+TEST_CASE("independent_contrasts rejects infinite branch lengths", "[NewickTree][pic]") {
+	// +Inf is finite-looking to an isnan()/negative check but poisons sqrt()/the
+	// weighting into silent 0 / NaN output; it must be rejected up front. Built via
+	// NodeInput so the infinity reaches validation regardless of parser behavior.
+	std::vector<miint::NodeInput> in = {
+	    {0, std::optional<int64_t>(2), "A", std::numeric_limits<double>::infinity(), std::nullopt},
+	    {1, std::optional<int64_t>(2), "B", 1.0, std::nullopt},
+	    {2, std::optional<int64_t>(4), "E", 1.0, std::nullopt},
+	    {3, std::optional<int64_t>(4), "C", 1.0, std::nullopt},
+	    {4, std::nullopt, "root", std::numeric_limits<double>::quiet_NaN(), std::nullopt},
+	};
+	auto tree = miint::NewickTree::build(in);
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("finite"));
+}
+
+TEST_CASE("independent_contrasts rejects negative branch lengths", "[NewickTree][pic]") {
+	auto tree = miint::NewickTree::parse("((A:1,B:-1)E:2,C:4)root;");
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("negative"));
+}
+
+TEST_CASE("independent_contrasts rejects a zero contrast variance", "[NewickTree][pic]") {
+	// Both of E's children have zero length -> v_i + v_j = 0 -> division by zero.
+	auto tree = miint::NewickTree::parse("((A:0,B:0)E:1,C:1)root;");
+	std::unordered_map<std::string, double> t({{"A", 1.0}, {"B", 2.0}, {"C", 3.0}});
+	REQUIRE_THROWS_WITH(tree.independent_contrasts(t), ContainsSubstring("zero"));
+}

--- a/test/cpp/test_ResolveMultifurcations.cpp
+++ b/test/cpp/test_ResolveMultifurcations.cpp
@@ -1,0 +1,217 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+#include <cmath>
+#include <limits>
+#include <string>
+#include <vector>
+#include "NewickTree.hpp"
+
+namespace {
+
+// Resolve a node index by name (fails the test if the name is absent).
+uint32_t idx(const miint::NewickTree &tree, const std::string &name) {
+	auto found = tree.find_node_by_name(name);
+	REQUIRE(found.has_value());
+	return found.value();
+}
+
+// Postcondition of resolve_multifurcations: no node has more than two children.
+// (Unifurcations are intentionally left alone, so the check is <= 2, not == 2.)
+void require_no_multifurcations(const miint::NewickTree &t) {
+	for (uint32_t i = 0; i < t.num_nodes(); ++i) {
+		if (!t.is_tip(i)) {
+			INFO("internal node " << i << " name='" << t.name(i) << "' has " << t.children(i).size() << " children");
+			REQUIRE(t.children(i).size() <= 2);
+		}
+	}
+}
+
+// The one child of `node` whose index is not `other` (for a 2-child node).
+uint32_t sibling_of(const miint::NewickTree &t, uint32_t node, uint32_t other) {
+	const auto &ch = t.children(node);
+	REQUIRE(ch.size() == 2);
+	return ch[0] == other ? ch[1] : ch[0];
+}
+
+// A fully bifurcating tree with distinct branch lengths on every edge.
+const char *kBinaryTree = "(((A:1,B:2)G:3,C:4)H:5,(D:6,E:7)I:8)root;";
+
+} // namespace
+
+// ============================================================================
+// Pass-through: nothing to resolve
+// ============================================================================
+
+TEST_CASE("resolve leaves an already-bifurcating tree byte-identical", "[NewickTree][resolve]") {
+	auto tree = miint::NewickTree::parse(kBinaryTree);
+	auto before = tree.to_newick();
+
+	auto out = tree.resolve_multifurcations();
+
+	// WHY: a tree with no polytomy must round-trip unchanged — original indices,
+	// child order, names, and branch lengths are all preserved, so the Newick
+	// serialization is identical.
+	REQUIRE(out.num_nodes() == tree.num_nodes());
+	REQUIRE(out.num_tips() == tree.num_tips());
+	REQUIRE(out.to_newick() == before);
+	require_no_multifurcations(out);
+}
+
+TEST_CASE("resolve leaves a single tip unchanged", "[NewickTree][resolve]") {
+	auto tree = miint::NewickTree::parse("A;");
+	auto out = tree.resolve_multifurcations();
+	REQUIRE(out.num_nodes() == 1);
+	REQUIRE(out.num_tips() == 1);
+	REQUIRE(out.is_tip(out.root()));
+}
+
+TEST_CASE("resolve leaves a unifurcation alone (polytomies only)", "[NewickTree][resolve]") {
+	// root has a single child X, which is a real bifurcation. resolve() must not
+	// collapse the unifurcation (that is shear()'s job), only split polytomies.
+	auto tree = miint::NewickTree::parse("((A:1,B:2)X:3)root;");
+	auto out = tree.resolve_multifurcations();
+	REQUIRE(out.num_nodes() == tree.num_nodes());
+	REQUIRE(out.children(out.root()).size() == 1);
+}
+
+// ============================================================================
+// Resolving polytomies into a deterministic left-comb
+// ============================================================================
+
+TEST_CASE("resolve trifurcation -> bifurcation with a zero-length connector", "[NewickTree][resolve]") {
+	auto tree = miint::NewickTree::parse("(A:1,B:2,C:3)root;");
+	auto out = tree.resolve_multifurcations();
+
+	REQUIRE(out.num_tips() == 3);
+	REQUIRE(out.num_nodes() == 5); // root, A, B, C, + 1 connector (m-2 = 1)
+	require_no_multifurcations(out);
+
+	auto root = out.root();
+	REQUIRE(out.name(root) == "root");
+	REQUIRE(out.children(root).size() == 2);
+
+	uint32_t a = idx(out, "A");
+	uint32_t b = idx(out, "B");
+	uint32_t c = idx(out, "C");
+
+	// Left-comb, child order preserved: root keeps A (first child) plus the new
+	// connector, in that order.
+	REQUIRE(out.children(root)[0] == a);
+	REQUIRE(out.parent(a) == root);
+	REQUIRE(out.branch_length(a) == Catch::Approx(1.0));
+
+	uint32_t connector = sibling_of(out, root, a);
+	REQUIRE_FALSE(out.is_tip(connector));
+	REQUIRE(out.name(connector).empty());
+	REQUIRE_FALSE(out.edge_id(connector).has_value());
+	REQUIRE(out.branch_length(connector) == Catch::Approx(0.0).margin(1e-12));
+
+	// The connector holds the remaining two children with lengths preserved.
+	REQUIRE(out.parent(b) == connector);
+	REQUIRE(out.parent(c) == connector);
+	REQUIRE(out.branch_length(b) == Catch::Approx(2.0));
+	REQUIRE(out.branch_length(c) == Catch::Approx(3.0));
+	REQUIRE(out.children(connector)[0] == b); // order preserved
+}
+
+TEST_CASE("resolve four-way multifurcation into a left-comb", "[NewickTree][resolve]") {
+	auto tree = miint::NewickTree::parse("(A:1,B:2,C:3,D:4)root;");
+	auto out = tree.resolve_multifurcations();
+
+	REQUIRE(out.num_tips() == 4);
+	REQUIRE(out.num_nodes() == 7); // 4 tips + root + (m-2 = 2) connectors
+	require_no_multifurcations(out);
+
+	uint32_t a = idx(out, "A"), b = idx(out, "B"), c = idx(out, "C"), d = idx(out, "D");
+	auto root = out.root();
+
+	// root -> [A, N1]
+	REQUIRE(out.children(root)[0] == a);
+	uint32_t n1 = sibling_of(out, root, a);
+	REQUIRE_FALSE(out.is_tip(n1));
+	REQUIRE(out.branch_length(n1) == Catch::Approx(0.0).margin(1e-12));
+
+	// N1 -> [B, N2]
+	REQUIRE(out.parent(b) == n1);
+	REQUIRE(out.children(n1)[0] == b);
+	uint32_t n2 = sibling_of(out, n1, b);
+	REQUIRE_FALSE(out.is_tip(n2));
+	REQUIRE(out.branch_length(n2) == Catch::Approx(0.0).margin(1e-12));
+
+	// N2 -> [C, D], with C ahead of D (order preserved at the final connector too).
+	REQUIRE(out.parent(c) == n2);
+	REQUIRE(out.parent(d) == n2);
+	REQUIRE(out.children(n2)[0] == c);
+	REQUIRE(out.branch_length(c) == Catch::Approx(3.0));
+	REQUIRE(out.branch_length(d) == Catch::Approx(4.0));
+}
+
+TEST_CASE("resolve a cladogram polytomy inserts explicit zero-length connectors", "[NewickTree][resolve]") {
+	// A topology-only tree (no branch lengths anywhere). Resolving the root
+	// polytomy inserts connectors with an EXPLICIT 0.0 length (not NaN): an
+	// arbitrary resolution asserts "no evolutionary distance here", and PIC (the
+	// downstream consumer) requires finite lengths. WHY pin this: it deliberately
+	// differs from shear()'s all-NaN-preserving collapse, so it must be a
+	// conscious choice, not an accident.
+	auto tree = miint::NewickTree::parse("(A,B,C)root;");
+	auto out = tree.resolve_multifurcations();
+
+	REQUIRE(out.num_tips() == 3);
+	REQUIRE(out.num_nodes() == 5);
+	require_no_multifurcations(out);
+
+	// Original tip edges stay unspecified (NaN); the new connector is 0.0.
+	REQUIRE(std::isnan(out.branch_length(idx(out, "A"))));
+	uint32_t connector = sibling_of(out, out.root(), idx(out, "A"));
+	REQUIRE_FALSE(out.is_tip(connector));
+	REQUIRE_FALSE(std::isnan(out.branch_length(connector)));
+	REQUIRE(out.branch_length(connector) == Catch::Approx(0.0).margin(1e-12));
+}
+
+TEST_CASE("resolve an internal polytomy, leaving its siblings untouched", "[NewickTree][resolve]") {
+	// X has 3 children; root is already bifurcating (X, D).
+	auto tree = miint::NewickTree::parse("((A:1,B:2,C:3)X:4,D:5)root;");
+	auto out = tree.resolve_multifurcations();
+
+	REQUIRE(out.num_tips() == 4);
+	REQUIRE(out.num_nodes() == 7); // A,B,C,D + root + X + 1 connector
+	require_no_multifurcations(out);
+
+	// X keeps its name and branch length and now has exactly two children.
+	uint32_t x = idx(out, "X");
+	REQUIRE(out.branch_length(x) == Catch::Approx(4.0));
+	REQUIRE(out.children(x).size() == 2);
+
+	// The sibling side (D) is completely unaffected.
+	uint32_t d = idx(out, "D");
+	REQUIRE(out.parent(d) == out.root());
+	REQUIRE(out.branch_length(d) == Catch::Approx(5.0));
+}
+
+// ============================================================================
+// Determinism and scale
+// ============================================================================
+
+TEST_CASE("resolve is deterministic across runs", "[NewickTree][resolve]") {
+	auto tree = miint::NewickTree::parse("(A:1,B:2,C:3,D:4,E:5)root;");
+	auto first = tree.resolve_multifurcations().to_newick();
+	auto second = tree.resolve_multifurcations().to_newick();
+	REQUIRE(first == second);
+}
+
+TEST_CASE("resolve a large star tree fully bifurcates it", "[NewickTree][resolve]") {
+	const int T = 1000;
+	std::vector<miint::NodeInput> in;
+	in.push_back({0, std::nullopt, "root", std::numeric_limits<double>::quiet_NaN(), std::nullopt});
+	for (int i = 1; i <= T; ++i) {
+		in.push_back({static_cast<int64_t>(i), std::optional<int64_t>(0), "t" + std::to_string(i), 1.0, std::nullopt});
+	}
+	auto tree = miint::NewickTree::build(in);
+
+	auto out = tree.resolve_multifurcations();
+
+	REQUIRE(out.num_tips() == static_cast<size_t>(T));
+	// tips + root + (T-2) connectors.
+	REQUIRE(out.num_nodes() == static_cast<size_t>(T + 1 + (T - 2)));
+	require_no_multifurcations(out);
+}

--- a/test/sql/phylo_independent_contrasts.test
+++ b/test/sql/phylo_independent_contrasts.test
@@ -243,6 +243,24 @@ SELECT * FROM phylo_independent_contrasts('poly', 'ptraits');
 ----
 tree_resolve_multifurcations
 
+# The offending node is unnamed and has a non-contiguous node_index (77). The
+# error must report the caller's node_index (77), not the internal dense index.
+statement ok
+CREATE TABLE unnamed_poly AS SELECT * FROM (VALUES
+    (10, 'A',  1.0, CAST(NULL AS BIGINT), 77),
+    (20, 'B',  1.0, NULL, 77),
+    (30, 'C',  1.0, NULL, 77),
+    (77, CAST(NULL AS VARCHAR), NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement ok
+CREATE TABLE unnamed_poly_traits AS SELECT * FROM (VALUES ('A', 'w', 1.0), ('B', 'w', 5.0), ('C', 'w', 2.0)) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('unnamed_poly', 'unnamed_poly_traits');
+----
+node 77
+
 # =============================================================================
 # Error: trait/tip mismatches
 # =============================================================================

--- a/test/sql/phylo_independent_contrasts.test
+++ b/test/sql/phylo_independent_contrasts.test
@@ -1,0 +1,435 @@
+# name: test/sql/phylo_independent_contrasts.test
+# description: Test phylo_independent_contrasts (Felsenstein 1985 PIC)
+# group: [sql]
+
+require miint
+
+# =============================================================================
+# Golden tree: ((A:1,B:3)E:2,C:4)root;  (internal nodes E=2, root=4)
+# Two traits, long form. Expected values are hand-derived (see
+# test/cpp/test_IndependentContrasts.cpp).
+#
+# Child order follows node_index, so E (2) precedes C (3) as children of root and
+# A (0) precedes B (1) as children of E — matching the Newick left-to-right order
+# used by the C++ golden, so the contrast signs are identical.
+# =============================================================================
+
+statement ok
+CREATE TABLE gtree AS SELECT * FROM (VALUES
+    (0, 'A',    1.0, CAST(NULL AS BIGINT), 2),
+    (1, 'B',    3.0, NULL, 2),
+    (2, 'E',    2.0, NULL, 4),
+    (3, 'C',    4.0, NULL, 4),
+    (4, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement ok
+CREATE TABLE gtraits AS SELECT * FROM (VALUES
+    ('A', 'X', 2.0), ('B', 'X', 6.0), ('C', 'X', 1.0),
+    ('A', 'Y', 5.0), ('B', 'Y', 1.0), ('C', 'Y', 0.0)
+) AS v(name, trait, value);
+
+# 2 internal nodes x 2 traits = 4 rows.
+query I
+SELECT count(*) FROM phylo_independent_contrasts('gtree', 'gtraits');
+----
+4
+
+# Every output row matches an expected (node_index, trait) key (nothing spurious,
+# nothing missing) ...
+query I
+WITH expected(node_index, trait) AS (
+    VALUES (2, 'X'), (4, 'X'), (2, 'Y'), (4, 'Y')
+)
+SELECT count(*)
+FROM phylo_independent_contrasts('gtree', 'gtraits') p
+JOIN expected e ON p.node_index = e.node_index AND p.trait = e.trait;
+----
+4
+
+# ... and every value matches the hand-derived golden within tolerance.
+query I
+WITH expected(node_index, trait, contrast, ancestral, variance) AS (
+    VALUES
+        (2, 'X', -2.0,         3.0,         4.0),
+        (4, 'X',  0.769800359, 2.185185185, 6.75),
+        (2, 'Y',  2.0,         4.0,         4.0),
+        (4, 'Y',  1.539600718, 2.370370370, 6.75)
+)
+SELECT count(*)
+FROM phylo_independent_contrasts('gtree', 'gtraits') p
+JOIN expected e ON p.node_index = e.node_index AND p.trait = e.trait
+WHERE abs(p.contrast - e.contrast) > 1e-6
+   OR abs(p.ancestral_estimate - e.ancestral) > 1e-6
+   OR abs(p.contrast_variance - e.variance) > 1e-9;
+----
+0
+
+# =============================================================================
+# node_index remap: output carries the caller's ORIGINAL node_index, not the
+# internal dense index — even with non-contiguous node_index and rows that are
+# not in ascending node_index order.
+# =============================================================================
+
+# Same tree as gtree, renumbered node_index = {A:10, B:30, E:20, C:40, root:5},
+# rows deliberately out of ascending order. Internal nodes are E (20), root (5);
+# their dense build indices would be 2 and 0.
+statement ok
+CREATE TABLE reindexed AS SELECT * FROM (VALUES
+    (10, 'A',    1.0, CAST(NULL AS BIGINT), 20),
+    (30, 'B',    3.0, NULL, 20),
+    (20, 'E',    2.0, NULL, 5),
+    (40, 'C',    4.0, NULL, 5),
+    (5,  'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+# All 4 output rows carry the internal nodes' ORIGINAL labels (5, 20), never the
+# dense positions (0, 2) — this is what the ReadTreeTable ORDER BY + remap buys.
+query II
+SELECT count(*), count(*) FILTER (WHERE node_index NOT IN (5, 20))
+FROM phylo_independent_contrasts('reindexed', 'gtraits');
+----
+4	0
+
+# The distinctive E contrast (X = -2.0) is reported against E's label (20).
+query I
+SELECT node_index FROM phylo_independent_contrasts('reindexed', 'gtraits')
+WHERE trait = 'X' AND abs(contrast - (-2.0)) < 1e-9;
+----
+20
+
+# =============================================================================
+# Type-flexible tip keys: BIGINT and UUID names match tip labels by canonical
+# text (same posture as read_id). Matching failure would surface as a "no trait
+# value for tip" error, so count = n-1 = 2 proves the join worked.
+# =============================================================================
+
+statement ok
+CREATE TABLE btree AS SELECT * FROM (VALUES
+    (0, CAST(100 AS BIGINT), 1.0, CAST(NULL AS BIGINT), 3),
+    (1, 200, 1.0, NULL, 3),
+    (2, 300, 1.0, NULL, 4),
+    (3, 900, 1.0, NULL, 4),
+    (4, CAST(NULL AS BIGINT), NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement ok
+CREATE TABLE btraits AS SELECT * FROM (VALUES
+    (CAST(100 AS BIGINT), 'w', 1.0), (200, 'w', 2.0), (300, 'w', 3.0)
+) AS v(name, trait, value);
+
+query I
+SELECT count(*) FROM phylo_independent_contrasts('btree', 'btraits');
+----
+2
+
+statement ok
+CREATE TABLE utree AS SELECT * FROM (VALUES
+    (0, CAST('11111111-1111-1111-1111-111111111111' AS UUID), 1.0, CAST(NULL AS BIGINT), 3),
+    (1, CAST('22222222-2222-2222-2222-222222222222' AS UUID), 1.0, NULL, 3),
+    (2, CAST('33333333-3333-3333-3333-333333333333' AS UUID), 1.0, NULL, 4),
+    (3, CAST(NULL AS UUID), 1.0, NULL, 4),
+    (4, CAST(NULL AS UUID), NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement ok
+CREATE TABLE utraits AS SELECT * FROM (VALUES
+    (CAST('11111111-1111-1111-1111-111111111111' AS UUID), 'w', 1.0),
+    (CAST('22222222-2222-2222-2222-222222222222' AS UUID), 'w', 2.0),
+    (CAST('33333333-3333-3333-3333-333333333333' AS UUID), 'w', 3.0)
+) AS v(name, trait, value);
+
+query I
+SELECT count(*) FROM phylo_independent_contrasts('utree', 'utraits');
+----
+2
+
+# =============================================================================
+# Round-trip: a polytomy resolved by tree_resolve_multifurcations feeds PIC.
+# The resolver inserts a zero-length internal connector; PIC must accept it.
+# =============================================================================
+
+statement ok
+CREATE TABLE poly AS SELECT * FROM (VALUES
+    (0, 'A',    1.0, CAST(NULL AS BIGINT), 3),
+    (1, 'B',    2.0, NULL, 3),
+    (2, 'C',    3.0, NULL, 3),
+    (3, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement ok
+CREATE TABLE ptraits AS SELECT * FROM (VALUES ('A', 'w', 1.0), ('B', 'w', 5.0), ('C', 'w', 2.0)) AS v(name, trait, value);
+
+statement ok
+CREATE TABLE poly_resolved AS SELECT * FROM tree_resolve_multifurcations('poly');
+
+query I
+SELECT count(*) FROM phylo_independent_contrasts('poly_resolved', 'ptraits');
+----
+2
+
+# =============================================================================
+# Scaling: a large balanced tree and a deep caterpillar both yield n-1 finite
+# contrasts and stay fast (guards against O(n^2) / stack-overflow regressions).
+# =============================================================================
+
+# Balanced complete binary tree, 2^14 = 16384 tips (32767 nodes), heap layout:
+# node i has parent (i-1)//2, so every internal node has exactly two children.
+statement ok
+CREATE TABLE big_tree AS
+  SELECT i AS node_index, 't' || i AS name,
+         CASE WHEN i = 0 THEN NULL ELSE 1.0 END AS branch_length,
+         NULL::BIGINT AS edge_id,
+         CASE WHEN i = 0 THEN NULL ELSE (i - 1) // 2 END AS parent_index
+  FROM range(32767) t(i);
+
+statement ok
+CREATE TABLE big_traits AS
+  SELECT 't' || i AS name, 'w' AS trait, (i % 997)::DOUBLE AS value
+  FROM range(32767) t(i) WHERE 2 * i + 1 >= 32767;
+
+# 16383 internal nodes -> 16383 contrasts, all finite.
+query II
+SELECT count(*), count(*) FILTER (WHERE NOT isfinite(contrast))
+FROM phylo_independent_contrasts('big_tree', 'big_traits');
+----
+16383	0
+
+# Deep caterpillar: a 10000-way star -> resolve -> PIC. Exercises the iterative
+# post-order at depth (no stack overflow) and PIC over zero-length connectors.
+statement ok
+CREATE TABLE big_star AS
+  SELECT i AS node_index, CASE WHEN i = 0 THEN 'root' ELSE 't' || i END AS name,
+         CASE WHEN i = 0 THEN NULL ELSE 1.0 END AS branch_length,
+         NULL::BIGINT AS edge_id,
+         CASE WHEN i = 0 THEN NULL ELSE 0 END AS parent_index
+  FROM range(10001) t(i);
+
+statement ok
+CREATE TABLE big_cat AS SELECT * FROM tree_resolve_multifurcations('big_star');
+
+statement ok
+CREATE TABLE big_cat_traits AS
+  SELECT 't' || i AS name, 'w' AS trait, (i % 997)::DOUBLE AS value FROM range(1, 10001) t(i);
+
+# 10000 tips -> 9999 contrasts, all finite (zero-length connectors accepted).
+query II
+SELECT count(*), count(*) FILTER (WHERE NOT isfinite(contrast))
+FROM phylo_independent_contrasts('big_cat', 'big_cat_traits');
+----
+9999	0
+
+# =============================================================================
+# Views work for both inputs
+# =============================================================================
+
+statement ok
+CREATE VIEW gtree_v AS SELECT * FROM gtree;
+
+statement ok
+CREATE VIEW gtraits_v AS SELECT * FROM gtraits;
+
+query I
+SELECT count(*) FROM phylo_independent_contrasts('gtree_v', 'gtraits_v');
+----
+4
+
+# =============================================================================
+# Error: non-bifurcating tree names the resolver as the remedy
+# =============================================================================
+
+statement error
+SELECT * FROM phylo_independent_contrasts('poly', 'ptraits');
+----
+tree_resolve_multifurcations
+
+# =============================================================================
+# Error: trait/tip mismatches
+# =============================================================================
+
+# A tip with no trait value.
+statement ok
+CREATE TABLE gtraits_missing AS SELECT * FROM (VALUES ('A', 'X', 2.0), ('B', 'X', 6.0)) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_missing');
+----
+C
+
+# A trait value for a name that is not a tip.
+statement ok
+CREATE TABLE gtraits_extra AS SELECT * FROM (VALUES
+    ('A', 'X', 2.0), ('B', 'X', 6.0), ('C', 'X', 1.0), ('Z', 'X', 9.0)
+) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_extra');
+----
+not a tip
+
+# A NULL trait value.
+statement ok
+CREATE TABLE gtraits_null AS SELECT * FROM (VALUES
+    ('A', 'X', 2.0), ('B', 'X', 6.0), ('C', 'X', CAST(NULL AS DOUBLE))
+) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_null');
+----
+NULL value
+
+# A NULL name.
+statement ok
+CREATE TABLE gtraits_nullname AS SELECT * FROM (VALUES
+    (CAST(NULL AS VARCHAR), 'X', 2.0), ('B', 'X', 6.0), ('C', 'X', 1.0)
+) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_nullname');
+----
+NULL name
+
+# A NULL trait label.
+statement ok
+CREATE TABLE gtraits_nulltrait AS SELECT * FROM (VALUES
+    ('A', CAST(NULL AS VARCHAR), 2.0), ('B', 'X', 6.0), ('C', 'X', 1.0)
+) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_nulltrait');
+----
+NULL trait
+
+# An empty traits table.
+statement ok
+CREATE TABLE gtraits_empty AS SELECT * FROM gtraits WHERE false;
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_empty');
+----
+empty
+
+# Multi-trait attribution: three traits, only the LAST (sorted) one is incomplete.
+# The error must name that trait ('zzz_last'), not the first — this pins the
+# cold-path retry loop that re-runs per trait to attribute the failure.
+statement ok
+CREATE TABLE gtraits_lastbad AS SELECT * FROM (VALUES
+    ('A', 'aaa', 1.0), ('B', 'aaa', 2.0), ('C', 'aaa', 3.0),
+    ('A', 'bbb', 1.0), ('B', 'bbb', 2.0), ('C', 'bbb', 3.0),
+    ('A', 'zzz_last', 1.0), ('B', 'zzz_last', 2.0)  -- C missing for zzz_last only
+) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_lastbad');
+----
+zzz_last
+
+# A duplicate (name, trait) pair.
+statement ok
+CREATE TABLE gtraits_dup AS SELECT * FROM (VALUES
+    ('A', 'X', 2.0), ('A', 'X', 3.0), ('B', 'X', 6.0), ('C', 'X', 1.0)
+) AS v(name, trait, value);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'gtraits_dup');
+----
+Duplicate
+
+# =============================================================================
+# Error: branch-length problems
+# =============================================================================
+
+# Negative branch length.
+statement ok
+CREATE TABLE negtree AS SELECT * FROM (VALUES
+    (0, 'A', -1.0, CAST(NULL AS BIGINT), 3),
+    (1, 'B',  3.0, NULL, 3),
+    (2, 'C',  4.0, NULL, 4),
+    (3, 'E',  2.0, NULL, 4),
+    (4, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('negtree', 'gtraits');
+----
+negative
+
+# No branch lengths at all (cladogram): reader substitutes NULL -> NaN.
+statement ok
+CREATE TABLE clad AS SELECT node_index, name, parent_index FROM gtree;
+
+statement error
+SELECT * FROM phylo_independent_contrasts('clad', 'gtraits');
+----
+branch length
+
+# Infinite branch length ('infinity'::DOUBLE): non-finite, must be rejected
+# (without the isfinite check it silently emits contrast=0 / NaN).
+statement ok
+CREATE TABLE inftree AS SELECT * FROM (VALUES
+    (0, 'A', CAST('infinity' AS DOUBLE), CAST(NULL AS BIGINT), 2),
+    (1, 'B', 3.0, NULL, 2),
+    (2, 'E', 2.0, NULL, 4),
+    (3, 'C', 4.0, NULL, 4),
+    (4, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('inftree', 'gtraits');
+----
+finite
+
+# Two zero-length children -> contrast variance is zero.
+statement ok
+CREATE TABLE ztree AS SELECT * FROM (VALUES
+    (0, 'A', 0.0, CAST(NULL AS BIGINT), 3),
+    (1, 'B', 0.0, NULL, 3),
+    (2, 'C', 4.0, NULL, 4),
+    (3, 'E', 2.0, NULL, 4),
+    (4, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement error
+SELECT * FROM phylo_independent_contrasts('ztree', 'gtraits');
+----
+zero
+
+# =============================================================================
+# Error: bad relations / columns
+# =============================================================================
+
+statement error
+SELECT * FROM phylo_independent_contrasts('no_tree', 'gtraits');
+----
+does not exist
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'no_traits');
+----
+does not exist
+
+statement ok
+CREATE TABLE bad_tree AS SELECT 1 AS x;
+
+statement error
+SELECT * FROM phylo_independent_contrasts('bad_tree', 'gtraits');
+----
+node_index
+
+statement ok
+CREATE TABLE bad_traits AS SELECT 1 AS x;
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'bad_traits');
+----
+name
+
+# Traits table with name+trait but no value column (exercises the 'value' branch
+# of the schema check specifically).
+statement ok
+CREATE TABLE traits_noval AS SELECT name, trait FROM gtraits;
+
+statement error
+SELECT * FROM phylo_independent_contrasts('gtree', 'traits_noval');
+----
+value

--- a/test/sql/tree_resolve_multifurcations.test
+++ b/test/sql/tree_resolve_multifurcations.test
@@ -1,0 +1,245 @@
+# name: test/sql/tree_resolve_multifurcations.test
+# description: Test tree_resolve_multifurcations (resolve polytomies into bifurcations)
+# group: [sql]
+
+require miint
+
+# =============================================================================
+# Trifurcating root: (A:1,B:2,C:3)root;  ->  root:[A, N], N:[B, C]
+# =============================================================================
+
+statement ok
+CREATE TABLE tri3 AS SELECT * FROM (VALUES
+    (0, 'A',    1.0, CAST(NULL AS BIGINT), 3),
+    (1, 'B',    2.0, NULL, 3),
+    (2, 'C',    3.0, NULL, 3),
+    (3, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+statement ok
+CREATE TABLE r3 AS SELECT * FROM tree_resolve_multifurcations('tri3');
+
+# 5 nodes total (root, A, B, C, + 1 connector), 3 tips.
+query II
+SELECT count(*), count(*) FILTER (WHERE is_tip) FROM r3;
+----
+5	3
+
+# No node has more than two children after resolution.
+query I
+SELECT coalesce(max(cnt), 0) FROM (
+    SELECT parent_index, count(*) AS cnt FROM r3 WHERE parent_index IS NOT NULL GROUP BY parent_index
+);
+----
+2
+
+# Exactly one root.
+query I
+SELECT count(*) FROM r3 WHERE parent_index IS NULL;
+----
+1
+
+# Original tip branch lengths are preserved.
+query TR
+SELECT name, branch_length FROM r3 WHERE name IN ('A', 'B', 'C') ORDER BY name;
+----
+A	1.0
+B	2.0
+C	3.0
+
+# Exactly one connector: unnamed, internal, zero branch length.
+query IR
+SELECT count(*), coalesce(max(branch_length), -1) FROM r3 WHERE name = '' AND is_tip = false;
+----
+1	0.0
+
+# Left-comb wiring: A stays on the root; B and C share the connector, whose
+# parent is the root.
+query T
+SELECT p.name FROM r3 s JOIN r3 p ON s.parent_index = p.node_index WHERE s.name = 'A';
+----
+root
+
+query I
+SELECT count(DISTINCT parent_index) FROM r3 WHERE name IN ('B', 'C');
+----
+1
+
+query T
+SELECT DISTINCT p.name FROM r3 s JOIN r3 p ON s.parent_index = p.node_index WHERE s.name IN ('B', 'C');
+----
+(empty)
+
+query T
+SELECT gp.name
+FROM r3 s
+JOIN r3 p ON s.parent_index = p.node_index
+JOIN r3 gp ON p.parent_index = gp.node_index
+WHERE s.name = 'B';
+----
+root
+
+# =============================================================================
+# Determinism: resolution follows node_index, not scan order
+# =============================================================================
+
+# Materialize tri3 in reverse node_index order. With preserve_insertion_order on
+# (default), an unordered scan of this table returns rows DESC — so if the reader
+# did not ORDER BY node_index, build() would see C first and the comb would put C
+# (not A) directly on the root. The reader sorts by node_index, so the result is
+# identical to the ascending input.
+statement ok
+CREATE TABLE tri3_desc AS SELECT * FROM tri3 ORDER BY node_index DESC;
+
+statement ok
+CREATE TABLE r3_desc AS SELECT * FROM tree_resolve_multifurcations('tri3_desc');
+
+# A still sits directly on the root (c0), exactly as for tri3.
+query T
+SELECT p.name FROM r3_desc s JOIN r3_desc p ON s.parent_index = p.node_index WHERE s.name = 'A';
+----
+root
+
+# B and C still share the connector (empty name), not the root.
+query T
+SELECT DISTINCT p.name FROM r3_desc s JOIN r3_desc p ON s.parent_index = p.node_index WHERE s.name IN ('B', 'C');
+----
+(empty)
+
+# =============================================================================
+# Already bifurcating: (((A:1,B:2)G:3,C:4)H:5,(D:6,E:7)I:8)root; -> unchanged
+# =============================================================================
+
+statement ok
+CREATE TABLE t AS SELECT * FROM (VALUES
+    (0, 'A',    1.0, CAST(NULL AS BIGINT), 2),
+    (1, 'B',    2.0, NULL, 2),
+    (2, 'G',    3.0, NULL, 4),
+    (3, 'C',    4.0, NULL, 4),
+    (4, 'H',    5.0, NULL, 8),
+    (5, 'D',    6.0, NULL, 7),
+    (6, 'E',    7.0, NULL, 7),
+    (7, 'I',    8.0, NULL, 8),
+    (8, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+# Same node/tip counts, no connectors added (no empty-named nodes).
+query III
+SELECT count(*), count(*) FILTER (WHERE is_tip), count(*) FILTER (WHERE name = '')
+FROM tree_resolve_multifurcations('t');
+----
+9	5	0
+
+# =============================================================================
+# Unifurcation is NOT collapsed (resolve handles polytomies only)
+# =============================================================================
+
+statement ok
+CREATE TABLE uni AS SELECT * FROM (VALUES
+    (0, 'A',    1.0, CAST(NULL AS BIGINT), 2),
+    (1, 'B',    2.0, NULL, 2),
+    (2, 'X',    3.0, NULL, 3),
+    (3, 'root', NULL, NULL, NULL)
+) AS v(node_index, name, branch_length, edge_id, parent_index);
+
+# root keeps its single child X untouched.
+query I
+SELECT count(*) FROM tree_resolve_multifurcations('uni') s
+WHERE s.parent_index = (SELECT node_index FROM tree_resolve_multifurcations('uni') WHERE parent_index IS NULL);
+----
+1
+
+# =============================================================================
+# Large star tree: root with 1000 tip children
+# =============================================================================
+
+statement ok
+CREATE TABLE star AS
+SELECT i AS node_index,
+       CASE WHEN i = 0 THEN 'root' ELSE 't' || i END AS name,
+       CASE WHEN i = 0 THEN NULL ELSE 1.0 END AS branch_length,
+       NULL::BIGINT AS edge_id,
+       CASE WHEN i = 0 THEN NULL ELSE 0 END AS parent_index
+FROM range(1001) t(i);
+
+# 1000 tips + root + (1000-2) connectors = 1999 nodes; exactly one root; no node
+# has more than two children.
+query III
+SELECT count(*),
+       count(*) FILTER (WHERE is_tip),
+       count(*) FILTER (WHERE parent_index IS NULL)
+FROM tree_resolve_multifurcations('star');
+----
+1999	1000	1
+
+query I
+SELECT coalesce(max(cnt), 0) FROM (
+    SELECT parent_index, count(*) AS cnt
+    FROM tree_resolve_multifurcations('star')
+    WHERE parent_index IS NOT NULL GROUP BY parent_index
+);
+----
+2
+
+# =============================================================================
+# Idempotence + round-trip into another tree-consuming function
+# =============================================================================
+
+# r3 is already bifurcating, so resolving it again is a no-op (still 5 nodes).
+# This also proves the output carries the read_newick schema and feeds back in.
+query I
+SELECT count(*) FROM tree_resolve_multifurcations('r3');
+----
+5
+
+# =============================================================================
+# read_newick schema compatibility + COPY NEWICK round-trip
+# =============================================================================
+
+statement ok
+COPY (
+    SELECT node_index, name, branch_length, edge_id, parent_index
+    FROM tree_resolve_multifurcations('tri3')
+) TO '__TEST_DIR__/resolved.nwk' (FORMAT NEWICK);
+
+query I
+SELECT count(*) FROM read_newick('__TEST_DIR__/resolved.nwk');
+----
+5
+
+statement ok
+SELECT node_index, name, branch_length, edge_id, parent_index, is_tip
+FROM read_newick('__TEST_DIR__/resolved.nwk')
+UNION ALL
+SELECT * FROM tree_resolve_multifurcations('tri3');
+
+# =============================================================================
+# Views work
+# =============================================================================
+
+statement ok
+CREATE VIEW tri3_v AS SELECT * FROM tri3;
+
+query I
+SELECT count(*) FROM tree_resolve_multifurcations('tri3_v');
+----
+5
+
+# =============================================================================
+# Error cases
+# =============================================================================
+
+# Nonexistent tree table
+statement error
+SELECT * FROM tree_resolve_multifurcations('no_tree');
+----
+does not exist
+
+# Tree table missing required node_index/parent_index columns
+statement ok
+CREATE TABLE bad_tree AS SELECT 1 AS x;
+
+statement error
+SELECT * FROM tree_resolve_multifurcations('bad_tree');
+----
+node_index


### PR DESCRIPTION
Closes #159.

Adds **phylogenetic independent contrasts** (Felsenstein 1985) over a tree and one or more numeric per-tip traits, plus a companion **`tree_resolve_multifurcations`** that turns polytomies into a strictly bifurcating tree (PIC's precondition).

## Functions

### `phylo_independent_contrasts(tree, traits)`
Felsenstein (1985) PIC. `traits` is long-form `(name, trait, value)`; `name` is type-flexible (VARCHAR/UUID/BIGINT, matched to tip labels by canonical text). One row per (internal node, trait):

| column | type | |
|---|---|---|
| `node_index` | BIGINT | the input tree's node_index |
| `trait` | VARCHAR | trait name |
| `contrast` | DOUBLE | standardized contrast `(X_i − X_j)/√(v_i+v_j)` |
| `ancestral_estimate` | DOUBLE | inverse-variance-weighted node value |
| `contrast_variance` | DOUBLE | `v_i + v_j` |

Requires a strictly bifurcating tree with finite, non-negative branch lengths; every trait must cover exactly the tip set. The two-trait correlation/regression-through-origin stays layered in SQL over the per-node output (see docs).

### `tree_resolve_multifurcations(tree)`
Resolves each node with >2 children into a deterministic left-comb with zero-length connectors (root-to-tip distances preserved). Polytomies only — unifurcations remain `shear_tree`'s job. Output is the `read_newick` schema, so it round-trips into `phylo_independent_contrasts`.

## Notable decisions
- **Reject-then-resolve, not silent-resolve.** PIC errors on a polytomy and points to `tree_resolve_multifurcations`; on a unifurcation it points to `shear_tree`. This keeps the (statistically arbitrary) resolution an explicit, inspectable step rather than a hidden one. The arbitrariness/df caveat is documented.
- **Tip↔trait matching is canonical-text on both sides**, so numeric/UUID keys work (same posture as `read_id` in #145).
- **Shared `ReadTreeTable` now `ORDER BY node_index`** so child order — and thus resolution and contrast sign — is reproducible regardless of relation storage (views/joins/Parquet/parallel scans). Measured overhead ~0.2% on a 2M-node tree.
- **Cleanroom.** Implemented from Felsenstein (1985); goldens are hand-derived, not taken from any GPL comparative-methods package.

## Performance
Near-linear: 2M-node tree PIC ~1.3 s; deep 100k caterpillar is stack-safe (iterative traversal). Many-traits path precomputes the trait-independent variances once (batch overload).

## Testing (TDD, red→green→refactor)
- C++ Catch2 over the `NewickTree` core: hand-derived Felsenstein golden, weighting-direction/sign determinism, zero-length-internal-edge acceptance, and every error path; scaling cases.
- SQL surface tests for both functions: schema, BIGINT/UUID type-flex, resolve→PIC round-trip, node-index remap, determinism regression, and all error paths.
- Full suite green: SQL 198 cases / 10483 assertions; C++ 1234 cases / 14355 assertions; `make format-check` clean.

Base branch: `v1.5-variegata`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
