### PR TITLE
fix(bowtie2): default index build/align nthreads to DuckDB thread budget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1677,6 +1677,7 @@ set(TEST_SOURCES
     src/Minimap2Aligner.cpp
     test/cpp/test_Minimap2Aligner.cpp
     test/cpp/test_AlignBowtie2Sharded.cpp
+    test/cpp/test_Bowtie2Nthreads.cpp
     test/cpp/test_ShardProgress.cpp
     src/ncbi_parser.cpp
     src/zip_utils.cpp

--- a/src/align_bowtie2.cpp
+++ b/src/align_bowtie2.cpp
@@ -12,6 +12,7 @@
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/materialized_query_result.hpp"
 #include "duckdb/main/query_result.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 #include "duckdb/parser/keyword_helper.hpp"
 
 #include "gpl_boundary/arrow_ipc.hpp"
@@ -60,8 +61,11 @@ std::unordered_set<std::string> MakeKnownAlignParams() {
 // Build the bowtie2-align config_json. Common bowtie2 knobs flow through
 // `bt2_daemon::AppendBowtie2AlignParams`; the non-sharded path additionally
 // handles `threads` (its own knob, since the sharded variant warns about it
-// instead).
-std::string BuildAlignConfigJson(const named_parameter_map_t &named_params, const std::string &index_basename) {
+// instead) — an explicit value wins, else nthreads defaults to `db_threads`
+// (DuckDB's configured thread budget) so alignment uses the query's cores by
+// default rather than one.
+std::string BuildAlignConfigJson(const named_parameter_map_t &named_params, const std::string &index_basename,
+                                 int64_t db_threads) {
 	static const auto kKnown = MakeKnownAlignParams();
 	for (const auto &kv : named_params) {
 		if (kKnown.find(kv.first) == kKnown.end()) {
@@ -71,15 +75,7 @@ std::string BuildAlignConfigJson(const named_parameter_map_t &named_params, cons
 
 	bt2_daemon::ConfigJsonBuilder cfg;
 	cfg.append_str("index_path", index_basename);
-
-	auto threads_it = named_params.find("threads");
-	if (threads_it != named_params.end() && !threads_it->second.IsNull()) {
-		const int64_t n = bt2_daemon::ValueAsInt("align_bowtie2", "threads", threads_it->second);
-		if (n < 1) {
-			throw InvalidInputException("align_bowtie2: threads must be >= 1 (got %lld)", static_cast<long long>(n));
-		}
-		cfg.append_int("nthreads", n);
-	}
+	cfg.append_int("nthreads", bt2_daemon::ResolveNthreadsFromParams(named_params, db_threads, "align_bowtie2"));
 
 	bt2_daemon::AppendBowtie2AlignParams(cfg, named_params, "align_bowtie2");
 	return cfg.build();
@@ -327,19 +323,12 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 	gs->temp_dir = MakeTempIndexDir();
 	const std::string index_basename = gs->temp_dir + "/idx";
 
-	// nthreads for build comes from the user's `threads` param (same
-	// rationale as the old direct-subprocess path: one knob covers both).
-	int64_t threads = 1;
-	{
-		auto it = bd.named_params.find("threads");
-		if (it != bd.named_params.end() && !it->second.IsNull()) {
-			threads = bt2_daemon::ValueAsInt("align_bowtie2", "threads", it->second);
-			if (threads < 1) {
-				throw InvalidInputException("align_bowtie2: threads must be >= 1 (got %lld)",
-				                            static_cast<long long>(threads));
-			}
-		}
-	}
+	// nthreads for build (and align, below) defaults to DuckDB's configured thread
+	// budget — one knob covers both, and omitting `threads` should use the query's
+	// cores rather than silently building single-threaded. An explicit `threads`
+	// overrides. Resolved once here and reused for the align config.
+	const int64_t db_threads = static_cast<int64_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	const int64_t threads = bt2_daemon::ResolveNthreadsFromParams(bd.named_params, db_threads, "align_bowtie2");
 	const std::string build_config = bt2_daemon::BuildBowtie2BuildConfigJson(index_basename, threads);
 	auto build_result = gs->session->Submit("bowtie2-build", build_config, subjects_ipc.data(), subjects_ipc.size());
 	gs->index_files = bt2_daemon::ParseBowtie2BuildIndexFiles(build_result.result_json, "align_bowtie2");
@@ -349,7 +338,7 @@ unique_ptr<GlobalTableFunctionState> InitGlobal(ClientContext &context, TableFun
 
 	// 4. Now that we have the index basename, finish building the align
 	//    config JSON.
-	gs->config_json_align = BuildAlignConfigJson(bd.named_params, index_basename);
+	gs->config_json_align = BuildAlignConfigJson(bd.named_params, index_basename, db_threads);
 
 	// 5. Open a streaming cursor on the query table. SendQuery returns a
 	//    StreamQueryResult that fetches chunks lazily.

--- a/src/align_bowtie2.cpp
+++ b/src/align_bowtie2.cpp
@@ -75,7 +75,12 @@ std::string BuildAlignConfigJson(const named_parameter_map_t &named_params, cons
 
 	bt2_daemon::ConfigJsonBuilder cfg;
 	cfg.append_str("index_path", index_basename);
-	cfg.append_int("nthreads", bt2_daemon::ResolveNthreadsFromParams(named_params, db_threads, "align_bowtie2"));
+	// Emit nthreads only when > 1, matching BuildBowtie2BuildConfigJson: a resolved
+	// value of 1 is bowtie2's own -p default, so sending it is redundant.
+	const int64_t nthreads = bt2_daemon::ResolveNthreadsFromParams(named_params, db_threads, "align_bowtie2");
+	if (nthreads > 1) {
+		cfg.append_int("nthreads", nthreads);
+	}
 
 	bt2_daemon::AppendBowtie2AlignParams(cfg, named_params, "align_bowtie2");
 	return cfg.build();

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -965,6 +965,20 @@ std::string BuildBowtie2BuildConfigJson(const std::string &index_basename, int64
 	return cfg.build();
 }
 
+int64_t ResolveNthreadsFromParams(const named_parameter_map_t &named_params, int64_t db_threads, const char *caller) {
+	auto it = named_params.find("threads");
+	const bool supplied = it != named_params.end() && !it->second.IsNull();
+	int64_t user_threads = 1;
+	if (supplied) {
+		user_threads = ValueAsInt(caller, "threads", it->second);
+		if (user_threads < 1) {
+			throw InvalidInputException("%s: threads must be >= 1 (got %lld)", caller,
+			                            static_cast<long long>(user_threads));
+		}
+	}
+	return ResolveBowtie2Nthreads(supplied, user_threads, db_threads);
+}
+
 std::vector<std::string> ParseBowtie2BuildIndexFiles(const std::string &result_json, const char *caller) {
 	using YyjsonDocPtr = std::unique_ptr<yj::yyjson_doc, decltype(&yj::yyjson_doc_free)>;
 	YyjsonDocPtr doc(yj::yyjson_read(result_json.data(), result_json.size(), 0), &yj::yyjson_doc_free);

--- a/src/include/align_bowtie2_daemon_common.hpp
+++ b/src/include/align_bowtie2_daemon_common.hpp
@@ -229,6 +229,32 @@ std::vector<uint8_t> BuildSubjectsIpc(const LoadedSubjects &subjects, const char
 // nthreads is omitted when <= 1 (daemon default).
 std::string BuildBowtie2BuildConfigJson(const std::string &index_basename, int64_t nthreads);
 
+// The effective bowtie2 nthreads for a NON-sharded build/align, given whether the
+// user explicitly supplied the `threads` knob and DuckDB's configured thread
+// budget. An explicit value wins; its ABSENCE falls back to `db_threads` so a
+// build/align uses the query's whole core budget by default instead of silently
+// running on one core — the same convention align_minimap2 follows via
+// TaskScheduler::NumberOfThreads(). `db_threads` is floored at 1 so a degenerate 0
+// can never produce a 0/negative `-p`. (align_bowtie2_sharded has its own thread
+// model — max_threads_per_shard × active shards, see EffectiveShardThreads — and
+// does not use this.) Kept inline + duckdb-free (like EffectiveShardThreads) so
+// the Catch2 binary exercises the decision without linking libduckdb; the Value
+// extraction + `>= 1` validation live in ResolveNthreadsFromParams below.
+inline int64_t ResolveBowtie2Nthreads(bool threads_supplied, int64_t user_threads, int64_t db_threads) {
+	if (threads_supplied) {
+		return user_threads;
+	}
+	return db_threads >= 1 ? db_threads : 1;
+}
+
+// Resolve the effective bowtie2 nthreads from a table function's named-parameter
+// map: read the miint-side `threads` knob (coerced via ValueAsInt, validated
+// `>= 1` — throws InvalidInputException naming `caller`), else fall back to
+// `db_threads` (DuckDB's configured thread count). Shared by save_bowtie2_index
+// and align_bowtie2 so the "explicit wins, else use the query's thread budget"
+// contract lives in one place; delegates the decision to ResolveBowtie2Nthreads.
+int64_t ResolveNthreadsFromParams(const named_parameter_map_t &named_params, int64_t db_threads, const char *caller);
+
 // Parse bowtie2-build's `result.index_files` JSON array into a vector of paths.
 // Throws IOException on malformed JSON or a missing array.
 std::vector<std::string> ParseBowtie2BuildIndexFiles(const std::string &result_json, const char *caller);

--- a/src/include/save_bowtie2_index.hpp
+++ b/src/include/save_bowtie2_index.hpp
@@ -22,7 +22,10 @@ public:
 	struct Data : public TableFunctionData {
 		std::string subject_table;
 		std::string output_path;
-		int64_t threads = 1;
+		// Carried from Bind so InitGlobal can resolve nthreads against the LIVE
+		// DuckDB thread budget (matching align_bowtie2), rather than caching a
+		// count at bind time that a re-executed prepared statement would stale.
+		named_parameter_map_t named_params;
 
 		std::vector<std::string> names;
 		std::vector<LogicalType> types;

--- a/src/save_bowtie2_index.cpp
+++ b/src/save_bowtie2_index.cpp
@@ -4,6 +4,7 @@
 #include "sequence_table_reader.hpp"
 
 #include "duckdb/common/exception.hpp"
+#include "duckdb/parallel/task_scheduler.hpp"
 
 #include "gpl_boundary/process.hpp"
 #include "gpl_boundary/session.hpp"
@@ -64,14 +65,11 @@ unique_ptr<FunctionData> SaveBowtie2IndexTableFunction::Bind(ClientContext &cont
 	// schema isn't otherwise needed here.
 	ValidateSequenceTableSchema(context, data->subject_table, /*allow_bigint=*/true);
 
-	auto threads_param = input.named_parameters.find("threads");
-	if (threads_param != input.named_parameters.end() && !threads_param->second.IsNull()) {
-		data->threads = threads_param->second.GetValue<int64_t>();
-		if (data->threads < 1) {
-			throw InvalidInputException("save_bowtie2_index: threads must be >= 1 (got %lld)",
-			                            static_cast<long long>(data->threads));
-		}
-	}
+	// Carry the named parameters to InitGlobal, where nthreads is resolved against
+	// the live DuckDB thread budget (matching align_bowtie2). Resolving there, not
+	// here, means a prepared statement re-executed after `SET threads=N` tracks the
+	// new count instead of the value captured at prepare time.
+	data->named_params = input.named_parameters;
 
 	for (const auto &name : data->names) {
 		names.emplace_back(name);
@@ -86,6 +84,14 @@ unique_ptr<GlobalTableFunctionState> SaveBowtie2IndexTableFunction::InitGlobal(C
                                                                                TableFunctionInitInput &input) {
 	auto &data = input.bind_data->Cast<Data>();
 	auto gstate = make_uniq<GlobalState>();
+
+	// Resolve nthreads before doing any work (spawn/load/build): an explicit
+	// `threads` wins — validated >= 1, so a bad value still throws before the
+	// daemon starts — else default to DuckDB's configured thread budget so the
+	// index builds in parallel. Read here (not at bind) so a re-executed prepared
+	// statement tracks the current `SET threads`.
+	const int64_t db_threads = static_cast<int64_t>(TaskScheduler::GetScheduler(context).NumberOfThreads());
+	const int64_t nthreads = bt2_daemon::ResolveNthreadsFromParams(data.named_params, db_threads, "save_bowtie2_index");
 
 	// 1. Spawn the daemon + require bowtie2-build (no >= 0.4.2 gate).
 	auto session = SpawnBuildSession();
@@ -107,7 +113,7 @@ unique_ptr<GlobalTableFunctionState> SaveBowtie2IndexTableFunction::InitGlobal(C
 		}
 	}
 
-	const std::string build_config = bt2_daemon::BuildBowtie2BuildConfigJson(data.output_path, data.threads);
+	const std::string build_config = bt2_daemon::BuildBowtie2BuildConfigJson(data.output_path, nthreads);
 	auto build_result = session->Submit("bowtie2-build", build_config, subjects_ipc.data(), subjects_ipc.size());
 	const auto index_files = bt2_daemon::ParseBowtie2BuildIndexFiles(build_result.result_json, "save_bowtie2_index");
 	if (index_files.empty()) {

--- a/test/cpp/test_Bowtie2Nthreads.cpp
+++ b/test/cpp/test_Bowtie2Nthreads.cpp
@@ -1,0 +1,39 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "align_bowtie2_daemon_common.hpp"
+
+using duckdb::bt2_daemon::ResolveBowtie2Nthreads;
+
+// ResolveBowtie2Nthreads decides bowtie2's nthreads (`-p` for bowtie2-align,
+// `--threads` for bowtie2-build) for the NON-sharded save_bowtie2_index /
+// align_bowtie2 paths. The intent — and the regression these cases lock down —
+// is that OMITTING `threads` must fall back to DuckDB's configured thread budget,
+// not silently run on one core. The old code hard-defaulted to 1, so a 4-thread
+// query built its index single-threaded (the qiita build_bowtie2_index report:
+// gpl-boundary pegged at 100% of one core). An explicit value always wins so a
+// user can still pin it. Flip either rule and one REQUIRE fails.
+// (align_bowtie2_sharded has its own thread model — max_threads_per_shard ×
+// active shards, see EffectiveShardThreads — and does not use this.)
+
+TEST_CASE("ResolveBowtie2Nthreads: absent threads → DuckDB thread budget", "[bowtie2_nthreads]") {
+	// The regression guard: no `threads` param on an 8-thread DuckDB must
+	// build/align with 8, not 1 — exactly the case the hard-default-to-1 broke.
+	REQUIRE(ResolveBowtie2Nthreads(/*threads_supplied*/ false, /*user_threads*/ 1, /*db_threads*/ 8) == 8);
+	REQUIRE(ResolveBowtie2Nthreads(false, 1, 4) == 4);
+}
+
+TEST_CASE("ResolveBowtie2Nthreads: explicit threads wins over the DuckDB budget", "[bowtie2_nthreads]") {
+	// A user who pins `threads := N` gets N regardless of the DuckDB thread count,
+	// both below and above the budget.
+	REQUIRE(ResolveBowtie2Nthreads(/*threads_supplied*/ true, /*user_threads*/ 2, /*db_threads*/ 8) == 2);
+	REQUIRE(ResolveBowtie2Nthreads(true, 16, 8) == 16);
+	// Explicit 1 is honored — a deliberate single-threaded build is not overridden
+	// back up to the budget.
+	REQUIRE(ResolveBowtie2Nthreads(true, 1, 8) == 1);
+}
+
+TEST_CASE("ResolveBowtie2Nthreads: degenerate db_threads floors at 1", "[bowtie2_nthreads]") {
+	// TaskScheduler::NumberOfThreads() is >= 1 in practice, but a 0 must never
+	// propagate to a 0/negative `-p`: floor it so the daemon gets a valid count.
+	REQUIRE(ResolveBowtie2Nthreads(false, 1, 0) == 1);
+}


### PR DESCRIPTION
## Problem

`save_bowtie2_index` and `align_bowtie2` hard-defaulted the bowtie2 `nthreads` to **1**, so a build/align with no explicit `threads` ran single-threaded even on a multi-thread DuckDB — gpl-boundary pegged at 100% of one core.

This surprised callers. In particular qiita's `build_bowtie2_index` job allocates 4 DuckDB threads + a 16 GB bowtie2 reserve but never passes `threads`, so it got a single-threaded build against that reservation. qiita was not doing anything wrong — miint's default was the bug.

## Fix

Both non-sharded paths now default `nthreads` to DuckDB's configured thread count (`TaskScheduler::NumberOfThreads()`), the same convention `align_minimap2` already follows. An explicit `threads := N` still overrides.

`align_bowtie2_sharded` already derived from the thread budget (`max_threads_per_shard` × active shards) and is **unchanged**.

### Details
- The decision lives in a pure, unit-tested helper `ResolveBowtie2Nthreads(supplied, user, db_threads)` (inline + duckdb-free, like `EffectiveShardThreads`, so the Catch2 binary exercises it without libduckdb).
- A shared `ResolveNthreadsFromParams` does the `Value` extraction + `>= 1` validation for both callers (DRY — replaces three copies of the extract/validate block).
- `save_bowtie2_index` resolves at **InitGlobal** (not Bind), before any daemon spawn, so a re-executed prepared statement tracks the live `SET threads` — matching `align_bowtie2`. The now-dead `Data::threads` field is removed.

## Testing
- New C++ unit test `test_Bowtie2Nthreads.cpp` locks in the regression: absent `threads` → DuckDB budget, explicit wins, `db_threads` floored at 1.
- Full bowtie2 SQL suite (9 files: `save_bowtie2_index`, `align_bowtie2`{,`_bigint`,`_uuid`}, `align_bowtie2_sharded`{,`_bigint`,`_uuid`}, `simple_bowtie2`, `miint_warnings_bowtie2`) green against gpl-boundary 0.4.2.
- Verified end to end: on an 8-thread DuckDB, `threads := 1` pegs one core (~98%); the new default spreads across ~5.6 cores (~561%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)