### PR TITLE
fix(bowtie2): split subjects into <2GB Arrow batches to build >2GB indexes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1678,6 +1678,7 @@ set(TEST_SOURCES
     test/cpp/test_Minimap2Aligner.cpp
     test/cpp/test_AlignBowtie2Sharded.cpp
     test/cpp/test_Bowtie2Nthreads.cpp
+    test/cpp/test_Bowtie2SubjectsBatching.cpp
     test/cpp/test_ShardProgress.cpp
     src/ncbi_parser.cpp
     src/zip_utils.cpp

--- a/src/align_bowtie2_daemon_common.cpp
+++ b/src/align_bowtie2_daemon_common.cpp
@@ -896,6 +896,7 @@ LoadedSubjects LoadSingleEndSubjects(ClientContext &context, const std::string &
 }
 
 std::vector<uint8_t> BuildSubjectsIpc(const LoadedSubjects &subjects, const char *caller) {
+	// Build the struct<name:utf8, sequence:utf8> schema once; every batch shares it.
 	ArrowSchema schema {};
 	auto rc = ArrowSchemaInitFromType(&schema, NANOARROW_TYPE_STRUCT);
 	if (rc != NANOARROW_OK) {
@@ -911,48 +912,70 @@ std::vector<uint8_t> BuildSubjectsIpc(const LoadedSubjects &subjects, const char
 	ArrowSchemaInitFromType(schema.children[1], NANOARROW_TYPE_STRING);
 	ArrowSchemaSetName(schema.children[1], "sequence");
 
-	ArrowArray array {};
-	ArrowError err {};
-	if (ArrowArrayInitFromSchema(&array, &schema, &err) != NANOARROW_OK) {
-		schema.release(&schema);
-		throw InternalException("%s: ArrowArrayInit failed: %s", caller, err.message);
-	}
-	if (ArrowArrayStartAppending(&array) != NANOARROW_OK) {
-		array.release(&array);
-		schema.release(&schema);
-		throw InternalException("%s: ArrowArrayStartAppending failed", caller);
-	}
-	for (size_t i = 0; i < subjects.names.size(); ++i) {
-		ArrowStringView nv {subjects.names[i].data(), static_cast<int64_t>(subjects.names[i].size())};
-		ArrowStringView sv {subjects.sequences[i].data(), static_cast<int64_t>(subjects.sequences[i].size())};
-		if (ArrowArrayAppendString(array.children[0], nv) != NANOARROW_OK ||
-		    ArrowArrayAppendString(array.children[1], sv) != NANOARROW_OK ||
-		    ArrowArrayFinishElement(&array) != NANOARROW_OK) {
-			array.release(&array);
-			schema.release(&schema);
-			throw InternalException("%s: subjects append failed at row %d", caller, static_cast<int>(i));
+	// Split subjects into byte-bounded record batches so no batch's `name` or
+	// `sequence` STRING offset buffer crosses INT32_MAX — the >2 GB reference
+	// overflow ("subjects append failed at row N"). Each batch becomes one Arrow
+	// record batch; the daemon (bowtie2_build read_input) concatenates them all.
+	// LoadSingleEndSubjects guarantees non-empty subjects, so batch_rows is never
+	// empty and EncodeIpcStream always gets >= 1 array.
+	const std::vector<size_t> batch_rows =
+	    ComputeSubjectBatchRowCounts(subjects.names, subjects.sequences, kMaxSubjectBatchBytes);
+
+	// One ArrowArray per batch. Pre-sized (never reallocated) so references into
+	// it stay stable and each element starts zero-initialized (release == null),
+	// which release_all() relies on to skip not-yet-built arrays.
+	std::vector<ArrowArray> arrays(batch_rows.size());
+	// Release every already-built array plus the schema — the single cleanup used
+	// on every throw path and on success.
+	auto release_all = [&arrays, &schema]() {
+		for (auto &a : arrays) {
+			if (a.release) {
+				a.release(&a);
+			}
 		}
-	}
-	if (ArrowArrayFinishBuildingDefault(&array, &err) != NANOARROW_OK) {
-		array.release(&array);
-		schema.release(&schema);
-		throw InternalException("%s: ArrowArrayFinishBuilding failed: %s", caller, err.message);
+		if (schema.release) {
+			schema.release(&schema);
+		}
+	};
+
+	ArrowError err {};
+	size_t row = 0; // global subject index across all batches (for error messages)
+	for (size_t b = 0; b < batch_rows.size(); ++b) {
+		ArrowArray &array = arrays[b];
+		if (ArrowArrayInitFromSchema(&array, &schema, &err) != NANOARROW_OK) {
+			// This array's release is still null (init failed); release_all()
+			// cleans up the prior batches + schema.
+			release_all();
+			throw InternalException("%s: ArrowArrayInit failed: %s", caller, err.message);
+		}
+		if (ArrowArrayStartAppending(&array) != NANOARROW_OK) {
+			release_all();
+			throw InternalException("%s: ArrowArrayStartAppending failed", caller);
+		}
+		for (size_t j = 0; j < batch_rows[b]; ++j, ++row) {
+			ArrowStringView nv {subjects.names[row].data(), static_cast<int64_t>(subjects.names[row].size())};
+			ArrowStringView sv {subjects.sequences[row].data(), static_cast<int64_t>(subjects.sequences[row].size())};
+			if (ArrowArrayAppendString(array.children[0], nv) != NANOARROW_OK ||
+			    ArrowArrayAppendString(array.children[1], sv) != NANOARROW_OK ||
+			    ArrowArrayFinishElement(&array) != NANOARROW_OK) {
+				release_all();
+				throw InternalException("%s: subjects append failed at row %d", caller, static_cast<int>(row));
+			}
+		}
+		if (ArrowArrayFinishBuildingDefault(&array, &err) != NANOARROW_OK) {
+			release_all();
+			throw InternalException("%s: ArrowArrayFinishBuilding failed: %s", caller, err.message);
+		}
 	}
 
 	std::vector<uint8_t> bytes;
 	try {
-		bytes = gb::EncodeIpcStream(&schema, &array, 1);
+		bytes = gb::EncodeIpcStream(&schema, arrays.data(), arrays.size());
 	} catch (...) {
-		array.release(&array);
-		schema.release(&schema);
+		release_all();
 		throw;
 	}
-	if (array.release) {
-		array.release(&array);
-	}
-	if (schema.release) {
-		schema.release(&schema);
-	}
+	release_all();
 	return bytes;
 }
 

--- a/src/include/align_bowtie2_daemon_common.hpp
+++ b/src/include/align_bowtie2_daemon_common.hpp
@@ -247,6 +247,53 @@ inline int64_t ResolveBowtie2Nthreads(bool threads_supplied, int64_t user_thread
 	return db_threads >= 1 ? db_threads : 1;
 }
 
+// Max cumulative bytes for one subject Arrow record batch's STRING column. Arrow
+// STRING uses 32-bit offsets, so a column's running byte offset must never reach
+// INT32_MAX (2^31-1 ≈ 2.15 GB); BuildSubjectsIpc chunks subjects into batches
+// under this cap so a >2 GB total reference no longer overflows the offset buffer
+// (the "subjects append failed at row N" crash). 1.5 GB leaves margin below
+// INT32_MAX for the separate `name` offset buffer and the (n+1)-th offset entry.
+constexpr size_t kMaxSubjectBatchBytes = 1500000000; // 1.5 GB
+
+// Split subjects into Arrow record batches so NEITHER the `name` nor the
+// `sequence` STRING column's cumulative bytes exceed `max_batch_bytes` in any one
+// batch. Returns the row count per batch, in order; sum == names.size(). Empty
+// input yields {}. Requires names.size() == sequences.size().
+//
+// A subject whose own name or sequence already exceeds the cap still gets its own
+// single-row batch (it can't be split further) — safe in production because each
+// contig is < 2 GB < INT32_MAX, so a lone oversized row still fits int32 offsets.
+// Kept inline + duckdb-free (like ResolveBowtie2Nthreads) so the Catch2 binary
+// exercises the decision without linking libduckdb.
+inline std::vector<size_t> ComputeSubjectBatchRowCounts(const std::vector<std::string> &names,
+                                                        const std::vector<std::string> &sequences,
+                                                        size_t max_batch_bytes) {
+	std::vector<size_t> counts;
+	size_t cur_name_bytes = 0;
+	size_t cur_seq_bytes = 0;
+	size_t cur_count = 0;
+	for (size_t i = 0; i < names.size(); ++i) {
+		const size_t nb = names[i].size();
+		const size_t sb = sequences[i].size();
+		// Flush the current batch before adding row i if it would push either
+		// column past the cap. Never flush an empty batch — a lone oversized row
+		// must still land somewhere.
+		if (cur_count > 0 && (cur_name_bytes + nb > max_batch_bytes || cur_seq_bytes + sb > max_batch_bytes)) {
+			counts.push_back(cur_count);
+			cur_name_bytes = 0;
+			cur_seq_bytes = 0;
+			cur_count = 0;
+		}
+		cur_name_bytes += nb;
+		cur_seq_bytes += sb;
+		++cur_count;
+	}
+	if (cur_count > 0) {
+		counts.push_back(cur_count);
+	}
+	return counts;
+}
+
 // Resolve the effective bowtie2 nthreads from a table function's named-parameter
 // map: read the miint-side `threads` knob (coerced via ValueAsInt, validated
 // `>= 1` — throws InvalidInputException naming `caller`), else fall back to

--- a/test/cpp/test_Bowtie2SubjectsBatching.cpp
+++ b/test/cpp/test_Bowtie2SubjectsBatching.cpp
@@ -1,0 +1,103 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "align_bowtie2_daemon_common.hpp"
+
+using duckdb::bt2_daemon::ComputeSubjectBatchRowCounts;
+
+// ComputeSubjectBatchRowCounts decides how to split subjects into Arrow record
+// batches so NEITHER the `name` nor the `sequence` STRING column's cumulative
+// byte offset buffer crosses INT32_MAX. That overflow is the actual bug: with
+// one giant batch, `save_bowtie2_index` on a >2 GB reference threw
+// "subjects append failed at row N" the moment the running offset total wrapped
+// past 2^31-1. The intent locked down here: any total reference size (each
+// contig < cap) splits into byte-bounded batches whose row counts sum back to
+// the full subject count — no subject dropped, no batch over the cap unless a
+// single oversized row forces it (still safe because contigs are < 2 GB).
+// Tiny strings + tiny caps keep the tests allocation-free; the production cap
+// is kMaxSubjectBatchBytes.
+
+namespace {
+
+// Build a vector of `count` strings each of the given byte length, filled with
+// 'x'. Content is irrelevant to the size-only batching decision.
+std::vector<std::string> strings_of_sizes(const std::vector<size_t> &sizes) {
+	std::vector<std::string> out;
+	out.reserve(sizes.size());
+	for (size_t sz : sizes) {
+		out.emplace_back(sz, 'x');
+	}
+	return out;
+}
+
+// sum of a row-count vector — the invariant every non-degenerate case checks.
+size_t total(const std::vector<size_t> &counts) {
+	return std::accumulate(counts.begin(), counts.end(), size_t {0});
+}
+
+} // namespace
+
+TEST_CASE("ComputeSubjectBatchRowCounts: empty input yields no batches", "[bowtie2_subjects_batching]") {
+	std::vector<std::string> names;
+	std::vector<std::string> sequences;
+	REQUIRE(ComputeSubjectBatchRowCounts(names, sequences, 100).empty());
+}
+
+TEST_CASE("ComputeSubjectBatchRowCounts: everything under the cap is one batch", "[bowtie2_subjects_batching]") {
+	auto names = strings_of_sizes({1, 1, 1});
+	auto sequences = strings_of_sizes({1, 1, 1});
+	auto counts = ComputeSubjectBatchRowCounts(names, sequences, 100);
+	REQUIRE(counts == std::vector<size_t> {3});
+	REQUIRE(total(counts) == names.size());
+}
+
+TEST_CASE("ComputeSubjectBatchRowCounts: cumulative bytes exactly at the cap stay in one batch",
+          "[bowtie2_subjects_batching]") {
+	// seq sizes 3 + 4 == 7 == cap. The cap is inclusive, so no split.
+	auto names = strings_of_sizes({0, 0});
+	auto sequences = strings_of_sizes({3, 4});
+	auto counts = ComputeSubjectBatchRowCounts(names, sequences, 7);
+	REQUIRE(counts == std::vector<size_t> {2});
+}
+
+TEST_CASE("ComputeSubjectBatchRowCounts: sequence bytes over the cap force a split", "[bowtie2_subjects_batching]") {
+	// 4 + 4 == 8 > cap 7, so the second row starts a new batch.
+	auto names = strings_of_sizes({0, 0});
+	auto sequences = strings_of_sizes({4, 4});
+	auto counts = ComputeSubjectBatchRowCounts(names, sequences, 7);
+	REQUIRE(counts == std::vector<size_t> {1, 1});
+	REQUIRE(total(counts) == names.size());
+}
+
+TEST_CASE("ComputeSubjectBatchRowCounts: multiple rows pack into each batch", "[bowtie2_subjects_batching]") {
+	// seq sizes [3,3,3,3], cap 7: 3+3=6 fits, +3=9 overflows → {2,2}.
+	auto names = strings_of_sizes({0, 0, 0, 0});
+	auto sequences = strings_of_sizes({3, 3, 3, 3});
+	auto counts = ComputeSubjectBatchRowCounts(names, sequences, 7);
+	REQUIRE(counts == std::vector<size_t> {2, 2});
+	REQUIRE(total(counts) == names.size());
+}
+
+TEST_CASE("ComputeSubjectBatchRowCounts: a single row larger than the cap lands alone", "[bowtie2_subjects_batching]") {
+	// Row 0's sequence (10) already exceeds cap 7. It must still be emitted, in
+	// a batch by itself; row 1 then starts a fresh batch. (Safe in production:
+	// contigs are < 2 GB < INT32_MAX, so a lone oversized row still fits int32.)
+	auto names = strings_of_sizes({0, 0});
+	auto sequences = strings_of_sizes({10, 2});
+	auto counts = ComputeSubjectBatchRowCounts(names, sequences, 7);
+	REQUIRE(counts == std::vector<size_t> {1, 1});
+	REQUIRE(total(counts) == names.size());
+}
+
+TEST_CASE("ComputeSubjectBatchRowCounts: name bytes alone can force a split", "[bowtie2_subjects_batching]") {
+	// Sequences are tiny (1 byte) but names are 4 bytes each: 4+4=8 > cap 7, so
+	// the name column — not the sequence column — is what triggers the split.
+	auto names = strings_of_sizes({4, 4});
+	auto sequences = strings_of_sizes({1, 1});
+	auto counts = ComputeSubjectBatchRowCounts(names, sequences, 7);
+	REQUIRE(counts == std::vector<size_t> {1, 1});
+	REQUIRE(total(counts) == names.size());
+}

--- a/test/cpp/test_gpl_boundary_arrow_ipc.cpp
+++ b/test/cpp/test_gpl_boundary_arrow_ipc.cpp
@@ -12,6 +12,7 @@
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace duckdb::miint::gpl_boundary;
@@ -75,6 +76,46 @@ void make_array_two_rows(const ArrowSchema *schema, ArrowArray *array) {
 	}
 }
 
+// Build an ArrowSchema for `struct<name: utf8, sequence: utf8>` — the exact
+// schema BuildSubjectsIpc emits for bowtie2-build subjects. Caller owns it.
+void make_subjects_schema(ArrowSchema *schema) {
+	if (ArrowSchemaInitFromType(schema, NANOARROW_TYPE_STRUCT) != NANOARROW_OK) {
+		throw std::runtime_error("subjects schema init failed");
+	}
+	if (ArrowSchemaAllocateChildren(schema, 2) != NANOARROW_OK) {
+		throw std::runtime_error("subjects alloc children failed");
+	}
+	ArrowSchemaInitFromType(schema->children[0], NANOARROW_TYPE_STRING);
+	ArrowSchemaSetName(schema->children[0], "name");
+	ArrowSchemaInitFromType(schema->children[1], NANOARROW_TYPE_STRING);
+	ArrowSchemaSetName(schema->children[1], "sequence");
+}
+
+// Build one ArrowArray batch of (name, sequence) string rows against `schema`.
+// Caller owns array and must release it.
+void make_subjects_array(const ArrowSchema *schema, ArrowArray *array,
+                         const std::vector<std::pair<std::string, std::string>> &rows) {
+	ArrowError err {};
+	if (ArrowArrayInitFromSchema(array, schema, &err) != NANOARROW_OK) {
+		throw std::runtime_error("subjects array init failed");
+	}
+	if (ArrowArrayStartAppending(array) != NANOARROW_OK) {
+		throw std::runtime_error("subjects start appending failed");
+	}
+	for (const auto &row : rows) {
+		ArrowStringView nv {row.first.data(), static_cast<int64_t>(row.first.size())};
+		ArrowStringView sv {row.second.data(), static_cast<int64_t>(row.second.size())};
+		if (ArrowArrayAppendString(array->children[0], nv) != NANOARROW_OK ||
+		    ArrowArrayAppendString(array->children[1], sv) != NANOARROW_OK ||
+		    ArrowArrayFinishElement(array) != NANOARROW_OK) {
+			throw std::runtime_error("subjects append failed");
+		}
+	}
+	if (ArrowArrayFinishBuildingDefault(array, &err) != NANOARROW_OK) {
+		throw std::runtime_error("subjects finish building failed");
+	}
+}
+
 } // namespace
 
 TEST_CASE("EncodeIpcStream + DecodeIpcStream roundtrip preserves schema and rows", "[gpl-boundary][arrow_ipc]") {
@@ -129,6 +170,80 @@ TEST_CASE("EncodeIpcStream + DecodeIpcStream roundtrip preserves schema and rows
 	}
 	if (array.release) {
 		array.release(&array);
+	}
+	if (schema.release) {
+		schema.release(&schema);
+	}
+}
+
+TEST_CASE("EncodeIpcStream emits one RecordBatch per array for n_arrays > 1", "[gpl-boundary][arrow_ipc]") {
+	// Locks the multi-batch transport that the chunked BuildSubjectsIpc relies
+	// on to keep a >2 GB reference under Arrow's int32 STRING-offset limit: two
+	// arrays under ONE shared schema must decode back as two distinct batches
+	// (correct rows each), then EOS. Prior tests only covered n_arrays == 1.
+	ArrowSchema schema {};
+	make_subjects_schema(&schema);
+
+	std::vector<ArrowArray> arrays(2); // value-initialized: both start released (release == null)
+	make_subjects_array(&schema, &arrays[0], {{"c1", "ACGT"}, {"c2", "TTTT"}});
+	make_subjects_array(&schema, &arrays[1], {{"c3", "GGG"}});
+
+	std::vector<uint8_t> bytes = EncodeIpcStream(&schema, arrays.data(), arrays.size());
+	REQUIRE_FALSE(bytes.empty());
+
+	IpcStreamDecoder decoder(bytes.data(), bytes.size());
+	ArrowSchema decoded_schema {};
+	decoder.GetSchema(&decoded_schema);
+	REQUIRE(decoded_schema.n_children == 2);
+	REQUIRE(std::string(decoded_schema.children[0]->name) == "name");
+	REQUIRE(std::string(decoded_schema.children[1]->name) == "sequence");
+
+	// Batch 1: two rows, distinct content from batch 2.
+	ArrowArray batch1 {};
+	REQUIRE(decoder.NextBatch(&batch1));
+	REQUIRE(batch1.length == 2);
+	{
+		const auto *noff = static_cast<const int32_t *>(batch1.children[0]->buffers[1]);
+		const auto *nbytes = static_cast<const char *>(batch1.children[0]->buffers[2]);
+		const auto *soff = static_cast<const int32_t *>(batch1.children[1]->buffers[1]);
+		const auto *sbytes = static_cast<const char *>(batch1.children[1]->buffers[2]);
+		REQUIRE(std::string(nbytes + noff[0], noff[1] - noff[0]) == "c1");
+		REQUIRE(std::string(nbytes + noff[1], noff[2] - noff[1]) == "c2");
+		REQUIRE(std::string(sbytes + soff[0], soff[1] - soff[0]) == "ACGT");
+		REQUIRE(std::string(sbytes + soff[1], soff[2] - soff[1]) == "TTTT");
+	}
+
+	// Batch 2: one row.
+	ArrowArray batch2 {};
+	REQUIRE(decoder.NextBatch(&batch2));
+	REQUIRE(batch2.length == 1);
+	{
+		const auto *noff = static_cast<const int32_t *>(batch2.children[0]->buffers[1]);
+		const auto *nbytes = static_cast<const char *>(batch2.children[0]->buffers[2]);
+		const auto *soff = static_cast<const int32_t *>(batch2.children[1]->buffers[1]);
+		const auto *sbytes = static_cast<const char *>(batch2.children[1]->buffers[2]);
+		REQUIRE(std::string(nbytes + noff[0], noff[1] - noff[0]) == "c3");
+		REQUIRE(std::string(sbytes + soff[0], soff[1] - soff[0]) == "GGG");
+	}
+
+	// EOS after the last batch.
+	ArrowArray empty {};
+	REQUIRE_FALSE(decoder.NextBatch(&empty));
+
+	// Cleanup
+	if (decoded_schema.release) {
+		decoded_schema.release(&decoded_schema);
+	}
+	if (batch1.release) {
+		batch1.release(&batch1);
+	}
+	if (batch2.release) {
+		batch2.release(&batch2);
+	}
+	for (auto &a : arrays) {
+		if (a.release) {
+			a.release(&a);
+		}
 	}
 	if (schema.release) {
 		schema.release(&schema);


### PR DESCRIPTION
## Problem

`save_bowtie2_index` (and `align_bowtie2`, same code path) crashes on references whose **total** sequence length exceeds `INT32_MAX` (~2.15 GB):

```
INTERNAL Error: save_bowtie2_index: subjects append failed at row N
```

`BuildSubjectsIpc` encoded **all** subjects into a **single** Arrow record batch with `NANOARROW_TYPE_STRING` columns. Arrow `STRING` uses **32-bit offsets**, so the `sequence` column's cumulative offset buffer overflows once total bytes cross `INT32_MAX`. "row N" is simply the subject at which the running total crosses the limit. bowtie2 itself handles large references fine (it emits large indexes) — this was purely miint's Arrow **transport** limit. Found from a qiita `build_bowtie2_index` whole-reference run (released in v1.5.4).

## Fix (miint-only — no daemon, wire, or schema change)

Chunk subjects into byte-bounded Arrow record batches so no batch's `name` or `sequence` STRING offset buffer approaches `INT32_MAX`:

- New pure, `inline`, duckdb-free helper `ComputeSubjectBatchRowCounts(names, sequences, cap)` (`align_bowtie2_daemon_common.hpp`) decides the split; cap = `kMaxSubjectBatchBytes` = 1.5 GB (margin below `INT32_MAX` for the separate `name` offset buffer + the (n+1)-th offset entry).
- `BuildSubjectsIpc` now builds one `ArrowArray` per batch and calls `EncodeIpcStream(&schema, arrays.data(), arrays.size())` (already supported multiple batches). Single `release_all` cleanup on every throw path and on success; the append-failure message keeps a **global** row index.
- The daemon's `bowtie2_build read_input` already concatenates every record batch, so **no daemon change is needed**.
- Individual contigs are always < 2 GB, so a lone oversized row still fits int32 offsets (it gets its own batch).

No signature change — `save_bowtie2_index.cpp` / `align_bowtie2.cpp` are untouched.

## Verification

**Layered tests**
- `test_Bowtie2SubjectsBatching` (`[bowtie2_subjects_batching]`) — unit tests for the split decision (empty, all-fit, exact-cap inclusive, seq/name-forced splits, multi-row packing, lone oversized row).
- `test_gpl_boundary_arrow_ipc` — new `n_arrays == 2` `EncodeIpcStream`→decode round-trip locking the multi-batch transport.
- Existing bowtie2 SQL tests (`save_bowtie2_index`, `align_bowtie2{,_bigint,_uuid}`, `simple_bowtie2`, `miint_warnings_bowtie2`) — all green (single-batch parity).

**Real-scale before/after (controlled)** — a 2.25 GB reference (`> INT32_MAX`), 6 contigs, `{3,3}` 2-batch split:
- **Old code** (temporarily reverted `BuildSubjectsIpc`): `INTERNAL Error: subjects append failed at row 5`, 0 index files.
- **New code**: `success = true`, `num_subjects = 6`, full index written, and reads drawn from contigs in **both** batches align back to the correct reference (proves the daemon concatenated both batches).

## Stacking

Stacked on #164 (nthreads default fix) — a **separate** scaling bug. Base is set to `fix/bowtie2-index-default-threads` to keep this diff to its single commit; retarget to `v1.5-variegata` once #164 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)