### PR TITLE
fix(ena_upload): portable temp-dir staging for MinGW (+ temp mingw CI lane)

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -54,7 +54,11 @@ jobs:
       # excluded on branch pushes and PRs. Windows (all variants) + osx_amd64 +
       # wasm_mvp/wasm_threads stay excluded everywhere (broken / not shipped).
       # Tag builds drop wasm_eh from the exclude list so release artifacts carry it.
-      exclude_archs: ${{ startsWith(github.ref, 'refs/tags/') && 'windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;wasm_mvp;wasm_threads' || 'windows_amd64_rtools;windows_amd64;windows_amd64_mingw;osx_amd64;wasm_eh;wasm_mvp;wasm_threads' }}
+      # TEMPORARY (revert once green): windows_amd64_mingw is un-excluded from
+      # both strings to verify the ena_upload_reads mkdtemp portability fix
+      # compiles on MinGW in our own CI. Re-add 'windows_amd64_mingw;' to both
+      # exclude lists after the mingw lane is confirmed green — it is costly.
+      exclude_archs: ${{ startsWith(github.ref, 'refs/tags/') && 'windows_amd64_rtools;windows_amd64;osx_amd64;wasm_mvp;wasm_threads' || 'windows_amd64_rtools;windows_amd64;osx_amd64;wasm_eh;wasm_mvp;wasm_threads' }}
 
   test-with-bowtie2:
     name: Test with Bowtie2

--- a/src/ena_upload_reads.cpp
+++ b/src/ena_upload_reads.cpp
@@ -11,10 +11,12 @@
 #endif
 #include "ena_upload_helpers.hpp"
 #include "fastq_encoder.hpp"
+#include "remote_file_helper.hpp"
 
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_open_flags.hpp"
 #include "duckdb/common/file_system.hpp"
+#include "duckdb/common/random_engine.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/data_chunk.hpp"
 #include "duckdb/common/crypto/md5.hpp"
@@ -33,7 +35,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
-#include <unistd.h> // unlink, rmdir; mkdtemp on POSIX only (Aspera path is compiled out on MinGW)
+#include <unistd.h> // unlink, rmdir for temp-staging cleanup (available on MinGW)
 #include <vector>
 #include <zlib.h>
 
@@ -531,9 +533,8 @@ void UploadOneSample(ClientContext &context, const ENAUploadReadsBindData &bind,
 	auto &fs = FileSystem::GetFileSystem(context);
 	const auto filenames = OutputFilenames(plan.sample_ref, plan.resolved_layout); // 1 (single/interleaved) or 2
 
-	// On platforms without Aspera support fail-fast *before* the mkdtemp staging
-	// code — mkdtemp is POSIX-only and MinGW's libc doesn't provide it, so this
-	// guard also keeps the file compilable on Windows.
+	// On builds without Aspera support, fail-fast if Aspera transport was
+	// requested — the ascp binary path and its config aren't compiled in.
 #if !(MIINT_ASPERA_SUPPORTED && defined(MIINT_STATIC_BUILD))
 	if (gs.target.transport == UploadTransport::ASPERA) {
 		throw IOException("ena_upload_reads: Aspera transport is not supported on this build/platform");
@@ -549,16 +550,31 @@ void UploadOneSample(ClientContext &context, const ENAUploadReadsBindData &bind,
 		}
 	} else {
 		// Private temp dir so each staged file's basename matches its remote
-		// name; unlink + rmdir after transport.
-		string tmpl = miint::GetTempDir() + "/ena-upload-XXXXXX";
-		vector<char> buf(tmpl.begin(), tmpl.end());
-		buf.push_back('\0');
-		if (mkdtemp(buf.data()) == nullptr) {
-			throw IOException("ena_upload_reads: mkdtemp failed: %s", std::strerror(errno));
+		// name; removed after transport. mkdtemp(3) is POSIX-only (MinGW's libc
+		// omits it), so build a uniquely-named directory through DuckDB's
+		// FileSystem instead — portable across POSIX, Windows and Emscripten.
+		// GetTempDirectory honours DuckDB's configured temp_directory and the
+		// platform temp path; CreateDirectory is non-recursive, so ensure that
+		// root exists first. A 64-bit random suffix makes collision with an
+		// existing directory negligible; the bounded retry covers the off chance.
+		const string temp_root = miint::RemoteFileHelper::GetTempDirectory(context);
+		fs.CreateDirectoriesRecursive(temp_root);
+		RandomEngine rng;
+		for (idx_t attempt = 0;; attempt++) {
+			string candidate = fs.JoinPath(
+			    temp_root, StringUtil::Format("ena-upload-%016llx", (unsigned long long)rng.NextRandomInteger64()));
+			if (!fs.DirectoryExists(candidate)) {
+				fs.CreateDirectory(candidate);
+				temp_dir = candidate;
+				break;
+			}
+			if (attempt >= 64) {
+				throw IOException("ena_upload_reads: could not create a unique staging directory under '%s'",
+				                  temp_root);
+			}
 		}
-		temp_dir.assign(buf.data());
 		for (auto &fname : filenames) {
-			write_paths.push_back(temp_dir + "/" + fname);
+			write_paths.push_back(fs.JoinPath(temp_dir, fname));
 		}
 	}
 

--- a/test/sql/ena_upload_reads_stage_dir.test
+++ b/test/sql/ena_upload_reads_stage_dir.test
@@ -1,0 +1,42 @@
+# name: test/sql/ena_upload_reads_stage_dir.test
+# description: ena_upload_reads — the curl stage branch creates a private temp staging dir (portable FileSystem path, not POSIX mkdtemp) before transport
+# group: [sql]
+
+require miint
+
+# libcurl streaming-upload transport is compiled in on Linux/Windows but
+# disabled on macOS (vsearch/OpenSSL symbol clash); run_tests.sh exports
+# MIINT_HAS_CURL when the libcurl entry is present in miint_versions().
+require-env MIINT_HAS_CURL
+
+# Minimal single-end input (same fixture as ena_upload_reads_local.test).
+statement ok
+CREATE TABLE stage_in AS
+  SELECT 'sampleA' AS sample_ref, read_id, sequence1, qual1,
+         CAST(NULL AS VARCHAR) AS sequence2,
+         CAST(NULL AS UTINYINT[]) AS qual2,
+         sequence_index
+  FROM read_fastx('data/fastq/small_a.fq');
+
+# curl transport requires a user/password SECRET (ResolveUploadCredentials).
+statement ok
+CREATE SECRET stage_secret (TYPE ENA, USER 'anon', PASSWORD 'anon', ENDPOINT 'test');
+
+# Drive the stage branch: an ftp:// target routes through curl, so the sample is
+# first staged into a freshly-created private temp directory — the code path
+# reworked to use DuckDB's FileSystem (GetTempDirectory + CreateDirectoriesRecursive)
+# instead of POSIX mkdtemp(3), which MinGW omits. Point at a closed loopback port
+# so the transport fails fast *after* staging: reaching the "upload failed for
+# sample" error proves the staging directory was created and a gzipped file was
+# written into it on this platform (incl. Windows/MinGW) — exactly the temp-dir
+# portability path under test. A staging failure would surface a different error
+# (temp-dir creation), so this assertion also guards that regression.
+statement error
+SELECT * FROM ena_upload_reads(relation := 'stage_in',
+                               secret := 'stage_secret',
+                               target_url := 'ftp://127.0.0.1:1/incoming/');
+----
+upload failed for sample
+
+statement ok
+DROP SECRET stage_secret;


### PR DESCRIPTION
## Problem
The community-extensions build of miint fails on `windows_amd64_mingw`:

```
src/ena_upload_reads.cpp:556: error: 'mkdtemp' was not declared in this scope
```

`mkdtemp(3)` is POSIX-only; MinGW's libc omits it. This is a **regression**: the `SamplePlan`/`UploadOneSample` refactor moved the temp-dir creation out of its `#if MIINT_ASPERA_SUPPORTED` compile guard (where mingw never compiled it) into the always-compiled curl staging path, which *is* enabled on mingw.

## Fix (`d8456be`)
Create the private staging directory through DuckDB's `FileSystem` instead of `mkdtemp`:
- `RemoteFileHelper::GetTempDirectory(context)` — honours the configured `temp_directory` and the platform temp path (`GetTempPathA` on Windows), instead of the POSIX-only `/tmp`
- `CreateDirectoriesRecursive(root)` — `FileSystem::CreateDirectory` is non-recursive, so ensure the root exists first
- random-suffixed unique subdir via `RandomEngine` + `StringUtil::Format`, with a bounded retry

Portable across POSIX, Windows and Emscripten. Reuses the established pattern in `remote_file_helper.cpp`.

## Test (`d8456be`)
`test/sql/ena_upload_reads_stage_dir.test` drives the real curl stage branch to a closed loopback port (`ftp://127.0.0.1:1`) so transport fails **fast, after staging** — reaching `"upload failed for sample"` proves the staging dir was created and a gzipped file written on-platform (including the Windows/MinGW CI runner). Gated on `MIINT_HAS_CURL` (curl is disabled on macOS). Verified green locally.

> A pure C++ unit test isn't feasible: miint's Catch2 `tests` binary doesn't link libduckdb, so `FileSystem`/`RandomEngine` are unavailable there. The SQL test exercises the real path and, unlike a unit test with a valid scratch root, actually guards the Windows temp-dir bug.

## Temporary CI (`00afedd` — revert before merge)
Un-excludes `windows_amd64_mingw` from both `exclude_archs` strings so this pipeline compiles + tests it. **Revert this commit once the mingw lane is green** — the Windows build is costly and normally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)